### PR TITLE
Fix typo in "local devnet" instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,13 @@ cargo run -p op-rbuilder --bin op-rbuilder -- node \
 ```bash
 git clone https://github.com/flashbots/contender
 cd contender
-cargo run -- setup ./scenarios/simple.toml http://localhost:2222
+cargo run -- setup ./scenarios/simple.toml -r http://localhost:2222
 ```
 
 6. Run `contender`:
 
 ```bash
-cargo run -- spam ./scenarios/simple.toml http://localhost:2222 --tpb 10 --duration 10
+cargo run -- spam ./scenarios/simple.toml -r http://localhost:2222 --tpb 10 --duration 10
 ```
 
 And you should start to see blocks being built and landed on-chain with `contender` transactions.


### PR DESCRIPTION
## 📝 Summary

Fixed changes for instructions on running a local devnet

current instructions appear as:

when initializing contender
`cargo run -- setup ./scenarios/simple.toml http://localhost:2222`

and when running contender
`cargo run -- spam ./scenarios/simple.toml http://localhost:2222 --tpb 10 --duration 10`

but if those lines are ran, it'll produce an error because a '-r' or '-rpc' is needed before the RPC URL

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->
This change is required because the current instructions for initializing/running contender throws an error  and this fix would make the instructions on running a local devnet a lot clearer

---

## ✅ I have completed the following steps:

* [ x ] Run `make lint`
* [ x ] Run `make test`
* [ ] Added tests (if applicable)
