### PR TITLE
Revert op-rbuilder release workflow changes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,14 +101,12 @@ jobs:
           git config --global --add safe.directory "$(pwd)"
           . $HOME/.cargo/env
           cargo build --release --features=${{ matrix.features }} --target ${{ matrix.configs.target }} --package op-rbuilder
-          mkdir -p artifacts
-          mv target/${{ matrix.configs.target }}/release/op-rbuilder artifacts/op-rbuilder-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}${{ matrix.features && '-' }}${{ matrix.features }}
 
-      - name: Upload artifacts
+      - name: Upload op-rbuilder artifact
         uses: actions/upload-artifact@v4
         with:
           name: op-rbuilder-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}${{ matrix.features && '-' }}${{ matrix.features }}
-          path: artifacts
+          path: target/${{ matrix.configs.target }}/release/op-rbuilder
 
   draft-release:
     name: Draft release


### PR DESCRIPTION
## 📝 Summary

Reverting format of release artifacts. Otherwise the artifact sync will not work correctly.

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
