### PR TITLE
Add additional debug flags for flashtestations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /test/
 /integration_logs
 genesis.json
+tee_key.json
 /op-reth
 .env
 

--- a/crates/op-rbuilder/src/flashtestations/args.rs
+++ b/crates/op-rbuilder/src/flashtestations/args.rs
@@ -27,6 +27,22 @@ pub struct FlashtestationsArgs {
     #[arg(long = "flashtestations.debug-url", env = "FLASHTESTATIONS_DEBUG_URL")]
     pub debug_url: Option<String>,
 
+    /// The seed for the tee key in debug mode
+    #[arg(
+        long = "flashtestations.tee-key-seed",
+        env = "FLASHTESTATIONS_TEE_KEY_SEED",
+        default_value = "debug"
+    )]
+    pub tee_key_seed: String,
+
+    /// Path writing tee key to disk in debug mode
+    #[arg(
+        long = "flashtestations.tee-key-path",
+        env = "FLASHTESTATIONS_TEE_KEY_PATH",
+        default_value = "tee_key.json"
+    )]
+    pub tee_key_path: String,
+
     /// The rpc url to post the onchain attestation requests to
     #[arg(
         long = "flashtestations.rpc-url",

--- a/crates/op-rbuilder/src/tx_signer.rs
+++ b/crates/op-rbuilder/src/tx_signer.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+use alloy::signers::k256::sha2::Sha256;
 use alloy_consensus::SignableTransaction;
 use alloy_primitives::{Address, Signature, B256, U256};
 use op_alloy_consensus::OpTypedTransaction;
@@ -83,6 +84,23 @@ pub fn generate_ethereum_keypair() -> (SecretKey, PublicKey, Address) {
     let public_key = PublicKey::from_secret_key(&secp, &private_key);
 
     // Derive Ethereum address
+    let address = public_key_to_address(&public_key);
+
+    (private_key, public_key, address)
+}
+
+// Generate a key deterministically from a seed for debug and testing
+// Do not use in production
+pub fn generate_key_from_seed(seed: &str) -> (SecretKey, PublicKey, Address) {
+    // Hash the seed
+    let mut hasher = Sha256::new();
+    hasher.update(seed.as_bytes());
+    let hash = hasher.finalize();
+
+    // Create signing key
+    let secp = Secp256k1::new();
+    let private_key = SecretKey::from_slice(&hash).expect("Failed to create private key");
+    let public_key = PublicKey::from_secret_key(&secp, &private_key);
     let address = public_key_to_address(&public_key);
 
     (private_key, public_key, address)


### PR DESCRIPTION
## 📝 Summary

- Deterministic key generation in debug mode
- Write key to disk in debug mode

## 💡 Motivation and Context

Allows for better testing and development of handling tee logic (e.g. when integrating with builder playground)

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
