### PR TITLE
Genesis command outputs genesis file

### DIFF
--- a/crates/op-rbuilder/src/tests/framework/apis.rs
+++ b/crates/op-rbuilder/src/tests/framework/apis.rs
@@ -222,9 +222,9 @@ pub async fn generate_genesis(output: Option<String>) -> eyre::Result<()> {
     // Write the result to the output file
     if let Some(output) = output {
         std::fs::write(&output, serde_json::to_string_pretty(&genesis)?)?;
-        debug!("Generated genesis file at: {output}");
+        println!("Generated genesis file at: {output}");
     } else {
-        debug!("{}", serde_json::to_string_pretty(&genesis)?);
+        println!("{}", serde_json::to_string_pretty(&genesis)?);
     }
 
     Ok(())


### PR DESCRIPTION
## 📝 Summary

Fixing a regression introduced in https://github.com/flashbots/op-rbuilder/pull/132 by which the output of the genesis command is not shown on terminal.
