### PR TITLE
Add metric for bundles received

### DIFF
--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -76,6 +76,8 @@ pub struct OpRBuilderMetrics {
     pub da_block_size_limit: Gauge,
     /// Da tx size limit
     pub da_tx_size_limit: Gauge,
+    /// Number of valid bundles received at the eth_sendBundle endpoint
+    pub bundles_received: Counter,
 }
 
 /// Contains version information for the application.


### PR DESCRIPTION
## 📝 Summary

Add a metric to count the number of valid bundles received at the `eth_sendBundle` endpoint.

## 💡 Motivation and Context

https://github.com/flashbots/op-rbuilder/issues/92

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
