### PR TITLE
fix: ensure DA transaction throttling uses params that are set

### DIFF
--- a/crates/op-rbuilder/src/integration/integration_test.rs
+++ b/crates/op-rbuilder/src/integration/integration_test.rs
@@ -546,7 +546,9 @@ mod tests {
         }
 
         // check there's 10 flashblocks log lines (2000ms / 200ms)
-        op_rbuilder.find_log_line("Building flashblock 9").await?;
+        op_rbuilder
+            .find_log_line("Building flashblock idx=9")
+            .await?;
 
         // Process websocket messages
         let timeout_duration = Duration::from_secs(10);
@@ -675,7 +677,9 @@ mod tests {
         }
 
         // check there's no more than 10 flashblocks log lines (2000ms / 200ms)
-        op_rbuilder.find_log_line("Building flashblock 9").await?;
+        op_rbuilder
+            .find_log_line("Building flashblock idx=9")
+            .await?;
         op_rbuilder
             .find_log_line("Skipping flashblock reached target=10 idx=10")
             .await?;

--- a/crates/op-rbuilder/src/payload_builder_vanilla.rs
+++ b/crates/op-rbuilder/src/payload_builder_vanilla.rs
@@ -78,6 +78,7 @@ pub struct CustomOpPayloadBuilder {
     builder_signer: Option<Signer>,
     extra_block_deadline: std::time::Duration,
     enable_revert_protection: bool,
+    builder_config: OpBuilderConfig,
     #[cfg(feature = "flashblocks")]
     flashblocks_ws_url: String,
     #[cfg(feature = "flashblocks")]
@@ -90,12 +91,14 @@ impl CustomOpPayloadBuilder {
     #[cfg(feature = "flashblocks")]
     pub fn new(
         builder_signer: Option<Signer>,
+        config: OpBuilderConfig,
         flashblocks_ws_url: String,
         chain_block_time: u64,
         flashblock_block_time: u64,
     ) -> Self {
         Self {
             builder_signer,
+            config,
             flashblocks_ws_url,
             chain_block_time,
             flashblock_block_time,
@@ -103,18 +106,40 @@ impl CustomOpPayloadBuilder {
     }
 
     #[cfg(not(feature = "flashblocks"))]
+    #[allow(dead_code)]
     pub fn new(
+        builder_signer: Option<Signer>,
+        extra_block_deadline: std::time::Duration,
+        enable_revert_protection: bool,
+        flashblocks_ws_url: String,
+        chain_block_time: u64,
+        flashblock_block_time: u64,
+    ) -> Self {
+        Self::with_builder_config(
+            builder_signer,
+            extra_block_deadline,
+            enable_revert_protection,
+            flashblocks_ws_url,
+            chain_block_time,
+            flashblock_block_time,
+            Default::default(),
+        )
+    }
+
+    pub fn with_builder_config(
         builder_signer: Option<Signer>,
         extra_block_deadline: std::time::Duration,
         enable_revert_protection: bool,
         _flashblocks_ws_url: String,
         _chain_block_time: u64,
         _flashblock_block_time: u64,
+        builder_config: OpBuilderConfig,
     ) -> Self {
         Self {
             builder_signer,
             extra_block_deadline,
             enable_revert_protection,
+            builder_config,
         }
     }
 }
@@ -143,6 +168,7 @@ where
         Ok(OpPayloadBuilderVanilla::new(
             OpEvmConfig::optimism(ctx.chain_spec()),
             self.builder_signer,
+            self.builder_config,
             pool,
             ctx.provider().clone(),
         ))
@@ -249,18 +275,9 @@ impl<Pool, Client> OpPayloadBuilderVanilla<Pool, Client> {
     pub fn new(
         evm_config: OpEvmConfig,
         builder_signer: Option<Signer>,
-        pool: Pool,
-        client: Client,
-    ) -> Self {
-        Self::with_builder_config(evm_config, builder_signer, pool, client, Default::default())
-    }
-
-    pub fn with_builder_config(
-        evm_config: OpEvmConfig,
-        builder_signer: Option<Signer>,
-        pool: Pool,
-        client: Client,
         config: OpBuilderConfig,
+        pool: Pool,
+        client: Client,
     ) -> Self {
         Self {
             pool,


### PR DESCRIPTION
## 📝 Summary

Migrated from flashbots/rbuilder PR https://github.com/flashbots/rbuilder/pull/616

* Ensure the builders share the same `OpDAConfig` that the RPC endpoint does. 
* For Flashblocks builder, consider the DA param values

## 💡 Motivation and Context

Prior to this PR, I believe setting throttling via the RPC would not have any impact as an unrelated DAConfig object is created [here](https://github.com/flashbots/rbuilder/blob/develop/crates/op-rbuilder/src/payload_builder_vanilla.rs#L243). Part of the work to fix: https://github.com/flashbots/rbuilder/issues/613

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
