### PR TITLE
Make state root calculation configurable on Flashblocks builder

### DIFF
--- a/crates/op-rbuilder/src/args/op.rs
+++ b/crates/op-rbuilder/src/args/op.rs
@@ -141,7 +141,7 @@ pub struct FlashblocksArgs {
     /// Should we calculate state root for each flashblock
     #[arg(
         long = "flashblocks.calculate-state-root",
-        default_value = "false",
+        default_value = "true",
         env = "FLASHBLOCKS_CALCULATE_STATE_ROOT"
     )]
     pub calculate_state_root: bool,

--- a/crates/op-rbuilder/src/args/op.rs
+++ b/crates/op-rbuilder/src/args/op.rs
@@ -137,6 +137,14 @@ pub struct FlashblocksArgs {
         env = "FLASHBLOCK_LEEWAY_TIME"
     )]
     pub flashblocks_leeway_time: u64,
+
+    /// Should we calculate state root for each flashblock
+    #[arg(
+        long = "flashblocks.calculate-state-root",
+        default_value = "false",
+        env = "FLASHBLOCKS_CALCULATE_STATE_ROOT"
+    )]
+    pub calculate_state_root: bool,
 }
 
 impl Default for FlashblocksArgs {

--- a/crates/op-rbuilder/src/builders/flashblocks/config.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/config.rs
@@ -34,7 +34,7 @@ impl Default for FlashblocksConfig {
             interval: Duration::from_millis(250),
             leeway_time: Duration::from_millis(50),
             dynamic_adjustment: false,
-            calculate_state_root: false,
+            calculate_state_root: true,
         }
     }
 }

--- a/crates/op-rbuilder/src/builders/flashblocks/config.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/config.rs
@@ -23,7 +23,7 @@ pub struct FlashblocksConfig {
     /// Enables dynamic flashblocks number based on FCU arrival time
     pub dynamic_adjustment: bool,
 
-    /// Should we calculate state root for each flashblockAdd commentMore actions
+    /// Should we calculate state root for each flashblock
     pub calculate_state_root: bool,
 }
 

--- a/crates/op-rbuilder/src/builders/flashblocks/config.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/config.rs
@@ -22,6 +22,9 @@ pub struct FlashblocksConfig {
 
     /// Enables dynamic flashblocks number based on FCU arrival time
     pub dynamic_adjustment: bool,
+
+    /// Should we calculate state root for each flashblockAdd commentMore actions
+    pub calculate_state_root: bool,
 }
 
 impl Default for FlashblocksConfig {
@@ -31,6 +34,7 @@ impl Default for FlashblocksConfig {
             interval: Duration::from_millis(250),
             leeway_time: Duration::from_millis(50),
             dynamic_adjustment: false,
+            calculate_state_root: false,
         }
     }
 }
@@ -55,6 +59,7 @@ impl TryFrom<OpRbuilderArgs> for FlashblocksConfig {
             interval,
             leeway_time,
             dynamic_adjustment,
+            calculate_state_root: args.flashblocks.calculate_state_root,
         })
     }
 }

--- a/crates/op-rbuilder/src/builders/flashblocks/config.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/config.rs
@@ -34,7 +34,7 @@ impl Default for FlashblocksConfig {
             interval: Duration::from_millis(250),
             leeway_time: Duration::from_millis(50),
             dynamic_adjustment: false,
-            calculate_state_root: true,
+            calculate_state_root: false,
         }
     }
 }

--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -698,9 +698,8 @@ where
     // calculate the state root
     let mut state_root = B256::ZERO;
 
+    let state_root_start_time = Instant::now();
     if calculate_state_root {
-        let state_root_start_time = Instant::now();
-
         let state_provider = state.database.as_ref();
         let hashed_state = state_provider.hashed_post_state(execution_outcome.state());
         let (_state_root, _trie_output) = {
@@ -718,11 +717,10 @@ where
                 })?
         };
         state_root = _state_root;
-
-        ctx.metrics
-            .state_root_calculation_duration
-            .record(state_root_start_time.elapsed());
     }
+    ctx.metrics
+        .state_root_calculation_duration
+        .record(state_root_start_time.elapsed());
 
     let mut requests_hash = None;
     let withdrawals_root = if ctx

--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -506,7 +506,7 @@ where
                         &ctx,
                         &mut info,
                         self.config.specific.calculate_state_root,
-                    )?;
+                    );
                     ctx.metrics
                         .total_block_built_duration
                         .record(total_block_built_duration.elapsed());

--- a/crates/op-rbuilder/src/tests/flashblocks.rs
+++ b/crates/op-rbuilder/src/tests/flashblocks.rs
@@ -21,6 +21,7 @@ use crate::{
         flashblocks_block_time: 200,
         flashblocks_leeway_time: 0,
         flashblocks_dynamic: false,
+        calculate_state_root: true,
     },
     ..Default::default()
 })]

--- a/crates/op-rbuilder/src/tests/framework/macros/src/lib.rs
+++ b/crates/op-rbuilder/src/tests/framework/macros/src/lib.rs
@@ -29,6 +29,7 @@ const BUILDER_VARIANTS: &[VariantInfo] = &[
                     let mut args = #args;
                     args.flashblocks.enabled = true;
                     args.flashblocks.flashblocks_port = 0;
+                    args.flashblocks.calculate_state_root = true;
                     args
                 }
             }
@@ -39,6 +40,7 @@ const BUILDER_VARIANTS: &[VariantInfo] = &[
                     let mut args = crate::args::OpRbuilderArgs::default();
                     args.flashblocks.enabled = true;
                     args.flashblocks.flashblocks_port = 0;
+                    args.flashblocks.calculate_state_root = true;
                     args
                 }
             }


### PR DESCRIPTION
## 📝 Summary

related to https://github.com/flashbots/rollup-boost/pull/335

Makes state root computation configurable in the builder, setting it to just be the zero value if not enabled. Used in conjunction with linked rollup-boost modifications to have the L2 client compute the state root instead.

## 💡 Motivation and Context

The context here is that state root computation per flashblock is extremely slow, and there are concerns if we can launch on Base Mainnet and still produce flashblocks every 200ms with that. By disabling that computation in the builder, and instead having rollup boost use the L2 Client to recompute the state root, we get around that problem by introducing a minor overhead in the getPayload request to rollup boost.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
