### PR TITLE
Add replacement for default reth version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ op-alloy-consensus = { version = "0.16.0", default-features = false }
 op-alloy-flz = { version = "0.13.0", default-features = false }
 
 async-trait = { version = "0.1.83" }
-clap = { version = "4.4.3", features = ["derive", "env"] }
+clap = { version = "4.4.3", features = ["derive", "env", "string"] }
 clap_builder = { version = "4.5.19" }
 thiserror = { version = "1.0.64" }
 eyre = { version = "0.6.12" }

--- a/crates/op-rbuilder/src/args/mod.rs
+++ b/crates/op-rbuilder/src/args/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     builders::BuilderMode,
-    metrics::{CARGO_PKG_VERSION, VERGEN_GIT_SHA}
+    metrics::{CARGO_PKG_VERSION, VERGEN_GIT_SHA},
 };
 use clap_builder::{CommandFactory, FromArgMatches};
 pub use op::OpRbuilderArgs;

--- a/crates/op-rbuilder/src/args/mod.rs
+++ b/crates/op-rbuilder/src/args/mod.rs
@@ -1,5 +1,8 @@
-use crate::builders::BuilderMode;
-use clap::Parser;
+use crate::{
+    builders::BuilderMode,
+    metrics::{CARGO_PKG_VERSION, VERGEN_GIT_SHA}
+};
+use clap_builder::{CommandFactory, FromArgMatches};
 pub use op::OpRbuilderArgs;
 use playground::PlaygroundOptions;
 use reth_optimism_cli::{chainspec::OpChainSpecParser, commands::Commands};
@@ -22,6 +25,10 @@ pub trait CliExt {
     /// Returns the Cli instance with the parsed command line arguments
     /// and defaults populated if applicable.
     fn parsed() -> Self;
+
+    /// Returns the Cli instance with the parsed command line arguments
+    /// and replaces version, name, author, and about
+    fn set_version() -> Self;
 }
 
 pub type Cli = reth_optimism_cli::Cli<OpChainSpecParser, OpRbuilderArgs>;
@@ -58,7 +65,7 @@ impl CliExt for Cli {
     }
 
     fn parsed() -> Self {
-        Cli::parse().populate_defaults()
+        Cli::set_version().populate_defaults()
     }
 
     /// Returns the type of builder implementation that the node is started with.
@@ -70,6 +77,17 @@ impl CliExt for Cli {
             }
         }
         BuilderMode::Standard
+    }
+
+    /// Parses commands and overrides versions
+    fn set_version() -> Self {
+        let matches = Cli::command()
+            .version(format!("{CARGO_PKG_VERSION} ({VERGEN_GIT_SHA})"))
+            .about("Block builder designed for the Optimism stack")
+            .author("Flashbots")
+            .name("op-rbuilder")
+            .get_matches();
+        Cli::from_arg_matches(&matches).expect("Parsing args")
     }
 }
 

--- a/crates/op-rbuilder/src/main.rs
+++ b/crates/op-rbuilder/src/main.rs
@@ -18,10 +18,7 @@ mod traits;
 mod tx;
 mod tx_signer;
 
-use metrics::{
-    VersionInfo, BUILD_PROFILE_NAME, CARGO_PKG_VERSION, VERGEN_BUILD_TIMESTAMP,
-    VERGEN_CARGO_FEATURES, VERGEN_CARGO_TARGET_TRIPLE, VERGEN_GIT_SHA,
-};
+use metrics::VERSION;
 use moka::future::Cache;
 use monitor_tx_pool::monitor_tx_pool;
 use revert_protection::{EthApiExtServer, EthApiOverrideServer, RevertProtectionExt};
@@ -31,15 +28,6 @@ use tx::FBPooledTransaction;
 #[cfg(all(feature = "jemalloc", unix))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
-
-const VERSION: VersionInfo = VersionInfo {
-    version: CARGO_PKG_VERSION,
-    build_timestamp: VERGEN_BUILD_TIMESTAMP,
-    cargo_features: VERGEN_CARGO_FEATURES,
-    git_sha: VERGEN_GIT_SHA,
-    target_triple: VERGEN_CARGO_TARGET_TRIPLE,
-    build_profile: BUILD_PROFILE_NAME,
-};
 
 fn main() {
     let cli = Cli::parsed();

--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -21,6 +21,15 @@ pub const VERGEN_CARGO_FEATURES: &str = env!("VERGEN_CARGO_FEATURES");
 /// The build profile name.
 pub const BUILD_PROFILE_NAME: &str = env!("OP_RBUILDER_BUILD_PROFILE");
 
+pub const VERSION: VersionInfo = VersionInfo {
+    version: CARGO_PKG_VERSION,
+    build_timestamp: VERGEN_BUILD_TIMESTAMP,
+    cargo_features: VERGEN_CARGO_FEATURES,
+    git_sha: VERGEN_GIT_SHA,
+    target_triple: VERGEN_CARGO_TARGET_TRIPLE,
+    build_profile: BUILD_PROFILE_NAME,
+};
+
 /// op-rbuilder metrics
 #[derive(Metrics, Clone)]
 #[metrics(scope = "op_rbuilder")]


### PR DESCRIPTION
Move VERSION to different crate
closes https://github.com/flashbots/op-rbuilder/issues/14

## 📝 Summary

<!--- A general summary of your changes -->

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
