### PR TITLE
Add cli flag for funding key

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ cargo run -p op-rbuilder --bin op-rbuilder --features=flashtestations -- node \
     --flashtestations.enabled \
     --flashtestations.rpc-url your-rpc-url \ # rpc to submit the attestation transaction to
     --flashtestations.funding-amount 0.01 \ # amount in ETH to fund the TEE generated key
-    --flashtestations.registry-address 0xFlashtestationsRegistryAddress 
+    --flashtestations.funding-key secret-key \ # funding key for the TEE key
+    --flashtestations.registry-address 0xFlashtestationsRegistryAddress \
+    flashtestations.builder-policy-address 0xBuilderPolicyAddress
 ```
 
 Note that `--rollup.builder-secret-key` must be set and funded in order for the flashtestations key to be funded and submit the attestation on-chain.

--- a/crates/op-rbuilder/src/builders/flashblocks/service.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/service.rs
@@ -73,10 +73,8 @@ where
         tracing::debug!("Spawning flashblocks payload builder service");
         let signer = self.0.builder_signer;
         if self.0.flashtestations_config.flashtestations_enabled {
-            let funding_signer = signer.expect("Key to fund TEE generated address not set");
             let flashtestations_service = match spawn_flashtestations_service(
                 self.0.flashtestations_config.clone(),
-                funding_signer,
                 ctx,
             )
             .await

--- a/crates/op-rbuilder/src/builders/standard/payload.rs
+++ b/crates/op-rbuilder/src/builders/standard/payload.rs
@@ -53,17 +53,8 @@ where
         pool: Pool,
         _evm_config: OpEvmConfig,
     ) -> eyre::Result<Self::PayloadBuilder> {
-        let signer = self.0.builder_signer;
-
         if self.0.flashtestations_config.flashtestations_enabled {
-            let funding_signer = signer.expect("Key to fund TEE generated address not set");
-            match spawn_flashtestations_service(
-                self.0.flashtestations_config.clone(),
-                funding_signer,
-                ctx,
-            )
-            .await
-            {
+            match spawn_flashtestations_service(self.0.flashtestations_config.clone(), ctx).await {
                 Ok(service) => service,
                 Err(e) => {
                     tracing::warn!(error = %e, "Failed to spawn flashtestations service, falling back to standard builder tx");

--- a/crates/op-rbuilder/src/flashtestations/args.rs
+++ b/crates/op-rbuilder/src/flashtestations/args.rs
@@ -1,5 +1,7 @@
 use alloy_primitives::{utils::parse_ether, Address, U256};
 
+use crate::tx_signer::Signer;
+
 /// Parameters for Flashtestations configuration
 /// The names in the struct are prefixed with `flashtestations`
 #[derive(Debug, Clone, Default, PartialEq, Eq, clap::Args)]
@@ -32,6 +34,14 @@ pub struct FlashtestationsArgs {
         default_value = "http://localhost:8545"
     )]
     pub rpc_url: String,
+
+    /// Funding key for the TEE key
+    #[arg(
+        long = "flashtestations.funding-key",
+        env = "FLASHTESTATIONS_FUNDING_KEY",
+        required_if_eq("flashtestations_enabled", "true")
+    )]
+    pub funding_key: Option<Signer>,
 
     /// Funding amount for the generated signer
     #[arg(

--- a/crates/op-rbuilder/src/flashtestations/service.rs
+++ b/crates/op-rbuilder/src/flashtestations/service.rs
@@ -32,7 +32,7 @@ pub struct FlashtestationsService {
 
 // TODO: FlashtestationsService error types
 impl FlashtestationsService {
-    pub fn new(args: FlashtestationsArgs, funding_signer: Signer) -> Self {
+    pub fn new(args: FlashtestationsArgs) -> Self {
         let (private_key, public_key, address) = generate_ethereum_keypair();
         let tee_service_signer = Signer {
             address,
@@ -47,7 +47,8 @@ impl FlashtestationsService {
 
         let tx_manager = TxManager::new(
             tee_service_signer,
-            funding_signer,
+            args.funding_key
+                .expect("funding key required when flashtestations enabled"),
             args.rpc_url,
             args.registry_address
                 .expect("registry address required when flashtestations enabled"),
@@ -101,7 +102,6 @@ impl BuilderTx for FlashtestationsService {
 
 pub async fn spawn_flashtestations_service<Node>(
     args: FlashtestationsArgs,
-    funding_signer: Signer,
     ctx: &BuilderContext<Node>,
 ) -> eyre::Result<FlashtestationsService>
 where
@@ -109,7 +109,7 @@ where
 {
     info!("Flashtestations enabled");
 
-    let flashtestations_service = FlashtestationsService::new(args.clone(), funding_signer);
+    let flashtestations_service = FlashtestationsService::new(args.clone());
     // Generates new key and registers the attestation onchain
     flashtestations_service.bootstrap().await?;
 


### PR DESCRIPTION
## 📝 Summary

Resolves #167 

## 💡 Motivation and Context

Adds a separate cli flag for the TEE key to be funded.
---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
