### PR TITLE
feat: overwrite reth default cache directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6192,6 +6192,7 @@ dependencies = [
  "ctor",
  "dashmap 6.1.0",
  "derive_more",
+ "dirs-next",
  "eyre",
  "futures",
  "futures-util",

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ To enable metrics, set the `--metrics` flag like in [reth](https://reth.rs/run/m
 
 To see the full list of op-rbuilder metrics, see [`src/metrics.rs`](./crates/op-rbuilder/src/metrics.rs).
 
+Default `debug` level trace logs can be found at:
+
+- `~/.cache/op-rbuilder/logs` on Linux
+- `~/Library/Caches/op-rbuilder/logs` on macOS
+- `%localAppData%/op-rbuilder/logs` on Windows
+
 ## Integration Testing
 
 op-rbuilder has an integration test framework that runs the builder against mock engine api payloads and ensures that the builder produces valid blocks.

--- a/crates/op-rbuilder/Cargo.toml
+++ b/crates/op-rbuilder/Cargo.toml
@@ -137,6 +137,7 @@ ctor = { version = "0.4.2", optional = true }
 rlimit = { version = "0.10", optional = true }
 macros = { path = "src/tests/framework/macros", optional = true }
 testcontainers = "0.24.0"
+dirs-next = "2.0.0"
 
 [target.'cfg(unix)'.dependencies]
 tikv-jemallocator = { version = "0.6", optional = true }

--- a/crates/op-rbuilder/src/args/mod.rs
+++ b/crates/op-rbuilder/src/args/mod.rs
@@ -78,12 +78,17 @@ impl CliExt for Cli {
 
     /// Parses commands and overrides versions
     fn set_version() -> Self {
+        let logs_dir = dirs_next::cache_dir()
+            .map(|root| root.join("op-rbuilder/logs"))
+            .unwrap()
+            .into_os_string();
         let matches = Cli::command()
             .version(SHORT_VERSION)
             .long_version(LONG_VERSION)
             .about("Block builder designed for the Optimism stack")
             .author("Flashbots")
             .name("op-rbuilder")
+            .mut_arg("log_file_directory", |arg| arg.default_value(logs_dir))
             .get_matches();
         Cli::from_arg_matches(&matches).expect("Parsing args")
     }


### PR DESCRIPTION
## 📝 Summary

Close #232

Overwrite current `<CACHE_DIR>/reth/logs` directory for log files to `<CACHE_DIR>/op-rbuilder/logs` directory.
Still configurable with `--log.file.directory` arg.

## 💡 Motivation and Context

Using reth's `Cli`, we already inherit different tracing layers for logging. 
The default value for the file logger point to `<CACHE_DIR>/reth/logs`.
If running op-rbuilder with reth, this can mix cache files.

This PR correctly set the file log output. You can access by default debug level trace and access log at:
- `~/.cache/op-rbuilder/logs` on Linux
- `~/Library/Caches/op-rbuilder/logs` on macOS
- `%localAppData%/op-rbuilder/logs` on Windows

Additional file logging configuration (accessible with `--help`):
```
      --log.file.format <FORMAT>
          The format to use for logs written to the log file
          
          [default: terminal]

          Possible values:
          - json:     Represents JSON formatting for logs. This format outputs log records as JSON objects, making it suitable for structured logging
          - log-fmt:  Represents logfmt (key=value) formatting for logs. This format is concise and human-readable, typically used in command-line applications
          - terminal: Represents terminal-friendly formatting for logs

      --log.file.filter <FILTER>
          The filter to use for logs written to the log file
          
          [default: debug]

      --log.file.directory <PATH>
          The path to put log files in
          
          [default: <CACHE_DIR>/op-rbuilder/logs]

      --log.file.max-size <SIZE>
          The maximum size (in MB) of one log file
          
          [default: 200]

      --log.file.max-files <COUNT>
          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
          
          [default: 5]
```

The log file is still named `reth.log`, this open PR should make it configurable https://github.com/paradigmxyz/reth/pull/17883

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
