### PR TITLE
Add flag to enable revert protection

### DIFF
--- a/crates/op-rbuilder/src/args.rs
+++ b/crates/op-rbuilder/src/args.rs
@@ -44,4 +44,7 @@ pub struct OpRbuilderArgs {
     /// How much time extra to wait for the block building job to complete and not get garbage collected
     #[arg(long = "builder.extra-block-deadline-secs", default_value = "20")]
     pub extra_block_deadline_secs: u64,
+    /// Whether to enable revert protection by default
+    #[arg(long = "builder.enable-revert-protection", default_value = "false")]
+    pub enable_revert_protection: bool,
 }

--- a/crates/op-rbuilder/src/generator.rs
+++ b/crates/op-rbuilder/src/generator.rs
@@ -74,6 +74,8 @@ pub struct BlockPayloadJobGenerator<Client, Tasks, Builder> {
     last_payload: Arc<Mutex<CancellationToken>>,
     /// The extra block deadline in seconds
     extra_block_deadline: std::time::Duration,
+    /// Whether to enable revert protection
+    enable_revert_protection: bool,
 }
 
 // === impl EmptyBlockPayloadJobGenerator ===
@@ -88,6 +90,7 @@ impl<Client, Tasks, Builder> BlockPayloadJobGenerator<Client, Tasks, Builder> {
         builder: Builder,
         ensure_only_one_payload: bool,
         extra_block_deadline: std::time::Duration,
+        enable_revert_protection: bool,
     ) -> Self {
         Self {
             client,
@@ -97,6 +100,7 @@ impl<Client, Tasks, Builder> BlockPayloadJobGenerator<Client, Tasks, Builder> {
             ensure_only_one_payload,
             last_payload: Arc::new(Mutex::new(CancellationToken::new())),
             extra_block_deadline,
+            enable_revert_protection,
         }
     }
 }
@@ -182,6 +186,7 @@ where
             cancel: cancel_token,
             deadline,
             build_complete: None,
+            enable_revert_protection: self.enable_revert_protection,
         };
 
         job.spawn_build_job();
@@ -214,6 +219,8 @@ where
     pub(crate) cancel: CancellationToken,
     pub(crate) deadline: Pin<Box<Sleep>>, // Add deadline
     pub(crate) build_complete: Option<oneshot::Receiver<Result<(), PayloadBuilderError>>>,
+    /// Block building options
+    pub(crate) enable_revert_protection: bool,
 }
 
 impl<Tasks, Builder> PayloadJob for BlockPayloadJob<Tasks, Builder>
@@ -256,6 +263,8 @@ pub struct BuildArguments<Attributes, Payload: BuiltPayload> {
     pub config: PayloadConfig<Attributes, HeaderTy<Payload::Primitives>>,
     /// A marker that can be used to cancel the job.
     pub cancel: CancellationToken,
+    /// Whether to enable revert protection
+    pub enable_revert_protection: bool,
 }
 
 /// A [PayloadJob] is a future that's being polled by the `PayloadBuilderService`
@@ -271,6 +280,7 @@ where
         let payload_config = self.config.clone();
         let cell = self.cell.clone();
         let cancel = self.cancel.clone();
+        let enable_revert_protection = self.enable_revert_protection;
 
         let (tx, rx) = oneshot::channel();
         self.build_complete = Some(rx);
@@ -280,6 +290,7 @@ where
                 cached_reads: Default::default(),
                 config: payload_config,
                 cancel,
+                enable_revert_protection,
             };
 
             let result = builder.try_build(args, cell);
@@ -639,6 +650,7 @@ mod tests {
             builder.clone(),
             false,
             std::time::Duration::from_secs(1),
+            false,
         );
 
         // this is not nice but necessary

--- a/crates/op-rbuilder/src/integration/mod.rs
+++ b/crates/op-rbuilder/src/integration/mod.rs
@@ -1,6 +1,9 @@
 use alloy_consensus::TxEip1559;
 use alloy_eips::{eip1559::MIN_PROTOCOL_BASE_FEE, eip2718::Encodable2718, BlockNumberOrTag};
