### PR TITLE
fix: improve timing for Flashblock production

### DIFF
--- a/crates/op-rbuilder/src/args/op.rs
+++ b/crates/op-rbuilder/src/args/op.rs
@@ -93,11 +93,19 @@ pub struct FlashblocksArgs {
     )]
     pub flashblocks_addr: String,
 
-    /// flashblock block time in milliseconds
+    /// Number of Flashblocks per block
     #[arg(
-        long = "flashblocks.block-time",
-        default_value = "250",
-        env = "FLASHBLOCK_BLOCK_TIME"
+        long = "flashblocks.per-block",
+        default_value = "10",
+        env = "FLASHBLOCKS_PER_BLOCK"
     )]
-    pub flashblocks_block_time: u64,
+    pub flashblocks_per_block: u64,
+
+    /// Overhead for reset of block production (e.g. new payload request to sequencer EL)
+    #[arg(
+        long = "flashblocks.block-overhead",
+        default_value = "100",
+        env = "FLASHBLOCK_BLOCK_OVERHEAD"
+    )]
+    pub flashblocks_block_overhead: u64,
 }

--- a/crates/op-rbuilder/src/builders/flashblocks/config.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/config.rs
@@ -1,8 +1,9 @@
-use crate::{args::OpRbuilderArgs, builders::BuilderConfig};
+use crate::args::OpRbuilderArgs;
 use core::{
     net::{Ipv4Addr, SocketAddr},
     time::Duration,
 };
+use tracing::info;
 
 /// Configuration values that are specific to the flashblocks builder.
 #[derive(Debug, Clone)]
@@ -11,17 +12,21 @@ pub struct FlashblocksConfig {
     /// new flashblocks updates.
     pub ws_addr: SocketAddr,
 
+    /// The number of Flashblocks in each block
+    pub flashblocks_per_block: u64,
+
     /// How often a flashblock is produced. This is independent of the block time of the chain.
     /// Each block will contain one or more flashblocks. On average, the number of flashblocks
     /// per block is equal to the block time divided by the flashblock interval.
-    pub interval: Duration,
+    pub build_interval: Duration,
 }
 
 impl Default for FlashblocksConfig {
     fn default() -> Self {
         Self {
             ws_addr: SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 1111),
-            interval: Duration::from_millis(250),
+            build_interval: Duration::from_millis(225),
+            flashblocks_per_block: 10,
         }
     }
 }
@@ -30,25 +35,25 @@ impl TryFrom<OpRbuilderArgs> for FlashblocksConfig {
     type Error = eyre::Report;
 
     fn try_from(args: OpRbuilderArgs) -> Result<Self, Self::Error> {
-        let interval = Duration::from_millis(args.flashblocks.flashblocks_block_time);
-
         let ws_addr = SocketAddr::new(
             args.flashblocks.flashblocks_addr.parse()?,
             args.flashblocks.flashblocks_port,
         );
-        Ok(Self { ws_addr, interval })
-    }
-}
 
-pub trait FlashBlocksConfigExt {
-    fn flashblocks_per_block(&self) -> u64;
-}
+        let build_interval = Duration::from_millis(
+            (args.chain_block_time - args.flashblocks.flashblocks_block_overhead)
+                / args.flashblocks.flashblocks_per_block,
+        );
 
-impl FlashBlocksConfigExt for BuilderConfig<FlashblocksConfig> {
-    fn flashblocks_per_block(&self) -> u64 {
-        if self.block_time.as_millis() == 0 {
-            return 0;
-        }
-        (self.block_time.as_millis() / self.specific.interval.as_millis()) as u64
+        info!(
+            "Flashblocks parameters builder_interval={}",
+            build_interval.as_millis()
+        );
+
+        Ok(Self {
+            ws_addr,
+            build_interval,
+            flashblocks_per_block: args.flashblocks.flashblocks_per_block,
+        })
     }
 }

--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -5,7 +5,6 @@ use super::{config::FlashblocksConfig, wspub::WebSocketPublisher};
 use crate::{
     builders::{
         context::{estimate_gas_for_builder_tx, OpPayloadBuilderCtx},
-        flashblocks::config::FlashBlocksConfigExt,
         generator::{BlockCell, BuildArguments},
         BuilderConfig,
     },
@@ -229,12 +228,12 @@ where
             // return early since we don't need to build a block with transactions from the pool
             return Ok(());
         }
-        let gas_per_batch = ctx.block_gas_limit() / self.config.flashblocks_per_block();
+        let gas_per_batch = ctx.block_gas_limit() / self.config.specific.flashblocks_per_block;
         let mut total_gas_per_batch = gas_per_batch;
         let da_per_batch = ctx
             .da_config
             .max_da_block_size()
