### PR TITLE
flag to determine if calculating state root

### DIFF
--- a/crates/op-rbuilder/src/args/op.rs
+++ b/crates/op-rbuilder/src/args/op.rs
@@ -142,6 +142,14 @@ pub struct FlashblocksArgs {
         env = "FLASHBLOCK_LEEWAY_TIME"
     )]
     pub flashblocks_leeway_time: u64,
+
+    /// Should we calculate state root for each flashblock
+    #[arg(
+        long = "flashblocks.calculate-state-root",
+        default_value = "true",
+        env = "FLASHBLOCKS_CALCULATE_STATE_ROOT"
+    )]
+    pub flashblocks_calculate_state_root: bool,
 }
 
 impl Default for FlashblocksArgs {

--- a/crates/op-rbuilder/src/builders/flashblocks/config.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/config.rs
@@ -28,6 +28,9 @@ pub struct FlashblocksConfig {
 
     /// Disables dynamic flashblocks number adjustment based on FCU arrival time
     pub fixed: bool,
+
+    /// Should we calculate state root for each flashblock
+    pub calculate_state_root: bool,
 }
 
 impl Default for FlashblocksConfig {
@@ -37,6 +40,7 @@ impl Default for FlashblocksConfig {
             interval: Duration::from_millis(250),
             leeway_time: Duration::from_millis(50),
             fixed: false,
+            calculate_state_root: true,
         }
     }
 }
@@ -56,11 +60,14 @@ impl TryFrom<OpRbuilderArgs> for FlashblocksConfig {
 
         let fixed = args.flashblocks.flashblocks_fixed;
 
+        let calculate_state_root = args.flashblocks.flashblocks_calculate_state_root;
+
         Ok(Self {
             ws_addr,
             interval,
             leeway_time,
             fixed,
+            calculate_state_root,
         })
     }
 }

--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -877,8 +877,8 @@ where
 
     if calculate_state_root {
         let state_provider = state.database.as_ref();
-        let _hashed_state = state_provider.hashed_post_state(execution_outcome.state());
-        let (_state_root, _trie_output) = {
+        hashed_state = state_provider.hashed_post_state(execution_outcome.state());
+        (state_root, trie_output) = {
             state
                 .database
                 .as_ref()
@@ -898,9 +898,6 @@ where
         ctx.metrics
             .state_root_calculation_gauge
             .set(state_root_calculation_time);
-        state_root = _state_root;
-        trie_output = _trie_output;
-        hashed_state = _hashed_state;
     }
 
     let mut requests_hash = None;

--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -301,8 +301,12 @@ where
             ctx.add_builder_tx(&mut info, &mut state, builder_tx_gas, message.clone());
         }
 
-        let (payload, fb_payload) =
-            build_block(&mut state, &ctx, &mut info, ctx.attributes().no_tx_pool)?;
+        let (payload, fb_payload) = build_block(
+            &mut state,
+            &ctx,
+            &mut info,
+            calculate_state_root || ctx.attributes().no_tx_pool, // need to calculate state root for CL sync
+        )?;
 
         best_payload.set(payload.clone());
         self.send_payload_to_engine(payload);

--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -227,12 +227,7 @@ where
 
         let chain_spec = self.client.chain_spec();
         let timestamp = config.attributes.timestamp();
-        let is_doing_historical_sync = timestamp < current_timestamp;
-        let calculate_state_root = if is_doing_historical_sync {
-            true
-        } else {
-            self.config.specific.calculate_state_root
-        };
+        let calculate_state_root = self.config.specific.calculate_state_root;
         let block_env_attributes = OpNextBlockEnvAttributes {
             timestamp,
             suggested_fee_recipient: config.attributes.suggested_fee_recipient(),
@@ -314,7 +309,7 @@ where
 
         best_payload.set(payload.clone());
         self.send_payload_to_engine(payload);
-        if !is_doing_historical_sync {
+        if !ctx.attributes().no_tx_pool {
             let flashblock_byte_size = self
                 .ws_pub
                 .publish(&fb_payload)

--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -301,7 +301,8 @@ where
             ctx.add_builder_tx(&mut info, &mut state, builder_tx_gas, message.clone());
         }
 
-        let (payload, fb_payload) = build_block(&mut state, &ctx, &mut info, true)?;
+        let (payload, fb_payload) =
+            build_block(&mut state, &ctx, &mut info, ctx.attributes().no_tx_pool)?;
 
         best_payload.set(payload.clone());
         self.send_payload_to_engine(payload);

--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -46,7 +46,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     ops::{Div, Rem},
     sync::{Arc, OnceLock},
-    time::{Instant, SystemTime, UNIX_EPOCH},
+    time::Instant,
 };
 use tokio::sync::{
     mpsc,
@@ -201,10 +201,6 @@ where
         best_payload: BlockCell<OpBuiltPayload>,
     ) -> Result<(), PayloadBuilderError> {
         let block_build_start_time = Instant::now();
-        let current_timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
         let BuildArguments {
             mut cached_reads,
             config,
@@ -309,6 +305,7 @@ where
 
         best_payload.set(payload.clone());
         self.send_payload_to_engine(payload);
+        // not emitting flashblock if no_tx_pool in FCU, it's just syncing
         if !ctx.attributes().no_tx_pool {
             let flashblock_byte_size = self
                 .ws_pub

--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -301,7 +301,7 @@ where
             ctx.add_builder_tx(&mut info, &mut state, builder_tx_gas, message.clone());
         }
 
-        let (payload, fb_payload) = build_block(&mut state, &ctx, &mut info, calculate_state_root)?;
+        let (payload, fb_payload) = build_block(&mut state, &ctx, &mut info, true)?;
 
         best_payload.set(payload.clone());
         self.send_payload_to_engine(payload);

--- a/crates/op-rbuilder/src/tests/flashblocks.rs
+++ b/crates/op-rbuilder/src/tests/flashblocks.rs
@@ -21,6 +21,7 @@ use crate::{
         flashblocks_block_time: 200,
         flashblocks_leeway_time: 100,
         flashblocks_fixed: false,
+        flashblocks_calculate_state_root: true,
     },
     ..Default::default()
 })]
@@ -89,6 +90,7 @@ async fn smoke_dynamic_base(rbuilder: LocalInstance) -> eyre::Result<()> {
         flashblocks_block_time: 200,
         flashblocks_leeway_time: 100,
         flashblocks_fixed: false,
+        flashblocks_calculate_state_root: true,
     },
     ..Default::default()
 })]