-use alloy_provider::{Identity, Provider, ProviderBuilder};
+use alloy_primitives::{hex, TxHash, TxNonce};
+use alloy_provider::{
+    Identity, PendingTransactionBuilder, Provider, ProviderBuilder, RootProvider,
+};
 use op_alloy_consensus::OpTypedTransaction;
 use op_alloy_network::Optimism;
 use op_rbuilder::OpRbuilderConfig;
@@ -269,7 +272,9 @@ impl TestHarness {
         }
     }
 
-    pub async fn send_valid_transaction(&self) -> eyre::Result<()> {
+    pub async fn send_valid_transaction(
+        &self,
+    ) -> eyre::Result<PendingTransactionBuilder<Optimism>> {
         // Get builder's address
         let known_wallet = Signer::try_from_secret(BUILDER_PRIVATE_KEY.parse()?)?;
         let builder_address = known_wallet.address;
@@ -303,11 +308,64 @@ impl TestHarness {
             ..Default::default()
         });
         let signed_tx = known_wallet.sign_tx(tx_request)?;
-        let _ = provider
+        let pending_tx = provider
             .send_raw_transaction(signed_tx.encoded_2718().as_slice())
             .await?;
 
-        Ok(())
+        Ok(pending_tx)
+    }
+
+    pub async fn send_revert_transaction(
+        &self,
+    ) -> eyre::Result<PendingTransactionBuilder<Optimism>> {
+        // TODO: Merge this with send_valid_transaction
+        // Get builder's address
+        let known_wallet = Signer::try_from_secret(BUILDER_PRIVATE_KEY.parse()?)?;
+        let builder_address = known_wallet.address;
+
+        let url = format!("http://localhost:{}", self.builder_http_port);
+        let provider =
+            ProviderBuilder::<Identity, Identity, Optimism>::default().on_http(url.parse()?);
+
+        // Get current nonce includeing the ones from the txpool
+        let nonce = provider
+            .get_transaction_count(builder_address)
+            .pending()
+            .await?;
+
+        let latest_block = provider
+            .get_block_by_number(BlockNumberOrTag::Latest)
+            .await?
+            .unwrap();
+
+        let base_fee = max(
+            latest_block.header.base_fee_per_gas.unwrap(),
+            MIN_PROTOCOL_BASE_FEE,
+        );
+
+        // Transaction from builder should succeed
+        let tx_request = OpTypedTransaction::Eip1559(TxEip1559 {
+            chain_id: 901,
+            nonce,
+            gas_limit: 210000,
+            max_fee_per_gas: base_fee.into(),
+            input: hex!("60006000fd").into(), // PUSH1 0x00 PUSH1 0x00 REVERT
+            ..Default::default()
+        });
+        let signed_tx = known_wallet.sign_tx(tx_request)?;
+        let pending_tx = provider
+            .send_raw_transaction(signed_tx.encoded_2718().as_slice())
+            .await?;
+
+        Ok(pending_tx)
+    }
+
+    pub fn provider(&self) -> eyre::Result<RootProvider<Optimism>> {
+        let url = format!("http://localhost:{}", self.builder_http_port);
+        let provider =
+            ProviderBuilder::<Identity, Identity, Optimism>::default().on_http(url.parse()?);
+
+        Ok(provider)
     }
 
     pub async fn block_generator(&self) -> eyre::Result<BlockGenerator> {

--- a/crates/op-rbuilder/src/integration/mod.rs
+++ b/crates/op-rbuilder/src/integration/mod.rs
@@ -1,6 +1,6 @@
 use alloy_consensus::TxEip1559;
 use alloy_eips::{eip1559::MIN_PROTOCOL_BASE_FEE, eip2718::Encodable2718, BlockNumberOrTag};
-use alloy_primitives::{hex, TxHash, TxNonce};
+use alloy_primitives::hex;
 use alloy_provider::{
     Identity, PendingTransactionBuilder, Provider, ProviderBuilder, RootProvider,
 };

--- a/crates/op-rbuilder/src/integration/op_rbuilder.rs
+++ b/crates/op-rbuilder/src/integration/op_rbuilder.rs
@@ -27,6 +27,7 @@ pub struct OpRbuilderConfig {
     flashblocks_ws_url: Option<String>,
     chain_block_time: Option<u64>,
     flashbots_block_time: Option<u64>,
+    with_revert_protection: Option<bool>,
 }
 
 impl OpRbuilderConfig {
@@ -61,6 +62,11 @@ impl OpRbuilderConfig {
 
     pub fn with_builder_private_key(mut self, private_key: &str) -> Self {
         self.builder_private_key = Some(private_key.to_string());
+        self
+    }
+
+    pub fn with_revert_protection(mut self, revert_protection: bool) -> Self {
+        self.with_revert_protection = Some(revert_protection);
         self
     }
 
@@ -113,6 +119,12 @@ impl Service for OpRbuilderConfig {
             .arg("--port")
             .arg(self.network_port.expect("network_port not set").to_string())
             .arg("--ipcdisable");
+
+        if let Some(revert_protection) = self.with_revert_protection {
+            if revert_protection {
+                cmd.arg("--builder.enable-revert-protection");
+            }
+        }
 
         if let Some(builder_private_key) = &self.builder_private_key {
             cmd.arg("--rollup.builder-secret-key")

--- a/crates/op-rbuilder/src/main.rs
+++ b/crates/op-rbuilder/src/main.rs
@@ -41,6 +41,7 @@ fn main() {
                 .with_components(op_node.components().payload(CustomOpPayloadBuilder::new(
                     builder_args.builder_signer,
                     std::time::Duration::from_secs(builder_args.extra_block_deadline_secs),
+                    builder_args.enable_revert_protection,
                     builder_args.flashblocks_ws_url,
                     builder_args.chain_block_time,
                     builder_args.flashblock_block_time,

--- a/crates/op-rbuilder/src/payload_builder.rs
+++ b/crates/op-rbuilder/src/payload_builder.rs
@@ -106,6 +106,7 @@ impl CustomOpPayloadBuilder {
     pub fn new(
         builder_signer: Option<Signer>,
         extra_block_deadline: std::time::Duration,
+        enable_revert_protection: bool,
         flashblocks_ws_url: String,
         chain_block_time: u64,
         flashblock_block_time: u64,

--- a/crates/op-rbuilder/src/payload_builder.rs
+++ b/crates/op-rbuilder/src/payload_builder.rs
@@ -173,6 +173,7 @@ where
     ) -> eyre::Result<PayloadBuilderHandle<<Node::Types as NodeTypes>::Payload>> {
         tracing::info!("Spawning a custom payload builder");
         let extra_block_deadline = self.extra_block_deadline;
+        let enable_revert_protection = self.enable_revert_protection;
         let payload_builder = self.build_payload_builder(ctx, pool).await?;
         let payload_job_config = BasicPayloadJobGeneratorConfig::default();
 
@@ -183,6 +184,7 @@ where
             payload_builder,
             true,
             extra_block_deadline,
+            enable_revert_protection,
         );
 
         let (payload_service, payload_builder) =

--- a/crates/op-rbuilder/src/payload_builder.rs
+++ b/crates/op-rbuilder/src/payload_builder.rs
@@ -100,6 +100,7 @@ pub struct CustomOpPayloadBuilder {
     chain_block_time: u64,
     flashblock_block_time: u64,
     extra_block_deadline: std::time::Duration,
+    enable_revert_protection: bool,
 }
 
 impl CustomOpPayloadBuilder {
@@ -117,6 +118,7 @@ impl CustomOpPayloadBuilder {
             chain_block_time,
             flashblock_block_time,
             extra_block_deadline,
+            enable_revert_protection,
         }
     }
 }

--- a/crates/op-rbuilder/src/payload_builder_vanilla.rs
+++ b/crates/op-rbuilder/src/payload_builder_vanilla.rs
@@ -1117,8 +1117,8 @@ where
             if result.is_success() {
                 num_txs_simulated_success += 1;
             } else {
+                num_txs_simulated_fail += 1;
                 if self.enable_revert_protection {
-                    num_txs_simulated_fail += 1;
                     info!(target: "payload_builder", tx_hash = ?tx.tx_hash(), "skipping reverted transaction");
                     best_txs.mark_invalid(tx.signer(), tx.nonce());
                     info.invalid_tx_hashes.insert(tx.tx_hash());


### PR DESCRIPTION
## 📝 Summary

Enable revert protection behind a flag `--builder.enable-revert-protection`. This PR also adds an extra integration test to test the behaviour.