-            .map(|da_limit| da_limit / self.config.flashblocks_per_block());
+            .map(|da_limit| da_limit / self.config.specific.flashblocks_per_block);
         // Check that builder tx won't affect fb limit too much
         if let Some(da_limit) = da_per_batch {
             // We error if we can't insert any tx aside from builder tx in flashblock
@@ -244,14 +243,14 @@ where
         }
         let mut total_da_per_batch = da_per_batch;
 
-        let last_flashblock = self.config.flashblocks_per_block().saturating_sub(1);
+        let last_flashblock = self.config.specific.flashblocks_per_block.saturating_sub(1);
         let mut flashblock_count = 0;
         // Create a channel to coordinate flashblock building
         let (build_tx, mut build_rx) = mpsc::channel(1);
 
         // Spawn the timer task that signals when to build a new flashblock
         let cancel_clone = ctx.cancel.clone();
-        let interval = self.config.specific.interval;
+        let interval = self.config.specific.build_interval;
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(interval);
             loop {
@@ -265,12 +264,16 @@ where
                         }
                     }
                 _ = interval.tick() => {
-                            if let Err(err) = build_tx.send(()).await {
-                                error!(target: "payload_builder", "Error sending build signal: {}", err);
-                                break;
-                            }
+                    if let Err(err) = build_tx.send(()).await {
+                        if build_tx.is_closed() || cancel_clone.is_cancelled() {
+                            debug!(target: "payload_builder", "Building is stopped");
+                            break;
                         }
-                }
+
+                        error!(target: "payload_builder", "Error sending build signal: {}", err);
+                        break;
+                    }
+                }}
             }
         });
 
@@ -292,6 +295,17 @@ where
                         return None;
                     }
 
+                    // If we've built all the flashblocks, no more work to do
+                    if flashblock_count >= self.config.specific.flashblocks_per_block {
+                        tracing::info!(
+                            target: "payload_builder",
+                            "Built all Flashblocks target={} idx={}, stopping payload builder",
+                            self.config.specific.flashblocks_per_block,
+                            flashblock_count
+                        );
+                        return None;
+                    }
+
                     // Wait for next message
                     build_rx.recv().await
                 })
