### PR TITLE
Detect block building completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9788,7 +9788,7 @@ dependencies = [
 [[package]]
 name = "rollup-boost"
 version = "0.1.0"
-source = "git+http://github.com/flashbots/rollup-boost?rev=b9e6353d08672bd19e754a9525de47e04b34c84c#b9e6353d08672bd19e754a9525de47e04b34c84c"
+source = "git+http://github.com/flashbots/rollup-boost?rev=8506dfb7d84c65746f7c88d250983658438f59e8#8506dfb7d84c65746f7c88d250983658438f59e8"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",

--- a/crates/op-rbuilder/src/generator.rs
+++ b/crates/op-rbuilder/src/generator.rs
@@ -326,6 +326,19 @@ where
             return Poll::Ready(Ok(()));
         }
 
+        // Poll the build_complete_rx receiver
+        match this.build_complete_rx.poll_unpin(cx) {
+            Poll::Ready(Ok(result)) => {
+                tracing::debug!("Build job completed");
+                return Poll::Ready(result);
+            }
+            Poll::Ready(Err(_)) => {
+                tracing::warn!("Build job sender was dropped");
+                return Poll::Ready(Ok(()));
+            }
+            Poll::Pending => {}
+        }
+
         Poll::Pending
     }
 }


### PR DESCRIPTION
## 📝 Summary

The channel was not used previously, and this change makes `BlockPayloadJob` aware of the completion of the building.

## 💡 Motivation and Context

## ToDo

* [ ] Determine whether the job should remain active for some time after the assembly is complete.

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
