### PR TITLE
Avoid boxing for the txlogging task

### DIFF
--- a/crates/op-rbuilder/src/launcher.rs
+++ b/crates/op-rbuilder/src/launcher.rs
@@ -166,16 +166,9 @@ where
                 VERSION.register_version_metrics();
                 if builder_args.log_pool_transactions {
                     tracing::info!("Logging pool transactions");
-                    ctx.task_executor.spawn_critical(
-                        "txlogging",
-                        Box::pin(async move {
-                            monitor_tx_pool(
-                                ctx.pool.all_transactions_event_listener(),
-                                reverted_cache_copy,
-                            )
-                            .await;
-                        }),
-                    );
+                    let listener = ctx.pool.all_transactions_event_listener();
+                    let task = monitor_tx_pool(listener, reverted_cache_copy);
+                    ctx.task_executor.spawn_critical("txlogging", task);
                 }
 
                 Ok(())


### PR DESCRIPTION
## 📝 Summary

Improved how we launch the `txlogging` task.
Since `monitor_tx_pool` already returns a `Future`, we can simply reuse it.


## 💡 Motivation and Context

Reduce the number of boxes and closures to improve readability.

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
