### PR TITLE
Add reproducibility flags

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,16 @@
+[build]
+rustflags = [
+    "-C", "strip=symbols",
+    "-C", "codegen-units=1", 
+    "-C", "opt-level=3"
+]
+
+[profile.release]
+debug = false
+lto = "fat"
+panic = "abort" 
+codegen-units = 1
+incremental = false
+
+[env]
+SOURCE_DATE_EPOCH = { value = "0", force = true }


### PR DESCRIPTION
## 📝 Summary

Added some cargo flags to make builds reproducible

## 💡 Motivation and Context

Needed so that people can manually verify the artifacts we publish when trying to bootstrap our TDX images from source

