### PR TITLE
Refactor payload builder to accept generic builder tx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6290,6 +6290,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-eips",
+ "alloy-evm 0.15.0",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-op-evm 0.15.0",

--- a/crates/op-rbuilder/Cargo.toml
+++ b/crates/op-rbuilder/Cargo.toml
@@ -59,6 +59,7 @@ alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-contract.workspace = true
 alloy-eips.workspace = true
+alloy-evm.workspace = true
 alloy-rpc-types-beacon.workspace = true
 alloy-rpc-types-engine.workspace = true
 alloy-transport-http.workspace = true

--- a/crates/op-rbuilder/src/builders/builder_tx.rs
+++ b/crates/op-rbuilder/src/builders/builder_tx.rs
@@ -1,32 +1,169 @@
+use alloy_evm::Database;
+use alloy_primitives::{
+    map::foldhash::{HashSet, HashSetExt},
+    Address,
+};
+use core::fmt::Debug;
+use op_revm::OpTransactionError;
+use reth_evm::{eth::receipt_builder::ReceiptBuilderCtx, ConfigureEvm, Evm};
+use reth_node_api::PayloadBuilderError;
 use reth_optimism_primitives::OpTransactionSigned;
 use reth_primitives::Recovered;
+use reth_provider::{ProviderError, StateProvider};
+use reth_revm::{
+    database::StateProviderDatabase, db::states::bundle_state::BundleRetention, State,
+};
+use revm::{
+    context::result::{EVMError, ResultAndState},
+    DatabaseCommit,
+};
+use tracing::{debug, warn};
 
-use crate::tx_signer::Signer;
+use crate::{builders::context::OpPayloadBuilderCtx, primitives::reth::ExecutionInfo};
 
