### PR TITLE
fix: correctly calculate flashblock byte size

### DIFF
--- a/crates/op-rbuilder/src/builders/flashblocks/mod.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/mod.rs
@@ -8,6 +8,7 @@ mod config;
 mod best_txs;
 mod payload;
 mod service;
+mod util;
 mod wspub;
 
 /// Block building strategy that progressively builds chunks of a block and makes them available

--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -2,7 +2,10 @@ use super::{config::FlashblocksConfig, wspub::WebSocketPublisher};
 use crate::{
     builders::{
         context::{estimate_gas_for_builder_tx, OpPayloadBuilderCtx},
-        flashblocks::{best_txs::BestFlashblocksTxs, config::FlashBlocksConfigExt},
+        flashblocks::{
+            best_txs::BestFlashblocksTxs, config::FlashBlocksConfigExt,
+            util::calculate_flashblock_byte_size,
+        },
         generator::{BlockCell, BuildArguments},
         BuilderConfig, BuilderTx,
     },
@@ -535,7 +538,7 @@ where
                                 .record(flashblock_build_start_time.elapsed());
                             ctx.metrics
                                 .flashblock_byte_size_histogram
-                                .record(new_payload.block().size() as f64);
+                                .record(calculate_flashblock_byte_size(&fb_payload) as f64);
                             ctx.metrics
                                 .flashblock_num_tx_histogram
                                 .record(info.executed_transactions.len() as f64);

--- a/crates/op-rbuilder/src/builders/flashblocks/util.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/util.rs
@@ -1,0 +1,77 @@
+use rollup_boost::FlashblocksPayloadV1;
+use serde_json::Value;
+
+/// Calculates the approximate number of bytes used by a FlashblocksPayloadV1
+pub fn calculate_flashblock_byte_size(fb_payload: &FlashblocksPayloadV1) -> usize {
+    // Start with PayloadId (8 bytes) + Index (8 bytes)
+    let mut total_bytes = 16;
+
+    // Base (if present)
+    if let Some(ref base) = fb_payload.base {
+        // Sum of:
+        // * 32 parent_beacon_block_root
+        // * 32 parent_hash
+        // * 32 prev_randao
+        // * 20 fee_recipient
+        // * 8 block_number
+        // * 8 gas_limit
+        // * 8 timestamp
+        // * 32 base_fee_per_gas
+        total_bytes += 172;
+
+        // Bytes field - variable length
+        total_bytes += base.extra_data.len();
+    }
+
+    // Diff, sum of:
+    // * 32 state_root
+    // * 32 receipts_root
+    // * 32 block_hash
+    // * 32 withdrawals_root
+    // * 256 logs_bloom
+    // * 8 gas_used
+    total_bytes += 392;
+    // Transactions - sum of all transaction bytes
+    for tx in &fb_payload.diff.transactions {
+        total_bytes += tx.len();
+    }
+    // Withdrawals - each withdrawal has fixed fields:
+    // index (8) + validator_index (8) + address (20) + amount (8)
+    total_bytes += 44 * fb_payload.diff.withdrawals.len();
+
+    // Metadata
+    total_bytes += estimate_json_value_size(&fb_payload.metadata);
+
+    total_bytes
+}
+
+/// Traverse the serde_json::Value to estimate its size without serializing it
+fn estimate_json_value_size(value: &Value) -> usize {
+    match value {
+        Value::Null => 4,    // "null"
+        Value::Bool(_) => 5, // "true" or "false"
+        Value::Number(n) => n.to_string().len(),
+        Value::String(s) => s.len() + 2, // +2 for quotes
+        Value::Array(arr) => {
+            let mut size = 2; // brackets []
+            for (i, v) in arr.iter().enumerate() {
+                if i > 0 {
+                    size += 1; // comma
+                }
+                size += estimate_json_value_size(v);
+            }
+            size
+        }
+        Value::Object(map) => {
+            let mut size = 2; // braces {}
+            for (i, (k, v)) in map.iter().enumerate() {
+                if i > 0 {
+                    size += 1; // comma
+                }
+                size += k.len() + 3; // key + quotes + colon
+                size += estimate_json_value_size(v);
+            }
+            size
+        }
+    }
+}


### PR DESCRIPTION
## 📝 Summary
Use the flashblock payload to correctly record the byte size

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
