### PR TITLE
Split op-rbuilder in lib and main

### DIFF
--- a/crates/op-rbuilder/Cargo.toml
+++ b/crates/op-rbuilder/Cargo.toml
@@ -160,7 +160,7 @@ custom-engine-api = []
 
 [[bin]]
 name = "op-rbuilder"
-path = "src/main.rs"
+path = "src/bin/op-rbuilder/main.rs"
 
 [[bin]]
 name = "tester"

--- a/crates/op-rbuilder/src/bin/op-rbuilder/main.rs
+++ b/crates/op-rbuilder/src/bin/op-rbuilder/main.rs
@@ -1,0 +1,5 @@
+use op_rbuilder::launcher::launch;
+
+fn main() -> eyre::Result<()> {
+    launch()
+}

--- a/crates/op-rbuilder/src/bin/op-rbuilder/main.rs
+++ b/crates/op-rbuilder/src/bin/op-rbuilder/main.rs
@@ -1,5 +1,10 @@
 use op_rbuilder::launcher::launch;
 
 fn main() -> eyre::Result<()> {
+    // Prefer jemalloc for performance reasons.
+    #[cfg(all(feature = "jemalloc", unix))]
+    #[global_allocator]
+    static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
     launch()
 }

--- a/crates/op-rbuilder/src/bin/op-rbuilder/main.rs
+++ b/crates/op-rbuilder/src/bin/op-rbuilder/main.rs
@@ -1,10 +1,10 @@
 use op_rbuilder::launcher::launch;
 
-fn main() -> eyre::Result<()> {
-    // Prefer jemalloc for performance reasons.
-    #[cfg(all(feature = "jemalloc", unix))]
-    #[global_allocator]
-    static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+// Prefer jemalloc for performance reasons.
+#[cfg(all(feature = "jemalloc", unix))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
+fn main() -> eyre::Result<()> {
     launch()
 }

--- a/crates/op-rbuilder/src/launcher.rs
+++ b/crates/op-rbuilder/src/launcher.rs
@@ -2,8 +2,7 @@ use eyre::Result;
 
 use crate::{
     args::*,
-    builders::{BuilderConfig, PayloadBuilder},
-    builders::{BuilderMode, FlashblocksBuilder, StandardBuilder},
+    builders::{BuilderConfig, BuilderMode, FlashblocksBuilder, PayloadBuilder, StandardBuilder},
     metrics::VERSION,
     monitor_tx_pool::monitor_tx_pool,
     primitives::reth::engine_api_builder::OpEngineApiBuilder,
@@ -23,11 +22,6 @@ use reth_optimism_node::{
 };
 use reth_transaction_pool::TransactionPool;
 use std::{marker::PhantomData, sync::Arc};
-
-// Prefer jemalloc for performance reasons.
-#[cfg(all(feature = "jemalloc", unix))]
-#[global_allocator]
-static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 pub fn launch() -> Result<()> {
     let cli = Cli::parsed();

--- a/crates/op-rbuilder/src/launcher.rs
+++ b/crates/op-rbuilder/src/launcher.rs
@@ -1,24 +1,15 @@
-use args::*;
-use builders::{BuilderMode, FlashblocksBuilder, StandardBuilder};
+use crate::args::*;
+use crate::builders::{BuilderMode, FlashblocksBuilder, StandardBuilder};
 use eyre::Result;
 
-/// CLI argument parsing.
-pub mod args;
-mod builders;
-mod metrics;
-mod monitor_tx_pool;
-mod primitives;
-mod revert_protection;
-mod traits;
-mod tx;
-mod tx_signer;
-
-use builders::{BuilderConfig, PayloadBuilder};
+use crate::builders::{BuilderConfig, PayloadBuilder};
+use crate::metrics::VERSION;
+use crate::monitor_tx_pool::monitor_tx_pool;
+use crate::primitives::reth::engine_api_builder::OpEngineApiBuilder;
+use crate::revert_protection::{EthApiExtServer, EthApiOverrideServer, RevertProtectionExt};
+use crate::tx::FBPooledTransaction;
 use core::fmt::Debug;
-use metrics::VERSION;
 use moka::future::Cache;
-use monitor_tx_pool::monitor_tx_pool;
-use primitives::reth::engine_api_builder::OpEngineApiBuilder;
 use reth::builder::{NodeBuilder, WithLaunchContext};
 use reth_cli_commands::launcher::Launcher;
 use reth_db::mdbx::DatabaseEnv;
@@ -29,16 +20,14 @@ use reth_optimism_node::{
     OpNode,
 };
 use reth_transaction_pool::TransactionPool;
-use revert_protection::{EthApiExtServer, EthApiOverrideServer, RevertProtectionExt};
 use std::{marker::PhantomData, sync::Arc};
-use tx::FBPooledTransaction;
 
 // Prefer jemalloc for performance reasons.
 #[cfg(all(feature = "jemalloc", unix))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-fn main() -> Result<()> {
+pub fn launch() -> Result<()> {
     let cli = Cli::parsed();
     let mode = cli.builder_mode();
     let mut cli_app = cli.configure();

--- a/crates/op-rbuilder/src/launcher.rs
+++ b/crates/op-rbuilder/src/launcher.rs
@@ -1,13 +1,15 @@
-use crate::args::*;
-use crate::builders::{BuilderMode, FlashblocksBuilder, StandardBuilder};
 use eyre::Result;
 
-use crate::builders::{BuilderConfig, PayloadBuilder};
-use crate::metrics::VERSION;
-use crate::monitor_tx_pool::monitor_tx_pool;
-use crate::primitives::reth::engine_api_builder::OpEngineApiBuilder;
-use crate::revert_protection::{EthApiExtServer, EthApiOverrideServer, RevertProtectionExt};
-use crate::tx::FBPooledTransaction;
+use crate::{
+    args::*,
+    builders::{BuilderConfig, PayloadBuilder},
+    builders::{BuilderMode, FlashblocksBuilder, StandardBuilder},
+    metrics::VERSION,
+    monitor_tx_pool::monitor_tx_pool,
+    primitives::reth::engine_api_builder::OpEngineApiBuilder,
+    revert_protection::{EthApiExtServer, EthApiOverrideServer, RevertProtectionExt},
+    tx::FBPooledTransaction,
+};
 use core::fmt::Debug;
 use moka::future::Cache;
 use reth::builder::{NodeBuilder, WithLaunchContext};

--- a/crates/op-rbuilder/src/lib.rs
+++ b/crates/op-rbuilder/src/lib.rs
@@ -6,3 +6,11 @@ pub mod tests;
 
 pub mod traits;
 pub mod tx;
+
+/// CLI argument parsing.
+pub mod args;
+mod builders;
+pub mod launcher;
+mod metrics;
+mod monitor_tx_pool;
+mod revert_protection;


### PR DESCRIPTION
## 📝 Summary

Before, in the src folder we had both a `main.rs` function and an import `lib.rs` one. This setup created problems because methods exported in lib were not available for main since I believe the execution contexts were different.

This PR changes that and splits the op-rbuilder in two components, a library (under `src`) and the op-rbuilder main binary (under `bin`) which consumes the library. Other than the main split in functionality this PR does not introduce any other ergonomics about how to structure better the library to be consumed by the main binary. I will leave that to followup PRs that consume this functionality.
