### PR TITLE
Remove redundant account initialization

### DIFF
--- a/crates/op-rbuilder/src/tests/flashblocks.rs
+++ b/crates/op-rbuilder/src/tests/flashblocks.rs
@@ -8,7 +8,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     args::{FlashblocksArgs, OpRbuilderArgs},
-    tests::{ChainDriverExt, LocalInstance, TransactionBuilderExt},
+    tests::{LocalInstance, TransactionBuilderExt},
 };
 
 #[rb_test(flashblocks, args = OpRbuilderArgs {
@@ -25,7 +25,6 @@ use crate::{
 })]
 async fn smoke_dynamic_base(rbuilder: LocalInstance) -> eyre::Result<()> {
     let driver = rbuilder.driver().await?;
-    driver.fund_default_accounts().await?;
 
     // Create a struct to hold received messages
     let received_messages = Arc::new(Mutex::new(Vec::new()));
@@ -94,7 +93,6 @@ async fn smoke_dynamic_base(rbuilder: LocalInstance) -> eyre::Result<()> {
 })]
 async fn smoke_dynamic_unichain(rbuilder: LocalInstance) -> eyre::Result<()> {
     let driver = rbuilder.driver().await?;
-    driver.fund_default_accounts().await?;
 
     // Create a struct to hold received messages
     let received_messages = Arc::new(Mutex::new(Vec::new()));
@@ -163,7 +161,6 @@ async fn smoke_dynamic_unichain(rbuilder: LocalInstance) -> eyre::Result<()> {
 })]
 async fn smoke_classic_unichain(rbuilder: LocalInstance) -> eyre::Result<()> {
     let driver = rbuilder.driver().await?;
-    driver.fund_default_accounts().await?;
 
     // Create a struct to hold received messages
     let received_messages = Arc::new(Mutex::new(Vec::new()));
@@ -232,7 +229,6 @@ async fn smoke_classic_unichain(rbuilder: LocalInstance) -> eyre::Result<()> {
 })]
 async fn smoke_classic_base(rbuilder: LocalInstance) -> eyre::Result<()> {
     let driver = rbuilder.driver().await?;
-    driver.fund_default_accounts().await?;
 
     // Create a struct to hold received messages
     let received_messages = Arc::new(Mutex::new(Vec::new()));
@@ -301,7 +297,6 @@ async fn smoke_classic_base(rbuilder: LocalInstance) -> eyre::Result<()> {
 })]
 async fn unichain_dynamic_with_lag(rbuilder: LocalInstance) -> eyre::Result<()> {
     let driver = rbuilder.driver().await?;
-    driver.fund_default_accounts().await?;
 
     // Create a struct to hold received messages
     let received_messages = Arc::new(Mutex::new(Vec::new()));
@@ -372,7 +367,6 @@ async fn unichain_dynamic_with_lag(rbuilder: LocalInstance) -> eyre::Result<()> 
 })]
 async fn dynamic_with_full_block_lag(rbuilder: LocalInstance) -> eyre::Result<()> {
     let driver = rbuilder.driver().await?;
-    driver.fund_default_accounts().await?;
 
     // Create a struct to hold received messages
     let received_messages = Arc::new(Mutex::new(Vec::new()));

--- a/crates/op-rbuilder/src/tests/framework/instance.rs
+++ b/crates/op-rbuilder/src/tests/framework/instance.rs
@@ -6,7 +6,7 @@ use crate::{
     tests::{
         create_test_db,
         framework::{driver::ChainDriver, BUILDER_PRIVATE_KEY},
-        ChainDriverExt, EngineApi, Ipc, TransactionPoolObserver,
+        EngineApi, Ipc, TransactionPoolObserver,
     },
     tx::FBPooledTransaction,
     tx_signer::Signer,
@@ -179,10 +179,7 @@ impl LocalInstance {
         let Commands::Node(ref node_command) = args.command else {
             unreachable!()
         };
-        let instance = Self::new::<StandardBuilder>(node_command.ext.clone()).await?;
-        let driver = ChainDriver::<Ipc>::local(&instance).await?;
-        driver.fund_default_accounts().await?;
-        Ok(instance)
+        Self::new::<StandardBuilder>(node_command.ext.clone()).await
     }
 
     /// Creates new local instance of the OP builder node with the flashblocks builder configuration.
@@ -194,10 +191,7 @@ impl LocalInstance {
         };
         node_command.ext.flashblocks.enabled = true;
         node_command.ext.flashblocks.flashblocks_port = 0; // use random os assigned port
-        let instance = Self::new::<FlashblocksBuilder>(node_command.ext.clone()).await?;
-        let driver = ChainDriver::<Ipc>::local(&instance).await?;
-        driver.fund_default_accounts().await?;
-        Ok(instance)
+        Self::new::<FlashblocksBuilder>(node_command.ext.clone()).await
     }
 
     pub const fn config(&self) -> &NodeConfig<OpChainSpec> {


### PR DESCRIPTION
During testing we realized that the builder drivers are redundantly calculating a block on initialization.
