### PR TITLE
Add some telemetry for `eth_sendBundle`

### DIFF
--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -82,6 +82,8 @@ pub struct OpRBuilderMetrics {
     pub flashblock_time_drift: Histogram,
     /// Time offset we used for first flashblock
     pub first_flashblock_time_offset: Histogram,
+    /// Number of requests sent to the eth_sendBundle endpoint
+    pub bundle_requests: Counter,
     /// Number of valid bundles received at the eth_sendBundle endpoint
     pub valid_bundles: Counter,
     /// Number of reverted bundles

--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -86,6 +86,8 @@ pub struct OpRBuilderMetrics {
     pub bundle_requests: Counter,
     /// Number of valid bundles received at the eth_sendBundle endpoint
     pub valid_bundles: Counter,
+    /// Number of bundles that failed to execute
+    pub failed_bundles: Counter,
     /// Number of reverted bundles
     pub bundles_reverted: Histogram,
     /// Time taken to respond to a request to the eth_sendBundle endpoint

--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -86,7 +86,7 @@ pub struct OpRBuilderMetrics {
     pub valid_bundles: Counter,
     /// Number of reverted bundles
     pub bundles_reverted: Histogram,
-    /// Time taken to return a valid bundle sent to the eth_sendBundle endpoint
+    /// Time taken to respond to a request to the eth_sendBundle endpoint
     pub bundle_receive_duration: Histogram,
 }
 

--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -86,6 +86,8 @@ pub struct OpRBuilderMetrics {
     pub bundles_received: Counter,
     /// Number of reverted bundles
     pub bundles_reverted: Histogram,
+    /// Time taken to return a valid bundle sent to the eth_sendBundle endpoint
+    pub bundle_receive_duration: Histogram,
 }
 
 /// Contains version information for the application.

--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -83,7 +83,7 @@ pub struct OpRBuilderMetrics {
     /// Time offset we used for first flashblock
     pub first_flashblock_time_offset: Histogram,
     /// Number of valid bundles received at the eth_sendBundle endpoint
-    pub bundles_received: Counter,
+    pub valid_bundles: Counter,
     /// Number of reverted bundles
     pub bundles_reverted: Histogram,
     /// Time taken to return a valid bundle sent to the eth_sendBundle endpoint

--- a/crates/op-rbuilder/src/revert_protection.rs
+++ b/crates/op-rbuilder/src/revert_protection.rs
@@ -141,11 +141,10 @@ where
             .map_err(EthApiError::from)?;
 
         let recovered = recover_raw_transaction(&bundle_transaction)?;
-        let mut pool_transaction: FBPooledTransaction =
-            OpPooledTransaction::from_pooled(recovered).into();
-
-        pool_transaction.set_reverted_hashes(bundle.reverting_hashes.clone().unwrap_or_default());
-        pool_transaction.set_conditional(conditional);
+        let pool_transaction =
+            FBPooledTransaction::from(OpPooledTransaction::from_pooled(recovered))
+                .with_reverted_hashes(bundle.reverting_hashes.clone().unwrap_or_default())
+                .with_conditional(conditional);
 
         let hash = self
             .pool

--- a/crates/op-rbuilder/src/revert_protection.rs
+++ b/crates/op-rbuilder/src/revert_protection.rs
@@ -99,6 +99,8 @@ where
 
         if bundle_result.is_ok() {
             self.metrics.valid_bundles.increment(1);
+        } else {
+            self.metrics.failed_bundles.increment(1);
         }
 
         self.metrics

--- a/crates/op-rbuilder/src/revert_protection.rs
+++ b/crates/op-rbuilder/src/revert_protection.rs
@@ -129,7 +129,7 @@ where
             .await
             .map_err(EthApiError::from)?;
 
-        self.metrics.bundles_received.increment(1);
+        self.metrics.valid_bundles.increment(1);
         self.metrics
             .bundle_receive_duration
             .record(request_start_time.elapsed());

--- a/crates/op-rbuilder/src/revert_protection.rs
+++ b/crates/op-rbuilder/src/revert_protection.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Instant};
 
 use crate::{
     metrics::OpRBuilderMetrics,
@@ -88,6 +88,8 @@ where
     Provider: StateProviderFactory + Send + Sync + Clone + 'static,
 {
     async fn send_bundle(&self, bundle: Bundle) -> RpcResult<BundleResult> {
+        let request_start_time = Instant::now();
+
         let last_block_number = self
             .provider
             .best_block_number()
@@ -128,6 +130,9 @@ where
             .map_err(EthApiError::from)?;
 
         self.metrics.bundles_received.increment(1);
+        self.metrics
+            .bundle_receive_duration
+            .record(request_start_time.elapsed());
 
         let result = BundleResult { bundle_hash: hash };
         Ok(result)

--- a/crates/op-rbuilder/src/revert_protection.rs
+++ b/crates/op-rbuilder/src/revert_protection.rs
@@ -90,6 +90,7 @@ where
 {
     async fn send_bundle(&self, bundle: Bundle) -> RpcResult<BundleResult> {
         let request_start_time = Instant::now();
+        self.metrics.bundle_requests.increment(1);
 
         let bundle_result = self
             .send_bundle_inner(bundle)

--- a/crates/op-rbuilder/src/tx.rs
+++ b/crates/op-rbuilder/src/tx.rs
@@ -34,13 +34,14 @@ impl OpPooledTx for FBPooledTransaction {
 }
 
 pub trait MaybeRevertingTransaction {
-    fn set_reverted_hashes(&mut self, reverted_hashes: Vec<B256>);
+    fn with_reverted_hashes(self, reverted_hashes: Vec<B256>) -> Self;
     fn reverted_hashes(&self) -> Option<Vec<B256>>;
 }
 
 impl MaybeRevertingTransaction for FBPooledTransaction {
-    fn set_reverted_hashes(&mut self, reverted_hashes: Vec<B256>) {
+    fn with_reverted_hashes(mut self, reverted_hashes: Vec<B256>) -> Self {
         self.reverted_hashes = Some(reverted_hashes);
+        self
     }
 
     fn reverted_hashes(&self) -> Option<Vec<B256>> {


### PR DESCRIPTION
## 📝 Summary
Add some telemetry for the `eth_sendBundle` endpoint. Specifically, introduce the following metrics:
* Number of total requests
* Reponse latency
And also log error messages instead of just returning the error to the caller.

## 💡 Motivation and Context
Better monitoring/productionizing bundle support.

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
