### PR TITLE
Add block number and DA used to logging

### DIFF
--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -293,10 +293,10 @@ where
                     if flashblock_count >= self.config.flashblocks_per_block() {
                         tracing::info!(
                             target: "payload_builder",
-                            "Skipping flashblock reached target={} idx={} block_number={}",
-                            self.config.flashblocks_per_block(),
-                            flashblock_count,
-                            ctx.block_number(),
+                            target = self.config.flashblocks_per_block(),
+                            flashblock_count = flashblock_count,
+                            block_number = ctx.block_number(),
+                            "Skipping flashblock reached target",
                         );
                         continue;
                     }
@@ -304,13 +304,13 @@ where
                     // Continue with flashblock building
                     tracing::info!(
                         target: "payload_builder",
-                        "Building flashblock block_number={} idx={} target_gas={} gas_used={} taget_da={} da_used={}",
-                        ctx.block_number(),
-                        flashblock_count,
-                        total_gas_per_batch,
-                        info.cumulative_gas_used,
-                        total_da_per_batch.unwrap_or(0),
-                        info.cumulative_da_bytes_used,
+                        block_number = ctx.block_number(),
+                        flashblock_count = flashblock_count,
+                        target_gas = total_gas_per_batch,
+                        gas_used = info.cumulative_gas_used,
+                        target_da = total_da_per_batch.unwrap_or(0),
+                        da_used = info.cumulative_da_bytes_used,
+                        "Building flashblock",
                     );
                     let flashblock_build_start_time = Instant::now();
                     let state = StateProviderDatabase::new(&state_provider);

--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -293,9 +293,10 @@ where
                     if flashblock_count >= self.config.flashblocks_per_block() {
                         tracing::info!(
                             target: "payload_builder",
-                            "Skipping flashblock reached target={} idx={}",
+                            "Skipping flashblock reached target={} idx={} block_number={}",
                             self.config.flashblocks_per_block(),
-                            flashblock_count
+                            flashblock_count,
+                            ctx.block_number(),
                         );
                         continue;
                     }

--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -303,10 +303,13 @@ where
                     // Continue with flashblock building
                     tracing::info!(
                         target: "payload_builder",
-                        "Building flashblock idx={} target_gas={} taget_da={}",
+                        "Building flashblock block_number={} idx={} target_gas={} gas_used={} taget_da={} da_used={}",
+                        ctx.block_number(),
                         flashblock_count,
                         total_gas_per_batch,
+                        info.cumulative_gas_used,
                         total_da_per_batch.unwrap_or(0),
+                        info.cumulative_da_bytes_used,
                     );
                     let flashblock_build_start_time = Instant::now();
                     let state = StateProviderDatabase::new(&state_provider);

--- a/crates/op-rbuilder/src/builders/flashblocks/wspub.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/wspub.rs
@@ -187,7 +187,7 @@ async fn broadcast_loop(
                     sent.fetch_add(1, Ordering::Relaxed);
                     metrics.messages_sent_count.increment(1);
 
-                    tracing::info!("Broadcasted payload: {:?}", payload);
+                    tracing::debug!("Broadcasted payload: {:?}", payload);
                     if let Err(e) = stream.send(Message::Text(payload)).await {
                         tracing::debug!("Closing flashblocks subscription for {peer_addr}: {e}");
                         break; // Exit the loop if sending fails


### PR DESCRIPTION
## 📝 Summary
Adding block number to building logs allows to debug things more easily, also adding da used. 

<!--- A general summary of your changes -->

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