@@ -300,16 +314,6 @@ where
             // Exit loop if channel closed or cancelled
             match received {
                 Some(()) => {
-                    if flashblock_count >= self.config.flashblocks_per_block() {
-                        tracing::info!(
-                            target: "payload_builder",
-                            "Skipping flashblock reached target={} idx={}",
-                            self.config.flashblocks_per_block(),
-                            flashblock_count
-                        );
-                        continue;
-                    }
-
                     // Continue with flashblock building
                     tracing::info!(
                         target: "payload_builder",
@@ -318,6 +322,7 @@ where
                         total_gas_per_batch,
                         total_da_per_batch.unwrap_or(0),
                     );
+
                     let flashblock_build_start_time = Instant::now();
                     let state = StateProviderDatabase::new(&state_provider);
                     invoke_on_last_flashblock(flashblock_count, last_flashblock, || {
@@ -357,7 +362,7 @@ where
                     if ctx.cancel.is_cancelled() {
                         tracing::info!(
                             target: "payload_builder",
-                            "Job cancelled, stopping payload building",
+                            "Job cancelled, stopping payload building block_number={}", ctx.block_number()
                         );
                         // if the job was cancelled, stop
                         return Ok(());
@@ -419,11 +424,11 @@ where
                     }
                 }
                 None => {
-                    // Exit loop if channel closed or cancelled
                     self.metrics.block_built_success.increment(1);
                     self.metrics
                         .flashblock_count
                         .record(flashblock_count as f64);
+                    tracing::info!(target: "payload_builder", "Completed block building block={} flashblock_count={}", ctx.block_number(), flashblock_count);
                     return Ok(());
                 }
             }

--- a/crates/op-rbuilder/src/tests/flashblocks/smoke.rs
+++ b/crates/op-rbuilder/src/tests/flashblocks/smoke.rs
@@ -13,7 +13,7 @@ async fn chain_produces_blocks() -> eyre::Result<()> {
     let harness = TestHarnessBuilder::new("flashbots_chain_produces_blocks")
         .with_flashblocks_port(1239)
         .with_chain_block_time(2000)
-        .with_flashbots_block_time(200)
+        .with_flashblocks_per_block(10)
         .build()
         .await?;
 

--- a/crates/op-rbuilder/src/tests/framework/harness.rs
+++ b/crates/op-rbuilder/src/tests/framework/harness.rs
@@ -24,7 +24,7 @@ pub struct TestHarnessBuilder {
     use_revert_protection: bool,
     flashblocks_port: Option<u16>,
     chain_block_time: Option<u64>,
-    flashbots_block_time: Option<u64>,
+    flashblocks_per_block: Option<u64>,
     namespaces: Option<String>,
     extra_params: Option<String>,
 }
@@ -36,7 +36,7 @@ impl TestHarnessBuilder {
             use_revert_protection: false,
             flashblocks_port: None,
             chain_block_time: None,
-            flashbots_block_time: None,
+            flashblocks_per_block: None,
             namespaces: None,
             extra_params: None,
         }
@@ -57,8 +57,8 @@ impl TestHarnessBuilder {
         self
     }
 
-    pub fn with_flashbots_block_time(mut self, block_time: u64) -> Self {
-        self.flashbots_block_time = Some(block_time);
+    pub fn with_flashblocks_per_block(mut self, flashblocks_per_block: u64) -> Self {
+        self.flashblocks_per_block = Some(flashblocks_per_block);
         self
     }
 
@@ -104,8 +104,8 @@ impl TestHarnessBuilder {
             op_rbuilder_config = op_rbuilder_config.with_chain_block_time(chain_block_time);
         }
 
-        if let Some(flashbots_block_time) = self.flashbots_block_time {
-            op_rbuilder_config = op_rbuilder_config.with_flashbots_block_time(flashbots_block_time);
+        if let Some(flashblocks_per_block) = self.flashblocks_per_block {
+            op_rbuilder_config = op_rbuilder_config.with_flashbots_per_block(flashblocks_per_block);
         }
 
         // create the validation reth node
@@ -128,7 +128,7 @@ impl TestHarnessBuilder {
         let builder_log_path = builder.log_path.clone();
 
         Ok(TestHarness {
-            framework: framework,
+            framework,
             builder_auth_rpc_port,
             builder_http_port,
             validator_auth_rpc_port,

--- a/crates/op-rbuilder/src/tests/framework/op.rs
+++ b/crates/op-rbuilder/src/tests/framework/op.rs
@@ -25,7 +25,7 @@ pub struct OpRbuilderConfig {
     builder_private_key: Option<String>,
     flashblocks_port: Option<u16>,
     chain_block_time: Option<u64>,
-    flashbots_block_time: Option<u64>,
+    flashblocks_per_block: Option<u64>,
     with_revert_protection: Option<bool>,
     namespaces: Option<String>,
     extra_params: Option<String>,
@@ -81,8 +81,8 @@ impl OpRbuilderConfig {
         self
     }
 
-    pub fn with_flashbots_block_time(mut self, time: u64) -> Self {
-        self.flashbots_block_time = Some(time);
+    pub fn with_flashbots_per_block(mut self, count: u64) -> Self {
+        self.flashblocks_per_block = Some(count);
         self
     }
 
@@ -164,9 +164,9 @@ impl Service for OpRbuilderConfig {
                 .arg(chain_block_time.to_string());
         }
 
-        if let Some(flashbots_block_time) = self.flashbots_block_time {
-            cmd.arg("--flashblocks.block-time")
-                .arg(flashbots_block_time.to_string());
+        if let Some(flashblocks_per_block) = self.flashblocks_per_block {
+            cmd.arg("--flashblocks.per-block")
+                .arg(flashblocks_per_block.to_string());
         }
 
         if let Some(namespaces) = &self.namespaces {


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->

* Configure the number of Flashblocks per block and a block overhead vs. current Flashblock time. 
* Don't trigger the build_tx event, when you've built the full number of Flashblocks. This causes the function to return earlier.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

To ensure that we build the correct number of Flashblocks per block. See https://github.com/flashbots/op-rbuilder/issues/101 for full context.

I ran this on Base Sepolia today and it improved both:

1. Number of Flashblocks that were produced per block
![Screenshot 2025-06-03 at 3 13 55 PM](https://github.com/user-attachments/assets/2e6b05c5-e775-4d32-94e4-7a5651b120d4)
![Screenshot 2025-06-03 at 3 14 01 PM](https://github.com/user-attachments/assets/45777b70-0b59-49d2-a21c-ff8fb4055944)

2. Number of reorgs (where the block doesn't match the Flashblocks) dropped from ~20% to ~1%
![Screenshot 2025-06-03 at 3 13 43 PM](https://github.com/user-attachments/assets/bb823fd4-1d4a-4a46-979f-ee262f2089bb)

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
