### PR TITLE
Fix bundle result

### DIFF
--- a/crates/op-rbuilder/src/primitives/bundle.rs
+++ b/crates/op-rbuilder/src/primitives/bundle.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::Bytes;
+use alloy_primitives::{Bytes, B256};
 use alloy_rpc_types_eth::erc4337::TransactionConditional;
 use serde::{Deserialize, Serialize};
 
@@ -23,4 +23,10 @@ impl Bundle {
             timestamp_min: None,
         }
     }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct BundleResult {
+    #[serde(rename = "bundleHash")]
+    pub bundle_hash: B256,
 }

--- a/crates/op-rbuilder/src/tests/framework/txs.rs
+++ b/crates/op-rbuilder/src/tests/framework/txs.rs
@@ -1,4 +1,7 @@
-use crate::{primitives::bundle::Bundle, tx_signer::Signer};
+use crate::{
+    primitives::bundle::{Bundle, BundleResult},
+    tx_signer::Signer,
+};
 use alloy_consensus::TxEip1559;
 use alloy_eips::{eip2718::Encodable2718, BlockNumberOrTag};
 use alloy_primitives::{hex, Bytes};
@@ -154,14 +157,14 @@ impl TransactionBuilder {
                 block_number_max: bundle_opts.block_number_max,
             };
 
-            let tx_hash = provider
+            let result: BundleResult = provider
                 .client()
                 .request("eth_sendBundle", (bundle,))
                 .await?;
 
             return Ok(PendingTransactionBuilder::new(
                 provider.root().clone(),
-                tx_hash,
+                result.bundle_hash,
             ));
         }
 


### PR DESCRIPTION
## 📝 Summary

To be compatible with the sendBundle type, the result should be an object with the bundle hash not only the hash. https://docs.flashbots.net/flashbots-auction/advanced/rpc-endpoint#eth_sendbundle

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
