### PR TITLE
feat: Improve github CI for docker building

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
         id: extract_version
         run: |
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            VERSION="${GITHUB_REF#refs/tags/op-}"
+            VERSION="${GITHUB_REF#refs/tags/}"
           else
             VERSION="$(echo ${GITHUB_SHA} | cut -c1-7)"
           fi
@@ -154,7 +154,7 @@ jobs:
     if: ${{ github.event.inputs.build-docker == 'true' }}
     name: Build and publish Docker image
     needs: extract-version
-    runs-on: warp-ubuntu-latest-x64-16x
+    runs-on: ${{ matrix.configs.runner }}
     env:
       VERSION: ${{ needs.extract-version.outputs.VERSION }}
     permissions:
@@ -162,8 +162,11 @@ jobs:
       packages: write
     strategy:
       matrix:
-        features:
-          - ${{ github.event.inputs.features || '' }}
+        configs:
+          - target: linux/amd64
+            runner: warp-ubuntu-latest-x64-16x
+          - target: linux/arm64
+            runner: warp-ubuntu-latest-arm64-16x
     steps:
       - name: checkout sources
         uses: actions/checkout@v4
@@ -178,7 +181,7 @@ jobs:
         uses: docker/metadata-action@v5
         id: meta
         with:
-          images: ghcr.io/${{ github.repository_owner }}/op-rbuilder
+          images: ghcr.io/${{ github.repository }}
           labels: org.opencontainers.image.source=${{ github.repositoryUrl }}
           tags: |
             type=sha
@@ -208,5 +211,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
-            FEATURES=${{ matrix.features }}
+            FEATURES=${{ github.event.inputs.features || '' }}
             RBUILDER_BIN=op-rbuilder


### PR DESCRIPTION
Removed op- prefix for tags, because we are in op-rbuilder repo now
Added runners for docker building to speed up arm64 
Put more robust repo name

## 📝 Summary

<!--- A general summary of your changes -->

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
