### PR TITLE
Remove without_updates for flashblocks

### DIFF
--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -35,7 +35,6 @@ use reth_revm::{
     db::{states::bundle_state::BundleRetention, BundleState},
     State,
 };
-use reth_transaction_pool::BestTransactions;
 use revm::Database;
 use rollup_boost::{
     ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashblocksPayloadV1,
@@ -386,11 +385,9 @@ where
 
                     let best_txs_start_time = Instant::now();
                     let best_txs = BestPayloadTransactions::new(
-                        // TODO: once this issue is fixed we could remove without_updates and rely on regular impl
-                        // https://github.com/paradigmxyz/reth/issues/17325
+                        // We are not using without_updates in here, so arriving transaction could target the current block
                         self.pool
-                            .best_transactions_with_attributes(ctx.best_transaction_attributes())
-                            .without_updates(),
+                            .best_transactions_with_attributes(ctx.best_transaction_attributes()),
                     );
                     ctx.metrics
                         .transaction_pool_fetch_duration


### PR DESCRIPTION
## 📝 Summary

This change was in the way or the logic for targeting current block for inclusion

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
