### PR TITLE
Change default leeway-time + add better handing for global block cancellation

### DIFF
--- a/crates/op-rbuilder/src/args/op.rs
+++ b/crates/op-rbuilder/src/args/op.rs
@@ -134,7 +134,7 @@ pub struct FlashblocksArgs {
     /// building time before calculating number of fbs.
     #[arg(
         long = "flashblocks.leeway-time",
-        default_value = "50",
+        default_value = "75",
         env = "FLASHBLOCK_LEEWAY_TIME"
     )]
     pub flashblocks_leeway_time: u64,


### PR DESCRIPTION
## 📝 Summary

default leeway time was 50 ms, and optimism sends engine_getPayload 50ms before timestamp in attributes. 
also added global handling for job cancelling, to ensure it won't fire old flashblock

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
