### PR TITLE
Update reverting transaction hashes JSON

### DIFF
--- a/crates/op-rbuilder/src/primitives/bundle.rs
+++ b/crates/op-rbuilder/src/primitives/bundle.rs
@@ -9,8 +9,12 @@ pub struct Bundle {
     #[serde(rename = "txs")]
     pub transactions: Vec<Bytes>,
 
-    #[serde(rename = "reverting_tx_hashes")]
-    pub reverting_hashes: Vec<B256>,
+    #[serde(
+        default,
+        rename = "revertingTxHashes",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub reverting_hashes: Option<Vec<B256>>,
 
     #[serde(
         default,

--- a/crates/op-rbuilder/src/tests/framework/txs.rs
+++ b/crates/op-rbuilder/src/tests/framework/txs.rs
@@ -165,9 +165,9 @@ impl TransactionBuilder {
             let bundle = Bundle {
                 transactions: vec![transaction_encoded.into()],
                 reverting_hashes: if with_reverted_hash {
-                    vec![txn_hash]
+                    Some(vec![txn_hash])
                 } else {
-                    vec![]
+                    None
                 },
                 block_number_max: bundle_opts.block_number_max,
                 block_number_min: bundle_opts.block_number_min,

--- a/crates/op-rbuilder/src/tx.rs
+++ b/crates/op-rbuilder/src/tx.rs
@@ -34,13 +34,13 @@ impl OpPooledTx for FBPooledTransaction {
 }
 
 pub trait MaybeRevertingTransaction {
-    fn set_reverted_hashes(&mut self, reverted_hashes: Vec<B256>);
+    fn set_reverted_hashes(&mut self, reverted_hashes: Option<Vec<B256>>);
     fn reverted_hashes(&self) -> Option<Vec<B256>>;
 }
 
 impl MaybeRevertingTransaction for FBPooledTransaction {
-    fn set_reverted_hashes(&mut self, reverted_hashes: Vec<B256>) {
-        self.reverted_hashes = Some(reverted_hashes);
+    fn set_reverted_hashes(&mut self, reverted_hashes: Option<Vec<B256>>) {
+        self.reverted_hashes = reverted_hashes;
     }
 
     fn reverted_hashes(&self) -> Option<Vec<B256>> {


### PR DESCRIPTION
## 📝 Summary

This renames the reverting_transaction_hashes field's JSON key to be `revertingTxHashes`. In addition, this makes the field optional in the JSON.



## ✅ I have completed the following steps:

This builds but I am not able to get the tests to run locally.