### PR TITLE
fix: record num txs built with flashblocks enabled

### DIFF
--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -457,6 +457,7 @@ where
                     if block_cancel.is_cancelled() {
                         self.record_flashblocks_metrics(
                             &ctx,
+                            &info,
                             flashblocks_per_block,
                             &span,
                             "Payload building complete, channel closed or job cancelled",
@@ -512,6 +513,7 @@ where
                             if block_cancel.is_cancelled() {
                                 self.record_flashblocks_metrics(
                                     &ctx,
+                                    &info,
                                     flashblocks_per_block,
                                     &span,
                                     "Payload building complete, channel closed or job cancelled",
@@ -532,15 +534,6 @@ where
                             ctx.metrics
                                 .flashblock_num_tx_histogram
                                 .record(info.executed_transactions.len() as f64);
-
-                            if ctx.is_last_flashblock() {
-                                ctx.metrics
-                                    .payload_num_tx
-                                    .record(info.executed_transactions.len() as f64);
-                                ctx.metrics
-                                    .payload_num_tx_gauge
-                                    .set(info.executed_transactions.len() as f64);
-                            }
 
                             best_payload.set(new_payload.clone());
                             // Update bundle_state for next iteration
@@ -567,6 +560,7 @@ where
                 None => {
                     self.record_flashblocks_metrics(
                         &ctx,
+                        &info,
                         flashblocks_per_block,
                         &span,
                         "Payload building complete, channel closed or job cancelled",
@@ -581,6 +575,7 @@ where
     fn record_flashblocks_metrics(
         &self,
         ctx: &OpPayloadBuilderCtx<FlashblocksExtraCtx>,
+        info: &ExecutionInfo<ExtraExecutionInfo>,
         flashblocks_per_block: u64,
         span: &tracing::Span,
         message: &str,
@@ -592,6 +587,12 @@ where
         ctx.metrics
             .missing_flashblocks_count
             .record(flashblocks_per_block.saturating_sub(ctx.flashblock_index()) as f64);
+        ctx.metrics
+            .payload_num_tx
+            .record(info.executed_transactions.len() as f64);
+        ctx.metrics
+            .payload_num_tx_gauge
+            .set(info.executed_transactions.len() as f64);
 
         debug!(
             target: "payload_builder",

--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -300,13 +300,6 @@ where
             payload_id = fb_payload.payload_id.to_string(),
         );
 
-        ctx.metrics
-            .payload_num_tx
-            .record(info.executed_transactions.len() as f64);
-        ctx.metrics
-            .payload_num_tx_gauge
-            .set(info.executed_transactions.len() as f64);
-
         if ctx.attributes().no_tx_pool {
             info!(
                 target: "payload_builder",
@@ -320,6 +313,12 @@ where
             ctx.metrics
                 .total_block_built_gauge
                 .set(total_block_building_time);
+            ctx.metrics
+                .payload_num_tx
+                .record(info.executed_transactions.len() as f64);
+            ctx.metrics
+                .payload_num_tx_gauge
+                .set(info.executed_transactions.len() as f64);
 
             // return early since we don't need to build a block with transactions from the pool
             return Ok(());
@@ -533,6 +532,15 @@ where
                             ctx.metrics
                                 .flashblock_num_tx_histogram
                                 .record(info.executed_transactions.len() as f64);
+
+                            if ctx.is_last_flashblock() {
+                                ctx.metrics
+                                    .payload_num_tx
+                                    .record(info.executed_transactions.len() as f64);
+                                ctx.metrics
+                                    .payload_num_tx_gauge
+                                    .set(info.executed_transactions.len() as f64);
+                            }
 
                             best_payload.set(new_payload.clone());
                             // Update bundle_state for next iteration


### PR DESCRIPTION
## 📝 Summary
Change the location where we record the metrics for the number of txs in a block

## 💡 Motivation and Context
This wasn't being recorded correctly for flashblocks

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
