### PR TITLE
Fix regression on tester command

### DIFF
--- a/crates/op-rbuilder/src/bin/tester/main.rs
+++ b/crates/op-rbuilder/src/bin/tester/main.rs
@@ -70,7 +70,7 @@ pub async fn run_system(validation: bool) -> eyre::Result<()> {
 
     let engine_api = EngineApi::with_http("http://localhost:4444");
     let provider = ProviderBuilder::<Identity, Identity, Optimism>::default()
-        .connect_http("http://localhost:2222".try_into()?);
+        .connect_http("http://localhost:4444".try_into()?);
     let mut driver = ChainDriver::<Http>::remote(provider, engine_api);
 
     if validation {


### PR DESCRIPTION
## 📝 Summary

The way we use the tester command to simulate the EL node, there is only a single logical endpoint. This was added as part of #132 to split the JSON-RPC calls since we use the same routine for testing where there is a more intentional split.
