### PR TITLE
feat: add a justfile to run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,13 @@ To see the full list of op-rbuilder metrics, see [`src/metrics.rs`](./src/metric
 
 op-rbuilder has an integration test framework that runs the builder against mock engine api payloads and ensures that the builder produces valid blocks.
 
-To run the integration tests, run:
+You can run the tests using the command
+
+```bash
+just run-tests
+```
+
+or the following sequence:
 
 ```bash
 # Ensure you have op-reth installed in your path,
@@ -60,7 +66,7 @@ cargo run -p op-rbuilder --features="testing" --bin tester -- genesis --output g
 cargo build -p op-rbuilder --bin op-rbuilder
 
 # Run the integration tests
-cargo test --package op-rbuilder --lib --features integration -- integration::integration_test::tests
+cargo test --package op-rbuilder --lib
 ```
 
 ## Local Devnet

--- a/justfile
+++ b/justfile
@@ -1,3 +1,27 @@
+# Build and run op-rbuilder in playground mode for testing
 run-playground:
   cargo build --bin op-rbuilder -p op-rbuilder
   ./target/debug/op-rbuilder node --builder.playground
+
+# Run the complete test suite (genesis generation, build, and tests)
+run-tests:
+  just generate-test-genesis
+  just build-op-rbuilder
+  just run-tests-op-rbuilder
+
+# Download `op-reth` binary
+download-op-reth:
+  ./scripts/ci/download-op-reth.sh
+
+# Generate a genesis file (for tests)
+generate-test-genesis:
+  cargo run -p op-rbuilder --features="testing" --bin tester -- genesis --output genesis.json
+
+
+# Build the op-rbuilder binary
+build-op-rbuilder:
+  cargo build -p op-rbuilder --bin op-rbuilder
+
+# Run the integration tests
+run-tests-op-rbuilder:
+  PATH=$PATH:$(pwd) cargo test --package op-rbuilder --lib


### PR DESCRIPTION
## 📝 Summary

This PR adds a just command for running tests, which automatically downloads op-reth using the CI script and adds it to the PATH.

## 💡 Motivation and Context

There's no need to manually modify the PATH to add an `op-reth` binary.

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
