### PR TITLE
fix: add default-run to the op-rbuilder's manifest

### DIFF
--- a/crates/op-rbuilder/Cargo.toml
+++ b/crates/op-rbuilder/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+default-run = "op-rbuilder"
 
 [dependencies]
 reth.workspace = true


### PR DESCRIPTION
## 📝 Summary

Declares a default binary to run.

## 💡 Motivation and Context

Fix the minimal `cargo run` command and avoid requiring the binary to be explicitly specified.

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