-pub trait BuilderTx {
-    fn estimated_builder_tx_gas(&self) -> u64;
-    fn estimated_builder_tx_da_size(&self) -> Option<u64>;
-    fn signed_builder_tx(&self) -> Result<Recovered<OpTransactionSigned>, secp256k1::Error>;
+#[derive(Debug, Clone)]
+pub struct BuilderTransactionCtx {
+    pub gas_used: u64,
+    pub da_size: u64,
+    pub signed_tx: Recovered<OpTransactionSigned>,
 }
 
-// Scaffolding for how to construct the end of block builder transaction
-// This will be the regular end of block transaction without the TEE key
-#[derive(Clone)]
-pub struct StandardBuilderTx {
-    #[allow(dead_code)]
-    pub signer: Option<Signer>,
+/// Possible error variants during construction of builder txs.
+#[derive(Debug, thiserror::Error)]
+pub enum BuilderTransactionError {
+    /// Thrown when builder account load fails to get builder nonce
+    #[error("failed to load account {0}")]
+    AccountLoadFailed(Address),
+    /// Thrown when signature signing fails
+    #[error("failed to sign transaction: {0}")]
+    SigningError(secp256k1::Error),
+    /// Unrecoverable error during evm execution.
+    #[error("evm execution error {0}")]
+    EvmExecutionError(Box<dyn core::error::Error + Send + Sync>),
+    /// Any other builder transaction errors.
+    #[error(transparent)]
+    Other(Box<dyn core::error::Error + Send + Sync>),
 }
 
-impl BuilderTx for StandardBuilderTx {
-    fn estimated_builder_tx_gas(&self) -> u64 {
-        todo!()
+impl From<secp256k1::Error> for BuilderTransactionError {
+    fn from(error: secp256k1::Error) -> Self {
+        BuilderTransactionError::SigningError(error)
+    }
+}
+
+impl From<EVMError<ProviderError, OpTransactionError>> for BuilderTransactionError {
+    fn from(error: EVMError<ProviderError, OpTransactionError>) -> Self {
+        BuilderTransactionError::EvmExecutionError(Box::new(error))
+    }
+}
+
+impl From<BuilderTransactionError> for PayloadBuilderError {
+    fn from(error: BuilderTransactionError) -> Self {
+        match error {
+            BuilderTransactionError::EvmExecutionError(e) => {
+                PayloadBuilderError::EvmExecutionError(e)
+            }
+            _ => PayloadBuilderError::Other(Box::new(error)),
+        }
+    }
+}
+
+pub trait BuilderTransactions<ExtraCtx: Debug + Default = ()>: Debug {
+    fn simulate_builder_txs<Extra: Debug + Default>(
+        &self,
+        state_provider: impl StateProvider + Clone,
+        info: &mut ExecutionInfo<Extra>,
+        ctx: &OpPayloadBuilderCtx<ExtraCtx>,
+        db: &mut State<impl Database>,
+    ) -> Result<Vec<BuilderTransactionCtx>, BuilderTransactionError>;
+
+    fn add_builder_txs<Extra: Debug + Default>(
+        &self,
+        state_provider: impl StateProvider + Clone,
+        info: &mut ExecutionInfo<Extra>,
+        builder_ctx: &OpPayloadBuilderCtx<ExtraCtx>,
+        db: &mut State<impl Database>,
+    ) -> Result<Vec<BuilderTransactionCtx>, BuilderTransactionError> {
+        {
+            let mut evm = builder_ctx
+                .evm_config
+                .evm_with_env(&mut *db, builder_ctx.evm_env.clone());
+
+            let mut invalid: HashSet<Address> = HashSet::new();
+
+            let builder_txs =
+                self.simulate_builder_txs(state_provider, info, builder_ctx, evm.db_mut())?;
+            for builder_tx in builder_txs.iter() {
+                if invalid.contains(&builder_tx.signed_tx.signer()) {
+                    debug!(target: "payload_builder", tx_hash = ?builder_tx.signed_tx.tx_hash(), "builder signer invalid as previous builder tx reverted");
+                    continue;
+                }
+
+                let ResultAndState { result, state } = evm
+                    .transact(&builder_tx.signed_tx)
+                    .map_err(|err| BuilderTransactionError::EvmExecutionError(Box::new(err)))?;
+
+                if !result.is_success() {
+                    warn!(target: "payload_builder", tx_hash = ?builder_tx.signed_tx.tx_hash(), "builder tx reverted");
+                    invalid.insert(builder_tx.signed_tx.signer());
+                    continue;
+                }
+
+                // Add gas used by the transaction to cumulative gas used, before creating the receipt
+                let gas_used = result.gas_used();
+                info.cumulative_gas_used += gas_used;
+
+                let ctx = ReceiptBuilderCtx {
+                    tx: builder_tx.signed_tx.inner(),
+                    evm: &evm,
+                    result,
+                    state: &state,
+                    cumulative_gas_used: info.cumulative_gas_used,
+                };
+                info.receipts.push(builder_ctx.build_receipt(ctx, None));
+
+                // Commit changes
+                evm.db_mut().commit(state);
+
+                // Append sender and transaction to the respective lists
+                info.executed_senders.push(builder_tx.signed_tx.signer());
+                info.executed_transactions
+                    .push(builder_tx.signed_tx.clone().into_inner());
+            }
+
+            // Release the db reference by dropping evm
+            drop(evm);
+
+            Ok(builder_txs)
+        }
     }
 
-    fn estimated_builder_tx_da_size(&self) -> Option<u64> {
-        todo!()
-    }
+    fn simulate_builder_txs_state<Extra: Debug + Default>(
+        &self,
+        state_provider: impl StateProvider + Clone,
+        builder_txs: Vec<&BuilderTransactionCtx>,
+        ctx: &OpPayloadBuilderCtx<ExtraCtx>,
+        db: &mut State<impl Database>,
+    ) -> Result<State<StateProviderDatabase<impl StateProvider>>, BuilderTransactionError> {
+        let state = StateProviderDatabase::new(state_provider.clone());
+        let mut simulation_state = State::builder()
+            .with_database(state)
+            .with_bundle_prestate(db.bundle_state.clone())
+            .with_bundle_update()
+            .build();
+        let mut evm = ctx
+            .evm_config
+            .evm_with_env(&mut simulation_state, ctx.evm_env.clone());
 
-    fn signed_builder_tx(&self) -> Result<Recovered<OpTransactionSigned>, secp256k1::Error> {
-        todo!()
+        for builder_tx in builder_txs {
+            let ResultAndState { state, .. } = evm
+                .transact(&builder_tx.signed_tx)
+                .map_err(|err| BuilderTransactionError::EvmExecutionError(Box::new(err)))?;
+
+            evm.db_mut().commit(state);
+            evm.db_mut().merge_transitions(BundleRetention::Reverts);
+        }
+
+        Ok(simulation_state)
     }
 }

--- a/crates/op-rbuilder/src/builders/context.rs
+++ b/crates/op-rbuilder/src/builders/context.rs
@@ -1,12 +1,11 @@
-use alloy_consensus::{
-    conditional::BlockConditionalAttributes, Eip658Value, Transaction, TxEip1559,
-};
-use alloy_eips::{eip7623::TOTAL_COST_FLOOR_PER_TOKEN, Encodable2718, Typed2718};
+use alloy_consensus::{conditional::BlockConditionalAttributes, Eip658Value, Transaction};
+use alloy_eips::Typed2718;
+use alloy_evm::Database;
 use alloy_op_evm::block::receipt_builder::OpReceiptBuilder;
-use alloy_primitives::{Address, Bytes, TxKind, U256};
+use alloy_primitives::{Bytes, U256};
 use alloy_rpc_types_eth::Withdrawals;
 use core::fmt::Debug;
-use op_alloy_consensus::{OpDepositReceipt, OpTypedTransaction};
+use op_alloy_consensus::OpDepositReceipt;
 use op_revm::OpSpecId;
 use reth::payload::PayloadBuilderAttributes;
 use reth_basic_payload_builder::PayloadConfig;
@@ -27,17 +26,14 @@ use reth_optimism_txpool::{
     interop::{is_valid_interop, MaybeInteropTransaction},
 };
 use reth_payload_builder::PayloadId;
-use reth_primitives::{Recovered, SealedHeader};
+use reth_primitives::SealedHeader;
 use reth_primitives_traits::{InMemorySize, SignedTransaction};
-use reth_provider::ProviderError;
 use reth_revm::{context::Block, State};
 use reth_transaction_pool::{BestTransactionsAttributes, PoolTransaction};
-use revm::{
-    context::result::ResultAndState, interpreter::as_u64_saturated, Database, DatabaseCommit,
-};
+use revm::{context::result::ResultAndState, interpreter::as_u64_saturated, DatabaseCommit};
 use std::{sync::Arc, time::Instant};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, info, trace};
 
 use crate::{
     metrics::OpRBuilderMetrics,
@@ -199,7 +195,7 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
 
 impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
     /// Constructs a receipt for the given transaction.
-    fn build_receipt<E: Evm>(
+    pub fn build_receipt<E: Evm>(
         &self,
         ctx: ReceiptBuilderCtx<'_, OpTransactionSigned, E>,
         deposit_nonce: Option<u64>,
@@ -231,13 +227,10 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
     }
 
     /// Executes all sequencer transactions that are included in the payload attributes.
-    pub fn execute_sequencer_transactions<DB, E: Debug + Default>(
+    pub fn execute_sequencer_transactions<E: Debug + Default>(
         &self,
-        db: &mut State<DB>,
-    ) -> Result<ExecutionInfo<E>, PayloadBuilderError>
-    where
-        DB: Database<Error = ProviderError> + std::fmt::Debug,
-    {
+        db: &mut State<impl Database>,
+    ) -> Result<ExecutionInfo<E>, PayloadBuilderError> {
         let mut info = ExecutionInfo::with_capacity(self.attributes().transactions.len());
 
         let mut evm = self.evm_config.evm_with_env(&mut *db, self.evm_env.clone());
@@ -318,17 +311,14 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
     /// Executes the given best transactions and updates the execution info.
     ///
     /// Returns `Ok(Some(())` if the job was cancelled.
-    pub fn execute_best_transactions<DB, E: Debug + Default>(
+    pub fn execute_best_transactions<E: Debug + Default>(
         &self,
         info: &mut ExecutionInfo<E>,
-        db: &mut State<DB>,
+        db: &mut State<impl Database>,
         mut best_txs: impl PayloadTxsBounds,
         block_gas_limit: u64,
         block_da_limit: Option<u64>,
-    ) -> Result<Option<()>, PayloadBuilderError>
-    where
-        DB: Database<Error = ProviderError> + std::fmt::Debug,
-    {
+    ) -> Result<Option<()>, PayloadBuilderError> {
         let execute_txs_start_time = Instant::now();
         let mut num_txs_considered = 0;
         let mut num_txs_simulated = 0;
@@ -539,147 +529,4 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
         );
         Ok(None)
     }
-
-    pub fn add_builder_tx<DB, Extra: Debug + Default>(
-        &self,
-        info: &mut ExecutionInfo<Extra>,
-        db: &mut State<DB>,
-        builder_tx_gas: u64,
-        message: Vec<u8>,
-    ) -> Option<()>
-    where
-        DB: Database<Error = ProviderError> + std::fmt::Debug,
-    {
-        self.builder_signer()
-            .map(|signer| {
-                let base_fee = self.base_fee();
-                let chain_id = self.chain_id();
-                // Create and sign the transaction
-                let builder_tx =
-                    signed_builder_tx(db, builder_tx_gas, message, signer, base_fee, chain_id)?;
-
-                let mut evm = self.evm_config.evm_with_env(&mut *db, self.evm_env.clone());
-
-                let ResultAndState { result, state } = evm
-                    .transact(&builder_tx)
-                    .map_err(|err| PayloadBuilderError::EvmExecutionError(Box::new(err)))?;
-
-                // Add gas used by the transaction to cumulative gas used, before creating the receipt
-                let gas_used = result.gas_used();
-                info.cumulative_gas_used += gas_used;
-
-                let ctx = ReceiptBuilderCtx {
-                    tx: builder_tx.inner(),
-                    evm: &evm,
-                    result,
-                    state: &state,
-                    cumulative_gas_used: info.cumulative_gas_used,
-                };
-                info.receipts.push(self.build_receipt(ctx, None));
-
-                // Release the db reference by dropping evm
-                drop(evm);
-                // Commit changes
-                db.commit(state);
-
-                // Append sender and transaction to the respective lists
-                info.executed_senders.push(builder_tx.signer());
-                info.executed_transactions.push(builder_tx.into_inner());
-                Ok(())
-            })
-            .transpose()
-            .unwrap_or_else(|err: PayloadBuilderError| {
-                warn!(target: "payload_builder", %err, "Failed to add builder transaction");
-                None
-            })
-    }
-
-    /// Calculates EIP 2718 builder transaction size
-    // TODO: this function could be improved, ideally we shouldn't take mut ref to db and maybe
-    // it's possible to do this without db at all
-    pub fn estimate_builder_tx_da_size<DB>(
-        &self,
-        db: &mut State<DB>,
-        builder_tx_gas: u64,
-        message: Vec<u8>,
-    ) -> Option<u64>
-    where
-        DB: Database<Error = ProviderError>,
-    {
-        self.builder_signer()
-            .map(|signer| {
-                let base_fee = self.base_fee();
-                let chain_id = self.chain_id();
-                // Create and sign the transaction
-                let builder_tx =
-                    signed_builder_tx(db, builder_tx_gas, message, signer, base_fee, chain_id)?;
-                Ok(op_alloy_flz::tx_estimated_size_fjord_bytes(
-                    builder_tx.encoded_2718().as_slice(),
-                ))
-            })
-            .transpose()
-            .unwrap_or_else(|err: PayloadBuilderError| {
-                warn!(target: "payload_builder", %err, "Failed to add builder transaction");
-                None
-            })
-    }
-}
-
-pub fn estimate_gas_for_builder_tx(input: Vec<u8>) -> u64 {
-    // Count zero and non-zero bytes
-    let (zero_bytes, nonzero_bytes) = input.iter().fold((0, 0), |(zeros, nonzeros), &byte| {
-        if byte == 0 {
-            (zeros + 1, nonzeros)
-        } else {
-            (zeros, nonzeros + 1)
-        }
-    });
-
-    // Calculate gas cost (4 gas per zero byte, 16 gas per non-zero byte)
-    let zero_cost = zero_bytes * 4;
-    let nonzero_cost = nonzero_bytes * 16;
-
-    // Tx gas should be not less than floor gas https://eips.ethereum.org/EIPS/eip-7623
-    let tokens_in_calldata = zero_bytes + nonzero_bytes * 4;
-    let floor_gas = 21_000 + tokens_in_calldata * TOTAL_COST_FLOOR_PER_TOKEN;
-
-    std::cmp::max(zero_cost + nonzero_cost + 21_000, floor_gas)
-}
-
-/// Creates signed builder tx to Address::ZERO and specified message as input
-pub fn signed_builder_tx<DB>(
-    db: &mut State<DB>,
-    builder_tx_gas: u64,
-    message: Vec<u8>,
-    signer: Signer,
-    base_fee: u64,
-    chain_id: u64,
-) -> Result<Recovered<OpTransactionSigned>, PayloadBuilderError>
-where
-    DB: Database<Error = ProviderError>,
-{
-    // Create message with block number for the builder to sign
-    let nonce = db
-        .load_cache_account(signer.address)
-        .map(|acc| acc.account_info().unwrap_or_default().nonce)
-        .map_err(|_| {
-            PayloadBuilderError::other(OpPayloadBuilderError::AccountLoadFailed(signer.address))
-        })?;
-
-    // Create the EIP-1559 transaction
-    let tx = OpTypedTransaction::Eip1559(TxEip1559 {
-        chain_id,
-        nonce,
-        gas_limit: builder_tx_gas,
-        max_fee_per_gas: base_fee.into(),
-        max_priority_fee_per_gas: 0,
-        to: TxKind::Call(Address::ZERO),
-        // Include the message as part of the transaction data
-        input: message.into(),
-        ..Default::default()
-    });
-    // Sign the transaction
-    let builder_tx = signer.sign_tx(tx).map_err(PayloadBuilderError::other)?;
-
-    Ok(builder_tx)
 }

--- a/crates/op-rbuilder/src/builders/flashblocks/builder_tx.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/builder_tx.rs
@@ -1,0 +1,155 @@
+use alloy_consensus::TxEip1559;
+use alloy_eips::{eip7623::TOTAL_COST_FLOOR_PER_TOKEN, Encodable2718};
+use alloy_evm::Database;
+use alloy_primitives::{Address, TxKind};
+use core::fmt::Debug;
+use op_alloy_consensus::OpTypedTransaction;
+use reth_optimism_primitives::OpTransactionSigned;
+use reth_primitives::Recovered;
+use reth_provider::StateProvider;
+use reth_revm::State;
+
+use crate::{
+    builders::{
+        context::OpPayloadBuilderCtx, flashblocks::payload::FlashblocksExtraCtx,
+        BuilderTransactionCtx, BuilderTransactionError, BuilderTransactions,
+    },
+    flashtestations::service::FlashtestationsBuilderTx,
+    primitives::reth::ExecutionInfo,
+    tx_signer::Signer,
+};
+
+// This will be the end of block transaction of a regular block
+#[derive(Debug, Clone)]
+pub struct FlashblocksBuilderTx {
+    pub signer: Option<Signer>,
+    pub flashtestations_builder_tx: Option<FlashtestationsBuilderTx>,
+}
+
+impl FlashblocksBuilderTx {
+    pub fn new(
+        signer: Option<Signer>,
+        flashtestations_builder_tx: Option<FlashtestationsBuilderTx>,
+    ) -> Self {
+        Self {
+            signer,
+            flashtestations_builder_tx,
+        }
+    }
+
+    pub fn simulate_builder_tx<ExtraCtx: Debug + Default>(
+        &self,
+        ctx: &OpPayloadBuilderCtx<ExtraCtx>,
+        db: &mut State<impl Database>,
+    ) -> Result<Option<BuilderTransactionCtx>, BuilderTransactionError> {
+        match self.signer {
+            Some(signer) => {
+                let message: Vec<u8> = format!("Block Number: {}", ctx.block_number()).into_bytes();
+                let gas_used = self.estimate_builder_tx_gas(&message);
+                let signed_tx = self.signed_builder_tx(ctx, db, signer, gas_used, message)?;
+                let da_size = op_alloy_flz::tx_estimated_size_fjord_bytes(
+                    signed_tx.encoded_2718().as_slice(),
+                );
+                Ok(Some(BuilderTransactionCtx {
+                    gas_used,
+                    da_size,
+                    signed_tx,
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn estimate_builder_tx_gas(&self, input: &[u8]) -> u64 {
+        // Count zero and non-zero bytes
+        let (zero_bytes, nonzero_bytes) = input.iter().fold((0, 0), |(zeros, nonzeros), &byte| {
+            if byte == 0 {
+                (zeros + 1, nonzeros)
+            } else {
+                (zeros, nonzeros + 1)
+            }
+        });
+
+        // Calculate gas cost (4 gas per zero byte, 16 gas per non-zero byte)
+        let zero_cost = zero_bytes * 4;
+        let nonzero_cost = nonzero_bytes * 16;
+
+        // Tx gas should be not less than floor gas https://eips.ethereum.org/EIPS/eip-7623
+        let tokens_in_calldata = zero_bytes + nonzero_bytes * 4;
+        let floor_gas = 21_000 + tokens_in_calldata * TOTAL_COST_FLOOR_PER_TOKEN;
+
+        std::cmp::max(zero_cost + nonzero_cost + 21_000, floor_gas)
+    }
+
+    fn signed_builder_tx<ExtraCtx: Debug + Default>(
+        &self,
+        ctx: &OpPayloadBuilderCtx<ExtraCtx>,
+        db: &mut State<impl Database>,
+        signer: Signer,
+        gas_used: u64,
+        message: Vec<u8>,
+    ) -> Result<Recovered<OpTransactionSigned>, BuilderTransactionError> {
+        let nonce = db
+            .load_cache_account(signer.address)
+            .map(|acc| acc.account_info().unwrap_or_default().nonce)
+            .map_err(|_| BuilderTransactionError::AccountLoadFailed(signer.address))?;
+
+        // Create the EIP-1559 transaction
+        let tx = OpTypedTransaction::Eip1559(TxEip1559 {
+            chain_id: ctx.chain_id(),
+            nonce,
+            gas_limit: gas_used,
+            max_fee_per_gas: ctx.base_fee().into(),
+            max_priority_fee_per_gas: 0,
+            to: TxKind::Call(Address::ZERO),
+            // Include the message as part of the transaction data
+            input: message.into(),
+            ..Default::default()
+        });
+        // Sign the transaction
+        let builder_tx = signer
+            .sign_tx(tx)
+            .map_err(BuilderTransactionError::SigningError)?;
+
+        Ok(builder_tx)
+    }
+}
+
+impl BuilderTransactions<FlashblocksExtraCtx> for FlashblocksBuilderTx {
+    fn simulate_builder_txs<Extra: Debug + Default>(
+        &self,
+        state_provider: impl StateProvider + Clone,
+        info: &mut ExecutionInfo<Extra>,
+        ctx: &OpPayloadBuilderCtx<FlashblocksExtraCtx>,
+        db: &mut State<impl Database>,
+    ) -> Result<Vec<BuilderTransactionCtx>, BuilderTransactionError> {
+        let mut builder_txs = Vec::<BuilderTransactionCtx>::new();
+        if ctx.is_first_fallback_block() {
+            let flashblocks_builder_tx = self.simulate_builder_tx(ctx, db)?;
+            builder_txs.extend(flashblocks_builder_tx.clone());
+        }
+
+        if ctx.is_last_flashblock() {
+            let flashblocks_builder_tx = self.simulate_builder_tx(ctx, db)?;
+            builder_txs.extend(flashblocks_builder_tx.clone());
+            if let Some(flashtestations_builder_tx) = &self.flashtestations_builder_tx {
+                // We only include flashtestations txs in the last flashblock
+
+                let mut simulation_state = self.simulate_builder_txs_state::<FlashblocksExtraCtx>(
+                    state_provider.clone(),
+                    flashblocks_builder_tx.iter().collect(),
+                    ctx,
+                    db,
+                )?;
+                let flashtestations_builder_txs = flashtestations_builder_tx.simulate_builder_txs(
+                    state_provider,
+                    info,
+                    ctx,
+                    &mut simulation_state,
+                )?;
+                builder_txs.extend(flashtestations_builder_txs);
+            }
+        }
+        Ok(builder_txs)
+    }
+}

--- a/crates/op-rbuilder/src/builders/flashblocks/mod.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/mod.rs
@@ -3,8 +3,8 @@ use crate::traits::{NodeBounds, PoolBounds};
 use config::FlashblocksConfig;
 use service::FlashblocksServiceBuilder;
 
+mod builder_tx;
 mod config;
-//mod context;
 mod payload;
 mod service;
 mod wspub;

--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -1,10 +1,11 @@
 use super::{config::FlashblocksConfig, wspub::WebSocketPublisher};
 use crate::{
     builders::{
-        context::{estimate_gas_for_builder_tx, OpPayloadBuilderCtx},
+        builder_tx::BuilderTransactions,
+        context::OpPayloadBuilderCtx,
         flashblocks::config::FlashBlocksConfigExt,
         generator::{BlockCell, BuildArguments},
-        BuilderConfig, BuilderTx,
+        BuilderConfig,
     },
     metrics::OpRBuilderMetrics,
     primitives::reth::ExecutionInfo,
@@ -59,11 +60,13 @@ struct ExtraExecutionInfo {
 }
 
 #[derive(Debug, Default)]
-struct FlashblocksExtraCtx {
+pub struct FlashblocksExtraCtx {
     /// Current flashblock index
     pub flashblock_index: u64,
     /// Target flashblock count
     pub target_flashblock_count: u64,
+    /// Whether the current flashblock is the first fallback block
+    pub is_first_fallback_block: bool,
 }
 
 impl OpPayloadBuilderCtx<FlashblocksExtraCtx> {
@@ -75,6 +78,11 @@ impl OpPayloadBuilderCtx<FlashblocksExtraCtx> {
     /// Returns the target flashblock count
     pub fn target_flashblock_count(&self) -> u64 {
         self.extra_ctx.target_flashblock_count
+    }
+
+    /// Returns if the flashblock is the first fallback block
+    pub fn is_first_fallback_block(&self) -> bool {
+        self.extra_ctx.is_first_fallback_block
     }
 
     /// Increments the flashblock index
@@ -89,6 +97,11 @@ impl OpPayloadBuilderCtx<FlashblocksExtraCtx> {
         self.extra_ctx.target_flashblock_count
     }
 
+    /// Sets the first fallback block flag
+    pub fn set_first_fallback_block(&mut self, is_first_fallback_block: bool) {
+        self.extra_ctx.is_first_fallback_block = is_first_fallback_block;
+    }
+
     /// Returns if the flashblock is the last one
     pub fn is_last_flashblock(&self) -> bool {
         self.flashblock_index() == self.target_flashblock_count() - 1
@@ -97,7 +110,7 @@ impl OpPayloadBuilderCtx<FlashblocksExtraCtx> {
 
 /// Optimism's payload builder
 #[derive(Debug, Clone)]
-pub struct OpPayloadBuilder<Pool, Client, BT> {
+pub struct OpPayloadBuilder<Pool, Client, BuilderTx> {
     /// The type responsible for creating the evm.
     pub evm_config: OpEvmConfig,
     /// The transaction pool
@@ -112,18 +125,17 @@ pub struct OpPayloadBuilder<Pool, Client, BT> {
     /// The metrics for the builder
     pub metrics: Arc<OpRBuilderMetrics>,
     /// The end of builder transaction type
-    #[allow(dead_code)]
-    pub builder_tx: BT,
+    pub builder_tx: BuilderTx,
 }
 
-impl<Pool, Client, BT> OpPayloadBuilder<Pool, Client, BT> {
+impl<Pool, Client, BuilderTx> OpPayloadBuilder<Pool, Client, BuilderTx> {
     /// `OpPayloadBuilder` constructor.
     pub fn new(
         evm_config: OpEvmConfig,
         pool: Pool,
         client: Client,
         config: BuilderConfig<FlashblocksConfig>,
-        builder_tx: BT,
+        builder_tx: BuilderTx,
     ) -> eyre::Result<Self> {
         let metrics = Arc::new(OpRBuilderMetrics::default());
         let ws_pub = WebSocketPublisher::new(config.specific.ws_addr, Arc::clone(&metrics))?.into();
@@ -139,12 +151,12 @@ impl<Pool, Client, BT> OpPayloadBuilder<Pool, Client, BT> {
     }
 }
 
-impl<Pool, Client, BT> reth_basic_payload_builder::PayloadBuilder
-    for OpPayloadBuilder<Pool, Client, BT>
+impl<Pool, Client, BuilderTx> reth_basic_payload_builder::PayloadBuilder
+    for OpPayloadBuilder<Pool, Client, BuilderTx>
 where
     Pool: Clone + Send + Sync,
     Client: Clone + Send + Sync,
-    BT: Clone + Send + Sync,
+    BuilderTx: Clone + Send + Sync,
 {
     type Attributes = OpPayloadBuilderAttributes<OpTransactionSigned>;
     type BuiltPayload = OpBuiltPayload;
@@ -167,11 +179,11 @@ where
     }
 }
 
-impl<Pool, Client, BT> OpPayloadBuilder<Pool, Client, BT>
+impl<Pool, Client, BuilderTx> OpPayloadBuilder<Pool, Client, BuilderTx>
 where
     Pool: PoolBounds,
     Client: ClientBounds,
-    BT: BuilderTx,
+    BuilderTx: BuilderTransactions<FlashblocksExtraCtx>,
 {
     /// Constructs an Optimism payload from the transactions sent via the
     /// Payload attributes by the sequencer. If the `no_tx_pool` argument is passed in
@@ -250,6 +262,7 @@ where
             extra_ctx: FlashblocksExtraCtx {
                 flashblock_index: 0,
                 target_flashblock_count: self.config.flashblocks_per_block(),
+                is_first_fallback_block: true,
             },
         };
 
@@ -263,24 +276,19 @@ where
             .with_bundle_update()
             .build();
 
-        // We subtract gas limit and da limit for builder transaction from the whole limit
-        let message = format!("Block Number: {}", ctx.block_number()).into_bytes();
-        let builder_tx_gas = ctx
-            .builder_signer()
-            .map_or(0, |_| estimate_gas_for_builder_tx(message.clone()));
-        let builder_tx_da_size = ctx
-            .estimate_builder_tx_da_size(&mut db, builder_tx_gas, message.clone())
-            .unwrap_or(0);
-
         let mut info = execute_pre_steps(&mut db, &ctx)?;
         let sequencer_tx_time = sequencer_tx_start_time.elapsed();
         ctx.metrics.sequencer_tx_duration.record(sequencer_tx_time);
         ctx.metrics.sequencer_tx_gauge.set(sequencer_tx_time);
 
-        // If we have payload with txpool we add first builder tx right after deposits
-        if !ctx.attributes().no_tx_pool {
-            ctx.add_builder_tx(&mut info, &mut db, builder_tx_gas, message.clone());
-        }
+        // We add first builder tx right after deposits
+        let builder_txs =
+            self.builder_tx
+                .add_builder_txs(&state_provider, &mut info, &ctx, &mut db)?;
+
+        // We subtract gas limit and da limit for builder transaction from the whole limit
+        let builder_tx_gas = builder_txs.iter().fold(0, |acc, tx| acc + tx.gas_used);
+        let builder_tx_da_size: u64 = builder_txs.iter().fold(0, |acc, tx| acc + tx.da_size);
 
         let (payload, fb_payload, mut bundle_state) = build_block(db, &ctx, &mut info)?;
 
@@ -288,6 +296,8 @@ where
         self.ws_pub
             .publish(&fb_payload)
             .map_err(PayloadBuilderError::other)?;
+        // We set the first fallback block flag to false after building the first fallback block
+        ctx.set_first_fallback_block(false);
 
         info!(
             target: "payload_builder",
@@ -348,7 +358,9 @@ where
         if let Some(da_limit) = da_per_batch {
             // We error if we can't insert any tx aside from builder tx in flashblock
             if da_limit / 2 < builder_tx_da_size {
-                error!("Builder tx da size subtraction caused max_da_block_size to be 0. No transaction would be included.");
+                error!(
+                    "Builder tx da size subtraction caused max_da_block_size to be 0. No transaction would be included."
+                );
             }
         }
         let mut total_da_per_batch = da_per_batch;
@@ -426,8 +438,24 @@ where
                     let mut db = State::builder()
                         .with_database(state)
                         .with_bundle_update()
-                        .with_bundle_prestate(bundle_state)
+                        .with_bundle_prestate(bundle_state.clone())
                         .build();
+
+                    let builder_txs = self.builder_tx.simulate_builder_txs(
+                        &state_provider,
+                        &mut info,
+                        &ctx,
+                        &mut db,
+                    )?;
+                    let builder_tx_gas = builder_txs.iter().fold(0, |acc, tx| acc + tx.gas_used);
+                    let builder_tx_da_size: u64 =
+                        builder_txs.iter().fold(0, |acc, tx| acc + tx.da_size);
+
+                    total_gas_per_batch = total_gas_per_batch.saturating_sub(builder_tx_gas);
+                    // saturating sub just in case, we will log an error if da_limit too small for builder_tx_da_size
+                    if let Some(da_limit) = total_da_per_batch.as_mut() {
+                        *da_limit = da_limit.saturating_sub(builder_tx_da_size);
+                    }
 
                     let best_txs_start_time = Instant::now();
                     let best_txs = BestPayloadTransactions::new(
@@ -474,10 +502,8 @@ where
                         .payload_tx_simulation_gauge
                         .set(payload_tx_simulation_time);
 
-                    // If it is the last flashblocks, add the builder txn to the block if enabled
-                    if ctx.is_last_flashblock() {
-                        ctx.add_builder_tx(&mut info, &mut db, builder_tx_gas, message.clone());
-                    };
+                    self.builder_tx
+                        .add_builder_txs(&state_provider, &mut info, &ctx, &mut db)?;
 
                     let total_block_built_duration = Instant::now();
                     let build_result = build_block(db, &ctx, &mut info);
@@ -531,7 +557,9 @@ where
                                 if let Some(da) = total_da_per_batch.as_mut() {
                                     *da += da_limit;
                                 } else {
-                                    error!("Builder end up in faulty invariant, if da_per_batch is set then total_da_per_batch must be set");
+                                    error!(
+                                        "Builder end up in faulty invariant, if da_per_batch is set then total_da_per_batch must be set"
+                                    );
                                 }
                             }
 
@@ -677,12 +705,12 @@ where
     }
 }
 
-impl<Pool, Client, BT> crate::builders::generator::PayloadBuilder
-    for OpPayloadBuilder<Pool, Client, BT>
+impl<Pool, Client, BuilderTx> crate::builders::generator::PayloadBuilder
+    for OpPayloadBuilder<Pool, Client, BuilderTx>
 where
     Pool: PoolBounds,
     Client: ClientBounds,
-    BT: BuilderTx + Clone + Send + Sync,
+    BuilderTx: BuilderTransactions<FlashblocksExtraCtx> + Clone + Send + Sync,
 {
     type Attributes = OpPayloadBuilderAttributes<OpTransactionSigned>;
     type BuiltPayload = OpBuiltPayload;

--- a/crates/op-rbuilder/src/builders/flashblocks/service.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/service.rs
@@ -1,10 +1,12 @@
 use super::{payload::OpPayloadBuilder, FlashblocksConfig};
 use crate::{
     builders::{
-        builder_tx::StandardBuilderTx, generator::BlockPayloadJobGenerator, BuilderConfig,
-        BuilderTx,
+        builder_tx::BuilderTransactions,
+        flashblocks::{builder_tx::FlashblocksBuilderTx, payload::FlashblocksExtraCtx},
+        generator::BlockPayloadJobGenerator,
+        BuilderConfig,
     },
-    flashtestations::service::spawn_flashtestations_service,
+    flashtestations::service::bootstrap_flashtestations,
     traits::{NodeBounds, PoolBounds},
 };
 use reth_basic_payload_builder::BasicPayloadJobGeneratorConfig;
@@ -17,16 +19,16 @@ use reth_provider::CanonStateSubscriptions;
 pub struct FlashblocksServiceBuilder(pub BuilderConfig<FlashblocksConfig>);
 
 impl FlashblocksServiceBuilder {
-    fn spawn_payload_builder_service<Node, Pool, BT>(
+    fn spawn_payload_builder_service<Node, Pool, BuilderTx>(
         self,
         ctx: &BuilderContext<Node>,
         pool: Pool,
-        builder_tx: BT,
+        builder_tx: BuilderTx,
     ) -> eyre::Result<PayloadBuilderHandle<<Node::Types as NodeTypes>::Payload>>
     where
         Node: NodeBounds,
         Pool: PoolBounds,
-        BT: BuilderTx + Unpin + Clone + Send + Sync + 'static,
+        BuilderTx: BuilderTransactions<FlashblocksExtraCtx> + Unpin + Clone + Send + Sync + 'static,
     {
         let payload_builder = OpPayloadBuilder::new(
             OpEvmConfig::optimism(ctx.chain_spec()),
@@ -70,30 +72,22 @@ where
         pool: Pool,
         _: OpEvmConfig,
     ) -> eyre::Result<PayloadBuilderHandle<<Node::Types as NodeTypes>::Payload>> {
-        tracing::debug!("Spawning flashblocks payload builder service");
         let signer = self.0.builder_signer;
-        if self.0.flashtestations_config.flashtestations_enabled {
-            let flashtestations_service = match spawn_flashtestations_service(
-                self.0.flashtestations_config.clone(),
-                ctx,
-            )
-            .await
-            {
-                Ok(service) => service,
+        let flashtestations_builder_tx = if self.0.flashtestations_config.flashtestations_enabled {
+            match bootstrap_flashtestations(self.0.flashtestations_config.clone(), ctx).await {
+                Ok(builder_tx) => Some(builder_tx),
                 Err(e) => {
-                    tracing::warn!(error = %e, "Failed to spawn flashtestations service, falling back to standard builder tx");
-                    return self.spawn_payload_builder_service(
-                        ctx,
-                        pool,
-                        StandardBuilderTx { signer },
-                    );
+                    tracing::warn!(error = %e, "Failed to bootstrap flashtestations, builderb will not include flashtestations txs");
+                    None
                 }
-            };
-
-            if self.0.flashtestations_config.enable_block_proofs {
-                return self.spawn_payload_builder_service(ctx, pool, flashtestations_service);
             }
-        }
-        self.spawn_payload_builder_service(ctx, pool, StandardBuilderTx { signer })
+        } else {
+            None
+        };
+        self.spawn_payload_builder_service(
+            ctx,
+            pool,
+            FlashblocksBuilderTx::new(signer, flashtestations_builder_tx),
+        )
     }
 }

--- a/crates/op-rbuilder/src/builders/mod.rs
+++ b/crates/op-rbuilder/src/builders/mod.rs
@@ -20,7 +20,8 @@ mod flashblocks;
 mod generator;
 mod standard;
 
-pub use builder_tx::BuilderTx;
+pub use builder_tx::{BuilderTransactionCtx, BuilderTransactionError, BuilderTransactions};
+pub use context::OpPayloadBuilderCtx;
 pub use flashblocks::FlashblocksBuilder;
 pub use standard::StandardBuilder;
 

--- a/crates/op-rbuilder/src/builders/standard/builder_tx.rs
+++ b/crates/op-rbuilder/src/builders/standard/builder_tx.rs
@@ -1,0 +1,146 @@
+use alloy_consensus::TxEip1559;
+use alloy_eips::{eip7623::TOTAL_COST_FLOOR_PER_TOKEN, Encodable2718};
+use alloy_evm::Database;
+use alloy_primitives::{Address, TxKind};
+use core::fmt::Debug;
+use op_alloy_consensus::OpTypedTransaction;
+use reth_optimism_primitives::OpTransactionSigned;
+use reth_primitives::Recovered;
+use reth_provider::StateProvider;
+use reth_revm::State;
+
+use crate::{
+    builders::{
+        context::OpPayloadBuilderCtx, BuilderTransactionCtx, BuilderTransactionError,
+        BuilderTransactions,
+    },
+    flashtestations::service::FlashtestationsBuilderTx,
+    primitives::reth::ExecutionInfo,
+    tx_signer::Signer,
+};
+
+// This will be the end of block transaction of a regular block
+#[derive(Debug, Clone)]
+pub struct StandardBuilderTx {
+    pub signer: Option<Signer>,
+    pub flashtestations_builder_tx: Option<FlashtestationsBuilderTx>,
+}
+
+impl StandardBuilderTx {
+    pub fn new(
+        signer: Option<Signer>,
+        flashtestations_builder_tx: Option<FlashtestationsBuilderTx>,
+    ) -> Self {
+        Self {
+            signer,
+            flashtestations_builder_tx,
+        }
+    }
+
+    pub fn simulate_builder_tx<ExtraCtx: Debug + Default>(
+        &self,
+        ctx: &OpPayloadBuilderCtx<ExtraCtx>,
+        db: &mut State<impl Database>,
+    ) -> Result<Option<BuilderTransactionCtx>, BuilderTransactionError> {
+        match self.signer {
+            Some(signer) => {
+                let message: Vec<u8> = format!("Block Number: {}", ctx.block_number()).into_bytes();
+                let gas_used = self.estimate_builder_tx_gas(&message);
+                let signed_tx = self.signed_builder_tx(ctx, db, signer, gas_used, message)?;
+                let da_size = op_alloy_flz::tx_estimated_size_fjord_bytes(
+                    signed_tx.encoded_2718().as_slice(),
+                );
+                Ok(Some(BuilderTransactionCtx {
+                    gas_used,
+                    da_size,
+                    signed_tx,
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn estimate_builder_tx_gas(&self, input: &[u8]) -> u64 {
+        // Count zero and non-zero bytes
+        let (zero_bytes, nonzero_bytes) = input.iter().fold((0, 0), |(zeros, nonzeros), &byte| {
+            if byte == 0 {
+                (zeros + 1, nonzeros)
+            } else {
+                (zeros, nonzeros + 1)
+            }
+        });
+
+        // Calculate gas cost (4 gas per zero byte, 16 gas per non-zero byte)
+        let zero_cost = zero_bytes * 4;
+        let nonzero_cost = nonzero_bytes * 16;
+
+        // Tx gas should be not less than floor gas https://eips.ethereum.org/EIPS/eip-7623
+        let tokens_in_calldata = zero_bytes + nonzero_bytes * 4;
+        let floor_gas = 21_000 + tokens_in_calldata * TOTAL_COST_FLOOR_PER_TOKEN;
+
+        std::cmp::max(zero_cost + nonzero_cost + 21_000, floor_gas)
+    }
+
+    fn signed_builder_tx<ExtraCtx: Debug + Default>(
+        &self,
+        ctx: &OpPayloadBuilderCtx<ExtraCtx>,
+        db: &mut State<impl Database>,
+        signer: Signer,
+        gas_used: u64,
+        message: Vec<u8>,
+    ) -> Result<Recovered<OpTransactionSigned>, BuilderTransactionError> {
+        let nonce = db
+            .load_cache_account(signer.address)
+            .map(|acc| acc.account_info().unwrap_or_default().nonce)
+            .map_err(|_| BuilderTransactionError::AccountLoadFailed(signer.address))?;
+
+        // Create the EIP-1559 transaction
+        let tx = OpTypedTransaction::Eip1559(TxEip1559 {
+            chain_id: ctx.chain_id(),
+            nonce,
+            gas_limit: gas_used,
+            max_fee_per_gas: ctx.base_fee().into(),
+            max_priority_fee_per_gas: 0,
+            to: TxKind::Call(Address::ZERO),
+            // Include the message as part of the transaction data
+            input: message.into(),
+            ..Default::default()
+        });
+        // Sign the transaction
+        let builder_tx = signer
+            .sign_tx(tx)
+            .map_err(BuilderTransactionError::SigningError)?;
+
+        Ok(builder_tx)
+    }
+}
+
+impl BuilderTransactions for StandardBuilderTx {
+    fn simulate_builder_txs<Extra: Debug + Default>(
+        &self,
+        state_provider: impl StateProvider + Clone,
+        info: &mut ExecutionInfo<Extra>,
+        ctx: &OpPayloadBuilderCtx,
+        db: &mut State<impl Database>,
+    ) -> Result<Vec<BuilderTransactionCtx>, BuilderTransactionError> {
+        let mut builder_txs = Vec::<BuilderTransactionCtx>::new();
+        let standard_builder_tx = self.simulate_builder_tx(ctx, db)?;
+        builder_txs.extend(standard_builder_tx.clone());
+        if let Some(flashtestations_builder_tx) = &self.flashtestations_builder_tx {
+            let mut simulation_state = self.simulate_builder_txs_state::<()>(
+                state_provider.clone(),
+                standard_builder_tx.iter().collect(),
+                ctx,
+                db,
+            )?;
+            let flashtestations_builder_txs = flashtestations_builder_tx.simulate_builder_txs(
+                state_provider,
+                info,
+                ctx,
+                &mut simulation_state,
+            )?;
+            builder_txs.extend(flashtestations_builder_txs);
+        }
+        Ok(builder_txs)
+    }
+}

--- a/crates/op-rbuilder/src/builders/standard/mod.rs
+++ b/crates/op-rbuilder/src/builders/standard/mod.rs
@@ -1,11 +1,13 @@
-use payload::StandardPayloadBuilderBuilder;
-use reth_node_builder::components::BasicPayloadServiceBuilder;
-
-use crate::traits::{NodeBounds, PoolBounds};
+use crate::{
+    builders::standard::service::StandardServiceBuilder,
+    traits::{NodeBounds, PoolBounds},
+};
 
 use super::BuilderConfig;
 
+mod builder_tx;
 mod payload;
+mod service;
 
 /// Block building strategy that builds blocks using the standard approach by
 /// producing blocks every chain block time.
@@ -15,7 +17,7 @@ impl super::PayloadBuilder for StandardBuilder {
     type Config = ();
 
     type ServiceBuilder<Node, Pool>
-        = BasicPayloadServiceBuilder<StandardPayloadBuilderBuilder>
+        = StandardServiceBuilder
     where
         Node: NodeBounds,
         Pool: PoolBounds;
@@ -27,8 +29,6 @@ impl super::PayloadBuilder for StandardBuilder {
         Node: NodeBounds,
         Pool: PoolBounds,
     {
-        Ok(BasicPayloadServiceBuilder::new(
-            StandardPayloadBuilderBuilder(config),
-        ))
+        Ok(StandardServiceBuilder(config))
     }
 }

--- a/crates/op-rbuilder/src/builders/standard/payload.rs
+++ b/crates/op-rbuilder/src/builders/standard/payload.rs
@@ -1,21 +1,21 @@
+use super::super::context::OpPayloadBuilderCtx;
 use crate::{
-    builders::{generator::BuildArguments, BuilderConfig},
-    flashtestations::service::spawn_flashtestations_service,
+    builders::{generator::BuildArguments, BuilderConfig, BuilderTransactions},
     metrics::OpRBuilderMetrics,
     primitives::reth::ExecutionInfo,
-    traits::{ClientBounds, NodeBounds, PayloadTxsBounds, PoolBounds},
+    traits::{ClientBounds, PayloadTxsBounds, PoolBounds},
 };
 use alloy_consensus::{
     constants::EMPTY_WITHDRAWALS, proofs, BlockBody, Header, EMPTY_OMMER_ROOT_HASH,
 };
 use alloy_eips::{eip7685::EMPTY_REQUESTS_HASH, merge::BEACON_NONCE};
+use alloy_evm::Database;
 use alloy_primitives::U256;
 use reth::payload::PayloadBuilderAttributes;
 use reth_basic_payload_builder::{BuildOutcome, BuildOutcomeKind, MissingPayloadBehaviour};
 use reth_chain_state::{ExecutedBlock, ExecutedBlockWithTrieUpdates, ExecutedTrieUpdates};
 use reth_evm::{execute::BlockBuilder, ConfigureEvm};
 use reth_node_api::{Block, PayloadBuilderError};
-use reth_node_builder::{components::PayloadBuilderBuilder, BuilderContext};
 use reth_optimism_consensus::{calculate_receipt_root_no_memo_optimism, isthmus};
 use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
 use reth_optimism_forks::OpHardforks;
@@ -23,69 +23,20 @@ use reth_optimism_node::{OpBuiltPayload, OpPayloadBuilderAttributes};
 use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
 use reth_payload_util::{BestPayloadTransactions, NoopPayloadTransactions, PayloadTransactions};
 use reth_primitives::RecoveredBlock;
-use reth_provider::{
-    ExecutionOutcome, HashedPostStateProvider, ProviderError, StateRootProvider,
-    StorageRootProvider,
-};
+use reth_provider::{ExecutionOutcome, StateProvider};
 use reth_revm::{
     database::StateProviderDatabase, db::states::bundle_state::BundleRetention, State,
 };
 use reth_transaction_pool::{
     BestTransactions, BestTransactionsAttributes, PoolTransaction, TransactionPool,
 };
-use revm::Database;
 use std::{sync::Arc, time::Instant};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
-use super::super::context::{estimate_gas_for_builder_tx, OpPayloadBuilderCtx};
-
-pub struct StandardPayloadBuilderBuilder(pub BuilderConfig<()>);
-
-impl<Node, Pool> PayloadBuilderBuilder<Node, Pool, OpEvmConfig> for StandardPayloadBuilderBuilder
-where
-    Node: NodeBounds,
-    Pool: PoolBounds,
-{
-    type PayloadBuilder = StandardOpPayloadBuilder<Pool, Node::Provider>;
-
-    async fn build_payload_builder(
-        self,
-        ctx: &BuilderContext<Node>,
-        pool: Pool,
-        _evm_config: OpEvmConfig,
-    ) -> eyre::Result<Self::PayloadBuilder> {
-        if self.0.flashtestations_config.flashtestations_enabled {
-            match spawn_flashtestations_service(self.0.flashtestations_config.clone(), ctx).await {
-                Ok(service) => service,
-                Err(e) => {
-                    tracing::warn!(error = %e, "Failed to spawn flashtestations service, falling back to standard builder tx");
-                    return Ok(StandardOpPayloadBuilder::new(
-                        OpEvmConfig::optimism(ctx.chain_spec()),
-                        pool,
-                        ctx.provider().clone(),
-                        self.0.clone(),
-                    ));
-                }
-            };
-
-            if self.0.flashtestations_config.enable_block_proofs {
-                // TODO: flashtestations end of block transaction
-            }
-        }
-
-        Ok(StandardOpPayloadBuilder::new(
-            OpEvmConfig::optimism(ctx.chain_spec()),
-            pool,
-            ctx.provider().clone(),
-            self.0.clone(),
-        ))
-    }
-}
-
 /// Optimism's payload builder
 #[derive(Debug, Clone)]
-pub struct StandardOpPayloadBuilder<Pool, Client, Txs = ()> {
+pub struct StandardOpPayloadBuilder<Pool, Client, BuilderTx, Txs = ()> {
     /// The type responsible for creating the evm.
     pub evm_config: OpEvmConfig,
     /// The transaction pool
@@ -99,15 +50,18 @@ pub struct StandardOpPayloadBuilder<Pool, Client, Txs = ()> {
     pub best_transactions: Txs,
     /// The metrics for the builder
     pub metrics: Arc<OpRBuilderMetrics>,
+    /// The type responsible for creating the builder transactions
+    pub builder_tx: BuilderTx,
 }
 
-impl<Pool, Client> StandardOpPayloadBuilder<Pool, Client> {
+impl<Pool, Client, BuilderTx> StandardOpPayloadBuilder<Pool, Client, BuilderTx> {
     /// `OpPayloadBuilder` constructor.
     pub fn new(
         evm_config: OpEvmConfig,
         pool: Pool,
         client: Client,
         config: BuilderConfig<()>,
+        builder_tx: BuilderTx,
     ) -> Self {
         Self {
             pool,
@@ -116,6 +70,7 @@ impl<Pool, Client> StandardOpPayloadBuilder<Pool, Client> {
             evm_config,
             best_transactions: (),
             metrics: Default::default(),
+            builder_tx,
         }
     }
 }
@@ -146,11 +101,12 @@ impl<T: PoolTransaction> OpPayloadTransactions<T> for () {
     }
 }
 
-impl<Pool, Client, Txs> reth_basic_payload_builder::PayloadBuilder
-    for StandardOpPayloadBuilder<Pool, Client, Txs>
+impl<Pool, Client, BuilderTx, Txs> reth_basic_payload_builder::PayloadBuilder
+    for StandardOpPayloadBuilder<Pool, Client, BuilderTx, Txs>
 where
     Pool: PoolBounds,
     Client: ClientBounds,
+    BuilderTx: BuilderTransactions + Clone + Send + Sync,
     Txs: OpPayloadTransactions<Pool::Transaction>,
 {
     type Attributes = OpPayloadBuilderAttributes<OpTransactionSigned>;
@@ -209,10 +165,11 @@ where
     }
 }
 
-impl<Pool, Client, T> StandardOpPayloadBuilder<Pool, Client, T>
+impl<Pool, Client, BuilderTx, T> StandardOpPayloadBuilder<Pool, Client, BuilderTx, T>
 where
     Pool: PoolBounds,
     Client: ClientBounds,
+    BuilderTx: BuilderTransactions + Clone,
 {
     /// Constructs an Optimism payload from the transactions sent via the
     /// Payload attributes by the sequencer. If the `no_tx_pool` argument is passed in
@@ -280,22 +237,18 @@ where
         let builder = OpBuilder::new(best);
 
         let state_provider = self.client.state_by_block_hash(ctx.parent().hash())?;
-        let state = StateProviderDatabase::new(state_provider);
+        let state = StateProviderDatabase::new(&state_provider);
         let metrics = ctx.metrics.clone();
-
         if ctx.attributes().no_tx_pool {
-            let db = State::builder()
-                .with_database(state)
-                .with_bundle_update()
-                .build();
-            builder.build(db, ctx)
+            builder.build(state, &state_provider, ctx, self.builder_tx.clone())
         } else {
             // sequencer mode we can reuse cachedreads from previous runs
-            let db = State::builder()
-                .with_database(cached_reads.as_db_mut(state))
-                .with_bundle_update()
-                .build();
-            builder.build(db, ctx)
+            builder.build(
+                cached_reads.as_db_mut(state),
+                &state_provider,
+                ctx,
+                self.builder_tx.clone(),
+            )
         }
         .map(|out| {
             let total_block_building_time = block_build_start_time.elapsed();
@@ -349,28 +302,29 @@ pub struct ExecutedPayload {
 
 impl<Txs: PayloadTxsBounds> OpBuilder<'_, Txs> {
     /// Executes the payload and returns the outcome.
-    pub fn execute<DB, P>(
+    pub fn execute<BuilderTx>(
         self,
-        state: &mut State<DB>,
+        state_provider: impl StateProvider,
+        db: &mut State<impl Database>,
         ctx: &OpPayloadBuilderCtx,
+        builder_tx: BuilderTx,
     ) -> Result<BuildOutcomeKind<ExecutedPayload>, PayloadBuilderError>
     where
-        DB: Database<Error = ProviderError> + AsRef<P> + std::fmt::Debug,
-        P: StorageRootProvider,
+        BuilderTx: BuilderTransactions,
     {
         let Self { best } = self;
         info!(target: "payload_builder", id=%ctx.payload_id(), parent_header = ?ctx.parent().hash(), parent_number = ctx.parent().number, "building new payload");
 
         // 1. apply pre-execution changes
         ctx.evm_config
-            .builder_for_next_block(state, ctx.parent(), ctx.block_env_attributes.clone())
+            .builder_for_next_block(db, ctx.parent(), ctx.block_env_attributes.clone())
             .map_err(PayloadBuilderError::other)?
             .apply_pre_execution_changes()?;
 
         let sequencer_tx_start_time = Instant::now();
 
         // 3. execute sequencer transactions
-        let mut info = ctx.execute_sequencer_transactions(state)?;
+        let mut info = ctx.execute_sequencer_transactions(db)?;
 
         let sequencer_tx_time = sequencer_tx_start_time.elapsed();
         ctx.metrics.sequencer_tx_duration.record(sequencer_tx_time);
@@ -379,17 +333,14 @@ impl<Txs: PayloadTxsBounds> OpBuilder<'_, Txs> {
         // 4. if mem pool transactions are requested we execute them
 
         // gas reserved for builder tx
-        let message = format!("Block Number: {}", ctx.block_number())
-            .as_bytes()
-            .to_vec();
-        let builder_tx_gas = ctx
-            .builder_signer()
-            .map_or(0, |_| estimate_gas_for_builder_tx(message.clone()));
-        let block_gas_limit = ctx.block_gas_limit() - builder_tx_gas;
+        let builder_txs = builder_tx.simulate_builder_txs(&state_provider, &mut info, ctx, db)?;
+        let builder_tx_gas = builder_txs.iter().fold(0, |acc, tx| acc + tx.gas_used);
+        let block_gas_limit = ctx.block_gas_limit().saturating_sub(builder_tx_gas);
+        if block_gas_limit == 0 {
+            error!("Builder tx gas subtraction resulted in block gas limit to be 0. No transactions would be included");
+        }
         // Save some space in the block_da_limit for builder tx
-        let builder_tx_da_size = ctx
-            .estimate_builder_tx_da_size(state, builder_tx_gas, message.clone())
-            .unwrap_or(0);
+        let builder_tx_da_size = builder_txs.iter().fold(0, |acc, tx| acc + tx.da_size);
         let block_da_limit = ctx
             .da_config
             .max_da_block_size()
@@ -415,7 +366,7 @@ impl<Txs: PayloadTxsBounds> OpBuilder<'_, Txs> {
             if ctx
                 .execute_best_transactions(
                     &mut info,
-                    state,
+                    db,
                     best_txs,
                     block_gas_limit,
                     block_da_limit,
@@ -427,13 +378,13 @@ impl<Txs: PayloadTxsBounds> OpBuilder<'_, Txs> {
         }
 
         // Add builder tx to the block
-        ctx.add_builder_tx(&mut info, state, builder_tx_gas, message);
+        builder_tx.add_builder_txs(&state_provider, &mut info, ctx, db)?;
 
         let state_merge_start_time = Instant::now();
 
         // merge all transitions into bundle state, this would apply the withdrawal balance changes
         // and 4788 contract call
-        state.merge_transitions(BundleRetention::Reverts);
+        db.merge_transitions(BundleRetention::Reverts);
 
         let state_transition_merge_time = state_merge_start_time.elapsed();
         ctx.metrics
@@ -457,24 +408,32 @@ impl<Txs: PayloadTxsBounds> OpBuilder<'_, Txs> {
     }
 
     /// Builds the payload on top of the state.
-    pub fn build<DB, P>(
+    pub fn build<BuilderTx>(
         self,
-        mut state: State<DB>,
+        state: impl Database,
+        state_provider: impl StateProvider,
         ctx: OpPayloadBuilderCtx,
+        builder_tx: BuilderTx,
     ) -> Result<BuildOutcomeKind<OpBuiltPayload>, PayloadBuilderError>
     where
-        DB: Database<Error = ProviderError> + AsRef<P> + std::fmt::Debug,
-        P: StateRootProvider + HashedPostStateProvider + StorageRootProvider,
+        BuilderTx: BuilderTransactions,
     {
-        let ExecutedPayload { info } = match self.execute(&mut state, &ctx)? {
-            BuildOutcomeKind::Better { payload } | BuildOutcomeKind::Freeze(payload) => payload,
-            BuildOutcomeKind::Cancelled => return Ok(BuildOutcomeKind::Cancelled),
-            BuildOutcomeKind::Aborted { fees } => return Ok(BuildOutcomeKind::Aborted { fees }),
-        };
+        let mut db = State::builder()
+            .with_database(state)
+            .with_bundle_update()
+            .build();
+        let ExecutedPayload { info } =
+            match self.execute(&state_provider, &mut db, &ctx, builder_tx)? {
+                BuildOutcomeKind::Better { payload } | BuildOutcomeKind::Freeze(payload) => payload,
+                BuildOutcomeKind::Cancelled => return Ok(BuildOutcomeKind::Cancelled),
+                BuildOutcomeKind::Aborted { fees } => {
+                    return Ok(BuildOutcomeKind::Aborted { fees })
+                }
+            };
 
         let block_number = ctx.block_number();
         let execution_outcome = ExecutionOutcome::new(
-            state.take_bundle(),
+            db.take_bundle(),
             vec![info.receipts],
             block_number,
             Vec::new(),
@@ -495,12 +454,9 @@ impl<Txs: PayloadTxsBounds> OpBuilder<'_, Txs> {
         // calculate the state root
         let state_root_start_time = Instant::now();
 
-        let state_provider = state.database.as_ref();
         let hashed_state = state_provider.hashed_post_state(execution_outcome.state());
         let (state_root, trie_output) = {
-            state
-                .database
-                .as_ref()
+            state_provider
                 .state_root_with_updates(hashed_state.clone())
                 .inspect_err(|err| {
                     warn!(target: "payload_builder",
@@ -524,7 +480,7 @@ impl<Txs: PayloadTxsBounds> OpBuilder<'_, Txs> {
             // `l2tol1-message-passer`
             (
                 Some(
-                    isthmus::withdrawals_root(execution_outcome.state(), state.database.as_ref())
+                    isthmus::withdrawals_root(execution_outcome.state(), state_provider)
                         .map_err(PayloadBuilderError::other)?,
                 ),
                 Some(EMPTY_REQUESTS_HASH),

--- a/crates/op-rbuilder/src/builders/standard/service.rs
+++ b/crates/op-rbuilder/src/builders/standard/service.rs
@@ -1,0 +1,96 @@
+use reth_basic_payload_builder::{BasicPayloadJobGenerator, BasicPayloadJobGeneratorConfig};
+use reth_node_api::NodeTypes;
+use reth_node_builder::{components::PayloadServiceBuilder, BuilderContext};
+use reth_optimism_evm::OpEvmConfig;
+use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
+use reth_provider::CanonStateSubscriptions;
+
+use crate::{
+    builders::{
+        standard::{builder_tx::StandardBuilderTx, payload::StandardOpPayloadBuilder},
+        BuilderConfig, BuilderTransactions,
+    },
+    flashtestations::service::bootstrap_flashtestations,
+    traits::{NodeBounds, PoolBounds},
+};
+
+pub struct StandardServiceBuilder(pub BuilderConfig<()>);
+
+impl StandardServiceBuilder {
+    pub fn spawn_payload_builder_service<Node, Pool, BuilderTx>(
+        self,
+        evm_config: OpEvmConfig,
+        ctx: &BuilderContext<Node>,
+        pool: Pool,
+        builder_tx: BuilderTx,
+    ) -> eyre::Result<PayloadBuilderHandle<<Node::Types as NodeTypes>::Payload>>
+    where
+        Node: NodeBounds,
+        Pool: PoolBounds,
+        BuilderTx: BuilderTransactions + Unpin + Clone + Send + Sync + 'static,
+    {
+        let payload_builder = StandardOpPayloadBuilder::new(
+            evm_config,
+            pool,
+            ctx.provider().clone(),
+            self.0.clone(),
+            builder_tx,
+        );
+
+        let conf = ctx.config().builder.clone();
+
+        let payload_job_config = BasicPayloadJobGeneratorConfig::default()
+            .interval(conf.interval)
+            .deadline(conf.deadline)
+            .max_payload_tasks(conf.max_payload_tasks);
+
+        let payload_generator = BasicPayloadJobGenerator::with_builder(
+            ctx.provider().clone(),
+            ctx.task_executor().clone(),
+            payload_job_config,
+            payload_builder,
+        );
+        let (payload_service, payload_service_handle) =
+            PayloadBuilderService::new(payload_generator, ctx.provider().canonical_state_stream());
+
+        ctx.task_executor()
+            .spawn_critical("payload builder service", Box::pin(payload_service));
+
+        Ok(payload_service_handle)
+    }
+}
+
+impl<Node, Pool> PayloadServiceBuilder<Node, Pool, OpEvmConfig> for StandardServiceBuilder
+where
+    Node: NodeBounds,
+    Pool: PoolBounds,
+{
+    async fn spawn_payload_builder_service(
+        self,
+        ctx: &BuilderContext<Node>,
+        pool: Pool,
+        evm_config: OpEvmConfig,
+    ) -> eyre::Result<PayloadBuilderHandle<<Node::Types as NodeTypes>::Payload>> {
+        let signer = self.0.builder_signer;
+        let flashtestations_builder_tx = if self.0.flashtestations_config.flashtestations_enabled {
+            match bootstrap_flashtestations::<Node>(self.0.flashtestations_config.clone(), ctx)
+                .await
+            {
+                Ok(builder_tx) => Some(builder_tx),
+                Err(e) => {
+                    tracing::warn!(error = %e, "Failed to bootstrap flashtestations, builderb will not include flashtestations txs");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        self.spawn_payload_builder_service(
+            evm_config,
+            ctx,
+            pool,
+            StandardBuilderTx::new(signer, flashtestations_builder_tx),
+        )
+    }
+}

--- a/crates/op-rbuilder/src/flashtestations/service.rs
+++ b/crates/op-rbuilder/src/flashtestations/service.rs
@@ -2,12 +2,17 @@ use std::sync::Arc;
 
 use alloy_primitives::U256;
 use reth_node_builder::BuilderContext;
-use reth_optimism_primitives::OpTransactionSigned;
-use reth_primitives::Recovered;
+use reth_provider::StateProvider;
+use reth_revm::State;
+use revm::Database;
+use std::fmt::Debug;
 use tracing::{info, warn};
 
 use crate::{
-    builders::BuilderTx,
+    builders::{
+        BuilderTransactionCtx, BuilderTransactionError, BuilderTransactions, OpPayloadBuilderCtx,
+    },
+    primitives::reth::ExecutionInfo,
     traits::NodeBounds,
     tx_signer::{generate_ethereum_keypair, Signer},
 };
@@ -21,7 +26,7 @@ use super::{
 #[derive(Clone)]
 pub struct FlashtestationsService {
     // Attestation provider generating attestations
-    attestation_provider: Arc<Box<dyn AttestationProvider + Send + Sync>>,
+    attestation_provider: Arc<Box<dyn AttestationProvider + Send + Sync + 'static>>,
     // Handles the onchain attestation and TEE block building proofs
     tx_manager: TxManager,
     // TEE service generated key
@@ -86,24 +91,25 @@ impl FlashtestationsService {
     }
 }
 
-impl BuilderTx for FlashtestationsService {
-    fn estimated_builder_tx_gas(&self) -> u64 {
-        todo!()
-    }
+#[derive(Debug, Clone)]
+pub struct FlashtestationsBuilderTx {}
 
-    fn estimated_builder_tx_da_size(&self) -> Option<u64> {
-        todo!()
-    }
-
-    fn signed_builder_tx(&self) -> Result<Recovered<OpTransactionSigned>, secp256k1::Error> {
-        todo!()
+impl<ExtraCtx: Debug + Default> BuilderTransactions<ExtraCtx> for FlashtestationsBuilderTx {
+    fn simulate_builder_txs<Extra: Debug + Default>(
+        &self,
+        _state_provider: impl StateProvider + Clone,
+        _info: &mut ExecutionInfo<Extra>,
+        _ctx: &OpPayloadBuilderCtx<ExtraCtx>,
+        _db: &mut State<impl Database>,
+    ) -> Result<Vec<BuilderTransactionCtx>, BuilderTransactionError> {
+        Ok(vec![])
     }
 }
 
-pub async fn spawn_flashtestations_service<Node>(
+pub async fn bootstrap_flashtestations<Node>(
     args: FlashtestationsArgs,
     ctx: &BuilderContext<Node>,
-) -> eyre::Result<FlashtestationsService>
+) -> eyre::Result<FlashtestationsBuilderTx>
 where
     Node: NodeBounds,
 {
@@ -131,7 +137,7 @@ where
             },
         );
 
-    Ok(flashtestations_service)
+    Ok(FlashtestationsBuilderTx {})
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 📝 Summary

Refactor to allow the payload builder accept generics for how to construct the builder tx.

## 💡 Motivation and Context

Easier to add custom logic to builder tx based on the payload builder such as contract calls etc.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