@@ -157,6 +159,7 @@ async fn smoke_dynamic_unichain(rbuilder: LocalInstance) -> eyre::Result<()> {
         flashblocks_block_time: 200,
         flashblocks_leeway_time: 50,
         flashblocks_fixed: true,
+        flashblocks_calculate_state_root: true,
     },
     ..Default::default()
 })]
@@ -225,6 +228,7 @@ async fn smoke_classic_unichain(rbuilder: LocalInstance) -> eyre::Result<()> {
         flashblocks_block_time: 200,
         flashblocks_leeway_time: 50,
         flashblocks_fixed: true,
+        flashblocks_calculate_state_root: true,
     },
     ..Default::default()
 })]
@@ -293,6 +297,7 @@ async fn smoke_classic_base(rbuilder: LocalInstance) -> eyre::Result<()> {
         flashblocks_block_time: 200,
         flashblocks_leeway_time: 100,
         flashblocks_fixed: false,
+        flashblocks_calculate_state_root: true,
     },
     ..Default::default()
 })]
@@ -363,6 +368,7 @@ async fn unichain_dynamic_with_lag(rbuilder: LocalInstance) -> eyre::Result<()> 
         flashblocks_block_time: 200,
         flashblocks_leeway_time: 0,
         flashblocks_fixed: false,
+        flashblocks_calculate_state_root: true,
     },
     ..Default::default()
 })]
@@ -430,6 +436,7 @@ async fn dynamic_with_full_block_lag(rbuilder: LocalInstance) -> eyre::Result<()
         flashblocks_block_time: 200,
         flashblocks_leeway_time: 100,
         flashblocks_fixed: false,
+        flashblocks_calculate_state_root: true,
     },
     ..Default::default()
 })]
@@ -525,6 +532,7 @@ async fn test_flashblock_min_filtering(rbuilder: LocalInstance) -> eyre::Result<
         flashblocks_block_time: 200,
         flashblocks_leeway_time: 100,
         flashblocks_fixed: false,
+        flashblocks_calculate_state_root: true,
     },
     ..Default::default()
 })]

--- a/crates/op-rbuilder/src/tests/flashblocks.rs
+++ b/crates/op-rbuilder/src/tests/flashblocks.rs
@@ -362,6 +362,7 @@ async fn test_flashblock_max_filtering(rbuilder: LocalInstance) -> eyre::Result<
         flashblocks_block_time: 200,
         flashblocks_leeway_time: 100,
         flashblocks_fixed: false,
+        flashblocks_calculate_state_root: true,
     },
     ..Default::default()
 })]


### PR DESCRIPTION
## 📝 Summary
On Base Mainnet we don't calculate state root per flashblock, we control this with a flag. It only calculates state root when doing historical sync as it's necessary.  

For calculate state root, it does via rollup-boost and op-geth. https://github.com/flashbots/rollup-boost/pull/381


<!--- A general summary of your changes -->

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
