### PR TITLE
fix: override clap long version envs

### DIFF
--- a/crates/op-rbuilder/src/args/mod.rs
+++ b/crates/op-rbuilder/src/args/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     builders::BuilderMode,
-    metrics::{CARGO_PKG_VERSION, VERGEN_GIT_SHA},
+    metrics::{LONG_VERSION, SHORT_VERSION},
 };
 use clap_builder::{CommandFactory, FromArgMatches};
 pub use op::{FlashblocksArgs, OpRbuilderArgs, TelemetryArgs};
@@ -82,7 +82,8 @@ impl CliExt for Cli {
     /// Parses commands and overrides versions
     fn set_version() -> Self {
         let matches = Cli::command()
-            .version(format!("{CARGO_PKG_VERSION} ({VERGEN_GIT_SHA})"))
+            .version(SHORT_VERSION)
+            .long_version(LONG_VERSION)
             .about("Block builder designed for the Optimism stack")
             .author("Flashbots")
             .name("op-rbuilder")

--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -24,6 +24,22 @@ pub const VERGEN_CARGO_FEATURES: &str = env!("VERGEN_CARGO_FEATURES");
 /// The build profile name.
 pub const BUILD_PROFILE_NAME: &str = env!("OP_RBUILDER_BUILD_PROFILE");
 
+/// The short version information for op-rbuilder.
+pub const SHORT_VERSION: &str = env!("OP_RBUILDER_SHORT_VERSION");
+
+/// The long version information for op-rbuilder.
+pub const LONG_VERSION: &str = concat!(
+    env!("OP_RBUILDER_LONG_VERSION_0"),
+    "\n",
+    env!("OP_RBUILDER_LONG_VERSION_1"),
+    "\n",
+    env!("OP_RBUILDER_LONG_VERSION_2"),
+    "\n",
+    env!("OP_RBUILDER_LONG_VERSION_3"),
+    "\n",
+    env!("OP_RBUILDER_LONG_VERSION_4"),
+);
+
 pub const VERSION: VersionInfo = VersionInfo {
     version: CARGO_PKG_VERSION,
     build_timestamp: VERGEN_BUILD_TIMESTAMP,


### PR DESCRIPTION
## 📝 Summary

#52 introduced build time environment variables for extra metrics, similar to what is done in reth.
Clap long version (--version) configuration was not overridden and was using by default the one used by eth.
This PR is a fix to this by using the correct envs.
