### PR TITLE
Put the integration tests in their own feature

### DIFF
--- a/crates/op-rbuilder/Cargo.toml
+++ b/crates/op-rbuilder/Cargo.toml
@@ -130,7 +130,8 @@ alloy-provider = { workspace = true, default-features = true, features = [
 tempfile = "3.8"
 
 [features]
-default = ["jemalloc"]
+integration_tests = []
+default = ["jemalloc", "integration_tests"]
 
 jemalloc = [
 	"dep:tikv-jemallocator",

--- a/crates/op-rbuilder/src/tests/flashblocks/smoke.rs
+++ b/crates/op-rbuilder/src/tests/flashblocks/smoke.rs
@@ -8,6 +8,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::tests::TestHarnessBuilder;
 
+#[cfg(feature = "integration_tests")]
 #[tokio::test]
 async fn chain_produces_blocks() -> eyre::Result<()> {
     let harness = TestHarnessBuilder::new("flashbots_chain_produces_blocks")

--- a/crates/op-rbuilder/src/tests/vanilla/data_availability.rs
+++ b/crates/op-rbuilder/src/tests/vanilla/data_availability.rs
@@ -3,6 +3,7 @@ use alloy_provider::Provider;
 
 /// This test ensures that the transaction size limit is respected.
 /// We will set limit to 1 byte and see that the builder will not include any transactions.
+#[cfg(feature = "integration_tests")]
 #[tokio::test]
 async fn data_availability_tx_size_limit() -> eyre::Result<()> {
     let harness = TestHarnessBuilder::new("data_availability_tx_size_limit")
@@ -36,6 +37,7 @@ async fn data_availability_tx_size_limit() -> eyre::Result<()> {
 
 /// This test ensures that the block size limit is respected.
 /// We will set limit to 1 byte and see that the builder will not include any transactions.
+#[cfg(feature = "integration_tests")]
 #[tokio::test]
 async fn data_availability_block_size_limit() -> eyre::Result<()> {
     let harness = TestHarnessBuilder::new("data_availability_block_size_limit")
@@ -67,6 +69,7 @@ async fn data_availability_block_size_limit() -> eyre::Result<()> {
 /// Size of each transaction is 100000000
 /// We will set limit to 3 txs and see that the builder will include 3 transactions.
 /// We should not forget about builder transaction so we will spawn only 2 regular txs.
+#[cfg(feature = "integration_tests")]
 #[tokio::test]
 async fn data_availability_block_fill() -> eyre::Result<()> {
     let harness = TestHarnessBuilder::new("data_availability_block_fill")

--- a/crates/op-rbuilder/src/tests/vanilla/ordering.rs
+++ b/crates/op-rbuilder/src/tests/vanilla/ordering.rs
@@ -3,6 +3,7 @@ use alloy_consensus::Transaction;
 use futures::{future::join_all, stream, StreamExt};
 
 /// This test ensures that the transactions are ordered by fee priority in the block.
+#[cfg(feature = "integration_tests")]
 #[tokio::test]
 async fn fee_priority_ordering() -> eyre::Result<()> {
     let harness = TestHarnessBuilder::new("integration_test_fee_priority_ordering")

--- a/crates/op-rbuilder/src/tests/vanilla/revert.rs
+++ b/crates/op-rbuilder/src/tests/vanilla/revert.rs
@@ -10,6 +10,7 @@ use crate::{
 /// are eventually dropped from the pool once their block range is reached.
 /// This test creates N transactions with different block ranges.
 #[tokio::test]
+#[cfg(feature = "integration_tests")]
 async fn revert_protection_monitor_transaction_gc() -> eyre::Result<()> {
     let harness = TestHarnessBuilder::new("revert_protection_monitor_transaction_gc")
         .with_revert_protection()
@@ -59,6 +60,7 @@ async fn revert_protection_monitor_transaction_gc() -> eyre::Result<()> {
 
 /// If revert protection is disabled, the transactions that revert are included in the block.
 #[tokio::test]
+#[cfg(feature = "integration_tests")]
 async fn revert_protection_disabled() -> eyre::Result<()> {
     let harness = TestHarnessBuilder::new("revert_protection_disabled")
         .build()
@@ -81,6 +83,7 @@ async fn revert_protection_disabled() -> eyre::Result<()> {
 /// If revert protection is disabled, it should not be possible to send a revert bundle
 /// since the revert RPC endpoint is not available.
 #[tokio::test]
+#[cfg(feature = "integration_tests")]
 async fn revert_protection_disabled_bundle_endpoint_error() -> eyre::Result<()> {
     let harness = TestHarnessBuilder::new("revert_protection_disabled_bundle_endpoint_error")
         .build()
@@ -104,6 +107,7 @@ async fn revert_protection_disabled_bundle_endpoint_error() -> eyre::Result<()> 
 /// is not included in the block and tried again for the next bundle range blocks
 /// when it will be dropped from the pool.
 #[tokio::test]
+#[cfg(feature = "integration_tests")]
 async fn revert_protection_bundle() -> eyre::Result<()> {
     let harness = TestHarnessBuilder::new("revert_protection_bundle")
         .with_revert_protection()
@@ -177,6 +181,7 @@ async fn revert_protection_bundle() -> eyre::Result<()> {
 
 /// Test the behaviour of the revert protection bundle with a min block number.
 #[tokio::test]
+#[cfg(feature = "integration_tests")]
 async fn revert_protection_bundle_min_block_number() -> eyre::Result<()> {
     let harness = TestHarnessBuilder::new("revert_protection_bundle_min_block_number")
         .with_revert_protection()
@@ -226,6 +231,7 @@ async fn revert_protection_bundle_min_block_number() -> eyre::Result<()> {
 
 /// Test the range limits for the revert protection bundle.
 #[tokio::test]
+#[cfg(feature = "integration_tests")]
 async fn revert_protection_bundle_range_limits() -> eyre::Result<()> {
     let harness = TestHarnessBuilder::new("revert_protection_bundle_range_limits")
         .with_revert_protection()
@@ -297,6 +303,7 @@ async fn revert_protection_bundle_range_limits() -> eyre::Result<()> {
 /// If a transaction reverts and was sent as a normal transaction through the eth_sendRawTransaction
 /// bundle, the transaction should be included in the block.
 /// This behaviour is the same as the 'revert_protection_disabled' test.
+#[cfg(feature = "integration_tests")]
 #[tokio::test]
 async fn revert_protection_allow_reverted_transactions_without_bundle() -> eyre::Result<()> {
     let harness =
@@ -321,6 +328,7 @@ async fn revert_protection_allow_reverted_transactions_without_bundle() -> eyre:
 
 /// If a transaction reverts and gets dropped it, the eth_getTransactionReceipt should return
 /// an error message that it was dropped.
+#[cfg(feature = "integration_tests")]
 #[tokio::test]
 async fn revert_protection_check_transaction_receipt_status_message() -> eyre::Result<()> {
     let harness =

--- a/crates/op-rbuilder/src/tests/vanilla/smoke.rs
+++ b/crates/op-rbuilder/src/tests/vanilla/smoke.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 
 /// This is a smoke test that ensures that transactions are included in blocks
 /// and that the block generator is functioning correctly.
+#[cfg(feature = "integration_tests")]
 #[tokio::test]
 async fn chain_produces_blocks() -> eyre::Result<()> {
     let harness = TestHarnessBuilder::new("chain_produces_blocks")
@@ -69,6 +70,7 @@ async fn chain_produces_blocks() -> eyre::Result<()> {
 /// Ensures that payloads are generated correctly even when the builder is busy
 /// with other requests, such as fcu or getPayload.
 #[tokio::test]
+#[cfg(feature = "integration_tests")]
 async fn get_payload_close_to_fcu() -> eyre::Result<()> {
     let test_harness = TestHarnessBuilder::new("get_payload_close_to_fcu")
         .build()
@@ -100,6 +102,7 @@ async fn get_payload_close_to_fcu() -> eyre::Result<()> {
 /// This test validates that if we flood the builder with many transactions
 /// and we request short block times, the builder can still eventually resolve all the transactions
 #[tokio::test]
+#[cfg(feature = "integration_tests")]
 async fn transaction_flood_no_sleep() -> eyre::Result<()> {
     let test_harness = TestHarnessBuilder::new("transaction_flood_no_sleep")
         .build()

--- a/crates/op-rbuilder/src/tests/vanilla/txpool.rs
+++ b/crates/op-rbuilder/src/tests/vanilla/txpool.rs
@@ -2,6 +2,7 @@ use crate::tests::{framework::TestHarnessBuilder, ONE_ETH};
 use alloy_provider::ext::TxPoolApi;
 
 /// This test ensures that pending pool custom limit is respected and priority tx would be included even when pool if full.
+#[cfg(feature = "integration_tests")]
 #[tokio::test]
 async fn pending_pool_limit() -> eyre::Result<()> {
     let harness = TestHarnessBuilder::new("pending_pool_limit")


### PR DESCRIPTION
This is so that unit tests can be run without the whole development setup being there yet.

The feature is enabled by default, but unit tests can now be run separately.