### PR TITLE
Add metric to count reverted bundles

### DIFF
--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -78,6 +78,8 @@ pub struct OpRBuilderMetrics {
     pub da_tx_size_limit: Gauge,
     /// Number of valid bundles received at the eth_sendBundle endpoint
     pub bundles_received: Counter,
+    /// Number of reverted bundles
+    pub bundles_reverted: Histogram,
 }
 
 /// Contains version information for the application.


### PR DESCRIPTION
## 📝 Summary
Count the number of reverted bundles

## 💡 Motivation and Context
We can get spammed by bad bundles so we should track this

Resolves https://github.com/flashbots/op-rbuilder/issues/150

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
