### PR TITLE
Add info log for reverting tx hashes

### DIFF
--- a/crates/op-rbuilder/src/payload_builder_vanilla.rs
+++ b/crates/op-rbuilder/src/payload_builder_vanilla.rs
@@ -667,7 +667,7 @@ impl<Txs> OpBuilder<'_, Txs> {
         );
 
         let sealed_block = Arc::new(block.seal_slow());
-        info!(target: "payload_builder", id=%ctx.attributes().payload_id(), "sealed built block");
+        tracing::info!(target: "payload_builder", id=%ctx.attributes().payload_id(), "sealed built block");
 
         // create the executed block data
         let executed: ExecutedBlockWithTrieUpdates<OpPrimitives> = ExecutedBlockWithTrieUpdates {
@@ -1096,7 +1096,7 @@ where
                 num_txs_simulated_success += 1;
             } else {
                 num_txs_simulated_fail += 1;
-                trace!(target: "payload_builder", ?tx, "skipping reverted transaction");
+                info!(target: "payload_builder", tx_hash = ?tx.tx_hash(), "skipping reverted transaction");
                 best_txs.mark_invalid(tx.signer(), tx.nonce());
                 info.invalid_tx_hashes.insert(tx.tx_hash());
                 continue;

--- a/crates/op-rbuilder/src/payload_builder_vanilla.rs
+++ b/crates/op-rbuilder/src/payload_builder_vanilla.rs
@@ -667,7 +667,7 @@ impl<Txs> OpBuilder<'_, Txs> {
         );
 
         let sealed_block = Arc::new(block.seal_slow());
-        tracing::info!(target: "payload_builder", id=%ctx.attributes().payload_id(), "sealed built block");
+        info!(target: "payload_builder", id=%ctx.attributes().payload_id(), "sealed built block");
 
         // create the executed block data
         let executed: ExecutedBlockWithTrieUpdates<OpPrimitives> = ExecutedBlockWithTrieUpdates {


### PR DESCRIPTION
## 📝 Summary

Change the reverting hashes from trace to info as it'll be an important source of transaction tracing.

## 💡 Motivation and Context


---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
