### PR TITLE
Added feature-gated interop support

### DIFF
--- a/crates/op-rbuilder/Cargo.toml
+++ b/crates/op-rbuilder/Cargo.toml
@@ -141,6 +141,8 @@ min-trace-logs = ["tracing/release_max_level_trace"]
 
 testing = []
 
+interop = []
+
 [[bin]]
 name = "op-rbuilder"
 path = "src/main.rs"


### PR DESCRIPTION
This PR adds feature-gated interop support. Right now to produce interop binary we'll need to make PR with this support.
Long term we will remove this feature once we are comfortable enabling interop for everyone.
Uses derive-more for display. 

## 📝 Summary

<!--- A general summary of your changes -->

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
