### PR TITLE
Improve best tx iterator

### DIFF
--- a/crates/op-rbuilder/src/builders/context.rs
+++ b/crates/op-rbuilder/src/builders/context.rs
@@ -326,7 +326,7 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
         &self,
         info: &mut ExecutionInfo<E>,
         state: &mut State<DB>,
-        mut best_txs: impl PayloadTxsBounds,
+        best_txs: &mut impl PayloadTxsBounds,
         block_gas_limit: u64,
         block_da_limit: Option<u64>,
     ) -> Result<Option<()>, PayloadBuilderError>

--- a/crates/op-rbuilder/src/builders/flashblocks/best_txs.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/best_txs.rs
@@ -1,14 +1,7 @@
-use std::{
-    collections::{BTreeMap, VecDeque},
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
-};
-
-use alloy_primitives::Address;
+use alloy_primitives::{Address, TxHash};
 use reth_payload_util::PayloadTransactions;
 use reth_transaction_pool::PoolTransaction;
+use std::collections::HashSet;
 use tracing::debug;
 
 use crate::tx::MaybeFlashblockFilter;
@@ -19,8 +12,10 @@ where
     I: PayloadTransactions<Transaction = T>,
 {
     inner: I,
-    current_flashblock_number: Arc<AtomicU64>,
-    early_transactions: BTreeMap<u64, VecDeque<T>>,
+    current_flashblock_number: u64,
+    // Transactions that were already commited to the state. Using them again would cause NonceTooLow
+    // so we skip them
+    commited_transactions: HashSet<TxHash>,
 }
 
 impl<T, I> BestFlashblocksTxs<T, I>
@@ -28,12 +23,24 @@ where
     T: PoolTransaction,
     I: PayloadTransactions<Transaction = T>,
 {
-    pub fn new(inner: I, current_flashblock_number: Arc<AtomicU64>) -> Self {
+    pub fn new(inner: I) -> Self {
         Self {
             inner,
-            current_flashblock_number,
-            early_transactions: Default::default(),
+            current_flashblock_number: 0,
+            commited_transactions: Default::default(),
         }
+    }
+
+    /// Replaces current iterator with new one. We use it on new flashblock building, to refresh
+    /// priority boundaries
+    pub fn refresh_iterator(&mut self, inner: I, current_flashblock_number: u64) {
+        self.inner = inner;
+        self.current_flashblock_number = current_flashblock_number;
+    }
+
+    /// Remove transaction from next iteration and it already in the state
+    pub fn mark_commited(&mut self, txs: Vec<TxHash>) {
+        self.commited_transactions.extend(txs);
     }
 }
 
@@ -46,66 +53,30 @@ where
 
     fn next(&mut self, ctx: ()) -> Option<Self::Transaction> {
         loop {
-            let flashblock_number = self.current_flashblock_number.load(Ordering::Relaxed);
-
-            // Check for new transactions that can be executed with the higher flashblock number
-            while let Some((&min_flashblock, _)) = self.early_transactions.first_key_value() {
-                if min_flashblock > flashblock_number {
-                    break;
-                }
-
-                if let Some(mut txs) = self.early_transactions.remove(&min_flashblock) {
-                    while let Some(tx) = txs.pop_front() {
-                        // Re-check max flashblock number just in case
-                        if let Some(max) = tx.flashblock_number_max() {
-                            if flashblock_number > max {
-                                debug!(
-                                    target: "payload_builder",
-                                    sender = ?tx.sender(),
-                                    nonce = tx.nonce(),
-                                    current_flashblock = flashblock_number,
-                                    max_flashblock = max,
-                                    "Bundle flashblock max exceeded"
-                                );
-                                self.mark_invalid(tx.sender(), tx.nonce());
-                                continue;
-                            }
-                        }
-
-                        // The vecdeque isn't modified in place so we need to replace it
-                        if !txs.is_empty() {
-                            self.early_transactions.insert(min_flashblock, txs);
-                        }
-
-                        return Some(tx);
-                    }
-                }
-            }
-
             let tx = self.inner.next(ctx)?;
+            // Skip transaction we already included
+            if self.commited_transactions.contains(tx.hash()) {
+                continue;
+            }
 
             let flashblock_number_min = tx.flashblock_number_min();
             let flashblock_number_max = tx.flashblock_number_max();
 
             // Check min flashblock requirement
             if let Some(min) = flashblock_number_min {
-                if flashblock_number < min {
-                    self.early_transactions
-                        .entry(min)
-                        .or_default()
-                        .push_back(tx);
+                if self.current_flashblock_number < min {
                     continue;
                 }
             }
 
             // Check max flashblock requirement
             if let Some(max) = flashblock_number_max {
-                if flashblock_number > max {
+                if self.current_flashblock_number > max {
                     debug!(
                         target: "payload_builder",
                         sender = ?tx.sender(),
                         nonce = tx.nonce(),
-                        current_flashblock = flashblock_number,
+                        current_flashblock = self.current_flashblock_number,
                         max_flashblock = max,
                         "Bundle flashblock max exceeded"
                     );
@@ -118,15 +89,144 @@ where
         }
     }
 
+    /// Proxy to inner iterator
     fn mark_invalid(&mut self, sender: Address, nonce: u64) {
         self.inner.mark_invalid(sender, nonce);
+    }
+}
 
-        // Clear early_transactions from this sender with a greater nonce as
-        // these transactions now will not execute because there would be a
-        // nonce gap
-        self.early_transactions.retain(|_, txs| {
-            txs.retain(|tx| !(tx.sender() == sender && tx.nonce() > nonce));
-            !txs.is_empty()
-        });
+#[cfg(test)]
+mod tests {
+    use crate::{
+        builders::flashblocks::best_txs::BestFlashblocksTxs,
+        mock_tx::{MockFbTransaction, MockFbTransactionFactory},
+    };
+    use alloy_consensus::Transaction;
+    use reth_payload_util::{BestPayloadTransactions, PayloadTransactions};
+    use reth_transaction_pool::{pool::PendingPool, CoinbaseTipOrdering, PoolTransaction};
+    use std::sync::Arc;
+
+    #[test]
+    fn test_simple_case() {
+        let mut pool = PendingPool::new(CoinbaseTipOrdering::<MockFbTransaction>::default());
+        let mut f = MockFbTransactionFactory::default();
+
+        // Add 3 regular transaction
+        let tx_1 = f.create_eip1559();
+        let tx_2 = f.create_eip1559();
+        let tx_3 = f.create_eip1559();
+        pool.add_transaction(Arc::new(tx_1), 0);
+        pool.add_transaction(Arc::new(tx_2), 0);
+        pool.add_transaction(Arc::new(tx_3), 0);
+
+        // Create iterator
+        let mut iterator = BestFlashblocksTxs::new(BestPayloadTransactions::new(pool.best()));
+        // ### First flashblock
+        iterator.refresh_iterator(BestPayloadTransactions::new(pool.best()), 0);
+        // Accept first tx
+        let tx1 = iterator.next(()).unwrap();
+        // Invalidate second tx
+        let tx2 = iterator.next(()).unwrap();
+        iterator.mark_invalid(tx2.sender(), tx2.nonce());
+        // Accept third tx
+        let tx3 = iterator.next(()).unwrap();
+        // Check that it's empty
+        assert!(iterator.next(()).is_none(), "Iterator should be empty");
+        // Mark transaction as commited
+        iterator.mark_commited(vec![*tx1.hash(), *tx3.hash()]);
+
+        // ### Second flashblock
+        // It should not return txs 1 and 3, but should return 2
+        iterator.refresh_iterator(BestPayloadTransactions::new(pool.best()), 1);
+        let tx2 = iterator.next(()).unwrap();
+        // Check that it's empty
+        assert!(iterator.next(()).is_none(), "Iterator should be empty");
+        // Mark transaction as commited
+        iterator.mark_commited(vec![*tx2.hash()]);
+
+        // ### Third flashblock
+        iterator.refresh_iterator(BestPayloadTransactions::new(pool.best()), 2);
+        // Check that it's empty
+        assert!(iterator.next(()).is_none(), "Iterator should be empty");
+    }
+
+    /// Test bundle cases
+    /// We won't mark transactions as commited to test that boundaries are respected
+    #[test]
+    fn test_bundle_case() {
+        let mut pool = PendingPool::new(CoinbaseTipOrdering::<MockFbTransaction>::default());
+        let mut f = MockFbTransactionFactory::default();
+
+        // Add 4 fb transaction
+        let tx_1 = f.create_legacy_fb(None, None);
+        let tx_1_hash = *tx_1.hash();
+        let tx_2 = f.create_legacy_fb(None, Some(1));
+        let tx_2_hash = *tx_2.hash();
+        let tx_3 = f.create_legacy_fb(Some(1), None);
+        let tx_3_hash = *tx_3.hash();
+        let tx_4 = f.create_legacy_fb(Some(2), Some(3));
+        let tx_4_hash = *tx_4.hash();
+        pool.add_transaction(Arc::new(tx_1), 0);
+        pool.add_transaction(Arc::new(tx_2), 0);
+        pool.add_transaction(Arc::new(tx_3), 0);
+        pool.add_transaction(Arc::new(tx_4), 0);
+
+        // Create iterator
+        let mut iterator = BestFlashblocksTxs::new(BestPayloadTransactions::new(pool.best()));
+        // ### First flashblock
+        // should contain txs 1 and 2
+        iterator.refresh_iterator(BestPayloadTransactions::new(pool.best()), 0);
+        let tx1 = iterator.next(()).unwrap();
+        assert_eq!(tx1.hash(), &tx_1_hash);
+        let tx2 = iterator.next(()).unwrap();
+        assert_eq!(tx2.hash(), &tx_2_hash);
+        // Check that it's empty
+        assert!(iterator.next(()).is_none(), "Iterator should be empty");
+
+        // ### Second flashblock
+        // should contain txs 1, 2, and 3
+        iterator.refresh_iterator(BestPayloadTransactions::new(pool.best()), 1);
+        let tx1 = iterator.next(()).unwrap();
+        assert_eq!(tx1.hash(), &tx_1_hash);
+        let tx2 = iterator.next(()).unwrap();
+        assert_eq!(tx2.hash(), &tx_2_hash);
+        let tx3 = iterator.next(()).unwrap();
+        assert_eq!(tx3.hash(), &tx_3_hash);
+        // Check that it's empty
+        assert!(iterator.next(()).is_none(), "Iterator should be empty");
+
+        // ### Third flashblock
+        // should contain txs 1, 3, and 4
+        iterator.refresh_iterator(BestPayloadTransactions::new(pool.best()), 2);
+        let tx1 = iterator.next(()).unwrap();
+        assert_eq!(tx1.hash(), &tx_1_hash);
+        let tx3 = iterator.next(()).unwrap();
+        assert_eq!(tx3.hash(), &tx_3_hash);
+        let tx4 = iterator.next(()).unwrap();
+        assert_eq!(tx4.hash(), &tx_4_hash);
+        // Check that it's empty
+        assert!(iterator.next(()).is_none(), "Iterator should be empty");
+
+        // ### Forth flashblock
+        // should contain txs 1, 3, and 4
+        iterator.refresh_iterator(BestPayloadTransactions::new(pool.best()), 3);
+        let tx1 = iterator.next(()).unwrap();
+        assert_eq!(tx1.hash(), &tx_1_hash);
+        let tx3 = iterator.next(()).unwrap();
+        assert_eq!(tx3.hash(), &tx_3_hash);
+        let tx4 = iterator.next(()).unwrap();
+        assert_eq!(tx4.hash(), &tx_4_hash);
+        // Check that it's empty
+        assert!(iterator.next(()).is_none(), "Iterator should be empty");
+
+        // ### Fifth flashblock
+        // should contain txs 1 and 3
+        iterator.refresh_iterator(BestPayloadTransactions::new(pool.best()), 4);
+        let tx1 = iterator.next(()).unwrap();
+        assert_eq!(tx1.hash(), &tx_1_hash);
+        let tx3 = iterator.next(()).unwrap();
+        assert_eq!(tx3.hash(), &tx_3_hash);
+        // Check that it's empty
+        assert!(iterator.next(()).is_none(), "Iterator should be empty");
     }
 }

--- a/crates/op-rbuilder/src/builders/standard/payload.rs
+++ b/crates/op-rbuilder/src/builders/standard/payload.rs
@@ -404,7 +404,7 @@ impl<Txs: PayloadTxsBounds> OpBuilder<'_, Txs> {
 
         if !ctx.attributes().no_tx_pool {
             let best_txs_start_time = Instant::now();
-            let best_txs = best(ctx.best_transaction_attributes());
+            let mut best_txs = best(ctx.best_transaction_attributes());
             let transaction_pool_fetch_time = best_txs_start_time.elapsed();
             ctx.metrics
                 .transaction_pool_fetch_duration
@@ -417,7 +417,7 @@ impl<Txs: PayloadTxsBounds> OpBuilder<'_, Txs> {
                 .execute_best_transactions(
                     &mut info,
                     state,
-                    best_txs,
+                    &mut best_txs,
                     block_gas_limit,
                     block_da_limit,
                 )?

--- a/crates/op-rbuilder/src/lib.rs
+++ b/crates/op-rbuilder/src/lib.rs
@@ -10,5 +10,7 @@ pub mod traits;
 pub mod tx;
 pub mod tx_signer;
 
+#[cfg(test)]
+pub mod mock_tx;
 #[cfg(any(test, feature = "testing"))]
 pub mod tests;

--- a/crates/op-rbuilder/src/mock_tx.rs
+++ b/crates/op-rbuilder/src/mock_tx.rs
@@ -1,0 +1,453 @@
+use crate::tx::MaybeFlashblockFilter;
+use alloy_consensus::{
+    error::ValueError, transaction::Recovered, EthereumTxEnvelope, TxEip4844, TxEip4844WithSidecar,
+    TxType,
+};
+use alloy_eips::{
+    eip2930::AccessList,
+    eip4844::{env_settings::KzgSettings, BlobTransactionValidationError},
+    eip7594::BlobTransactionSidecarVariant,
+    eip7702::SignedAuthorization,
+    Typed2718,
+};
+use alloy_primitives::{Address, Bytes, TxHash, TxKind, B256, U256};
+use reth::primitives::TransactionSigned;
+use reth_primitives_traits::{InMemorySize, SignedTransaction};
+use reth_transaction_pool::{
+    identifier::TransactionId,
+    test_utils::{MockTransaction, MockTransactionFactory},
+    EthBlobTransactionSidecar, EthPoolTransaction, PoolTransaction, TransactionOrigin,
+    ValidPoolTransaction,
+};
+use std::{sync::Arc, time::Instant};
+
+/// A factory for creating and managing various types of mock transactions.
+#[derive(Debug, Default)]
+pub struct MockFbTransactionFactory {
+    pub(crate) factory: MockTransactionFactory,
+}
+
+// === impl MockTransactionFactory ===
+
+impl MockFbTransactionFactory {
+    /// Generates a transaction ID for the given [`MockTransaction`].
+    pub fn tx_id(&mut self, tx: &MockFbTransaction) -> TransactionId {
+        self.factory.tx_id(&tx.inner)
+    }
+
+    /// Validates a [`MockTransaction`] and returns a [`MockValidFbTx`].
+    pub fn validated(&mut self, transaction: MockFbTransaction) -> MockValidFbTx {
+        self.validated_with_origin(TransactionOrigin::External, transaction)
+    }
+
+    /// Validates a [`MockTransaction`] and returns a shared [`Arc<MockValidFbTx>`].
+    pub fn validated_arc(&mut self, transaction: MockFbTransaction) -> Arc<MockValidFbTx> {
+        Arc::new(self.validated(transaction))
+    }
+
+    /// Converts the transaction into a validated transaction with a specified origin.
+    pub fn validated_with_origin(
+        &mut self,
+        origin: TransactionOrigin,
+        transaction: MockFbTransaction,
+    ) -> MockValidFbTx {
+        MockValidFbTx {
+            propagate: false,
+            transaction_id: self.tx_id(&transaction),
+            transaction,
+            timestamp: Instant::now(),
+            origin,
+            authority_ids: None,
+        }
+    }
+
+    /// Creates a validated legacy [`MockTransaction`].
+    pub fn create_legacy(&mut self) -> MockValidFbTx {
+        self.validated(MockFbTransaction {
+            inner: MockTransaction::legacy(),
+            reverted_hashes: None,
+            flashblock_number_max: None,
+            flashblock_number_min: None,
+        })
+    }
+
+    /// Creates a validated legacy [`MockTransaction`].
+    pub fn create_legacy_fb(&mut self, min: Option<u64>, max: Option<u64>) -> MockValidFbTx {
+        self.validated(MockFbTransaction {
+            inner: MockTransaction::legacy(),
+            reverted_hashes: None,
+            flashblock_number_max: max,
+            flashblock_number_min: min,
+        })
+    }
+
+    /// Creates a validated EIP-1559 [`MockTransaction`].
+    pub fn create_eip1559(&mut self) -> MockValidFbTx {
+        self.validated(MockFbTransaction {
+            inner: MockTransaction::eip1559(),
+            reverted_hashes: None,
+            flashblock_number_max: None,
+            flashblock_number_min: None,
+        })
+    }
+
+    /// Creates a validated EIP-4844 [`MockTransaction`].
+    pub fn create_eip4844(&mut self) -> MockValidFbTx {
+        self.validated(MockFbTransaction {
+            inner: MockTransaction::eip4844(),
+            reverted_hashes: None,
+            flashblock_number_max: None,
+            flashblock_number_min: None,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct MockFbTransaction {
+    pub inner: MockTransaction,
+    /// reverted hashes for the transaction. If the transaction is a bundle,
+    /// this is the list of hashes of the transactions that reverted. If the
+    /// transaction is not a bundle, this is `None`.
+    pub reverted_hashes: Option<Vec<B256>>,
+
+    pub flashblock_number_min: Option<u64>,
+    pub flashblock_number_max: Option<u64>,
+}
+
+/// A validated transaction in the transaction pool, using [`MockTransaction`] as the transaction
+/// type.
+///
+/// This type is an alias for [`ValidPoolTransaction<MockTransaction>`].
+pub type MockValidFbTx = ValidPoolTransaction<MockFbTransaction>;
+
+impl PoolTransaction for MockFbTransaction {
+    type TryFromConsensusError = ValueError<EthereumTxEnvelope<TxEip4844>>;
+
+    type Consensus = TransactionSigned;
+
+    type Pooled = PooledTransactionVariant;
+
+    fn into_consensus(self) -> Recovered<Self::Consensus> {
+        self.inner.into()
+    }
+
+    fn from_pooled(pooled: Recovered<Self::Pooled>) -> Self {
+        Self {
+            inner: pooled.into(),
+            reverted_hashes: None,
+            flashblock_number_min: None,
+            flashblock_number_max: None,
+        }
+    }
+
+    fn hash(&self) -> &TxHash {
+        self.inner.get_hash()
+    }
+
+    fn sender(&self) -> Address {
+        *self.inner.get_sender()
+    }
+
+    fn sender_ref(&self) -> &Address {
+        self.inner.get_sender()
+    }
+
+    // Having `get_cost` from `make_setters_getters` would be cleaner but we didn't
+    // want to also generate the error-prone cost setters. For now cost should be
+    // correct at construction and auto-updated per field update via `update_cost`,
+    // not to be manually set.
+    fn cost(&self) -> &U256 {
+        match &self.inner {
+            MockTransaction::Legacy { cost, .. }
+            | MockTransaction::Eip2930 { cost, .. }
+            | MockTransaction::Eip1559 { cost, .. }
+            | MockTransaction::Eip4844 { cost, .. }
+            | MockTransaction::Eip7702 { cost, .. } => cost,
+        }
+    }
+
+    /// Returns the encoded length of the transaction.
+    fn encoded_length(&self) -> usize {
+        self.inner.size()
+    }
+}
+
+impl InMemorySize for MockFbTransaction {
+    fn size(&self) -> usize {
+        *self.inner.get_size()
+    }
+}
+
+impl Typed2718 for MockFbTransaction {
+    fn ty(&self) -> u8 {
+        match self.inner {
+            MockTransaction::Legacy { .. } => TxType::Legacy.into(),
+            MockTransaction::Eip1559 { .. } => TxType::Eip1559.into(),
+            MockTransaction::Eip4844 { .. } => TxType::Eip4844.into(),
+            MockTransaction::Eip2930 { .. } => TxType::Eip2930.into(),
+            MockTransaction::Eip7702 { .. } => TxType::Eip7702.into(),
+        }
+    }
+}
+
+impl alloy_consensus::Transaction for MockFbTransaction {
+    fn chain_id(&self) -> Option<u64> {
+        match &self.inner {
+            MockTransaction::Legacy { chain_id, .. } => *chain_id,
+            MockTransaction::Eip1559 { chain_id, .. }
+            | MockTransaction::Eip4844 { chain_id, .. }
+            | MockTransaction::Eip2930 { chain_id, .. }
+            | MockTransaction::Eip7702 { chain_id, .. } => Some(*chain_id),
+        }
+    }
+
+    fn nonce(&self) -> u64 {
+        *self.inner.get_nonce()
+    }
+
+    fn gas_limit(&self) -> u64 {
+        *self.inner.get_gas_limit()
+    }
+
+    fn gas_price(&self) -> Option<u128> {
+        match &self.inner {
+            MockTransaction::Legacy { gas_price, .. }
+            | MockTransaction::Eip2930 { gas_price, .. } => Some(*gas_price),
+            _ => None,
+        }
+    }
+
+    fn max_fee_per_gas(&self) -> u128 {
+        match &self.inner {
+            MockTransaction::Legacy { gas_price, .. }
+            | MockTransaction::Eip2930 { gas_price, .. } => *gas_price,
+            MockTransaction::Eip1559 {
+                max_fee_per_gas, ..
+            }
+            | MockTransaction::Eip4844 {
+                max_fee_per_gas, ..
+            }
+            | MockTransaction::Eip7702 {
+                max_fee_per_gas, ..
+            } => *max_fee_per_gas,
+        }
+    }
+
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        match &self.inner {
+            MockTransaction::Legacy { .. } | MockTransaction::Eip2930 { .. } => None,
+            MockTransaction::Eip1559 {
+                max_priority_fee_per_gas,
+                ..
+            }
+            | MockTransaction::Eip4844 {
+                max_priority_fee_per_gas,
+                ..
+            }
+            | MockTransaction::Eip7702 {
+                max_priority_fee_per_gas,
+                ..
+            } => Some(*max_priority_fee_per_gas),
+        }
+    }
+
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        match &self.inner {
+            MockTransaction::Eip4844 {
+                max_fee_per_blob_gas,
+                ..
+            } => Some(*max_fee_per_blob_gas),
+            _ => None,
+        }
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        match &self.inner {
+            MockTransaction::Legacy { gas_price, .. }
+            | MockTransaction::Eip2930 { gas_price, .. } => *gas_price,
+            MockTransaction::Eip1559 {
+                max_priority_fee_per_gas,
+                ..
+            }
+            | MockTransaction::Eip4844 {
+                max_priority_fee_per_gas,
+                ..
+            }
+            | MockTransaction::Eip7702 {
+                max_priority_fee_per_gas,
+                ..
+            } => *max_priority_fee_per_gas,
+        }
+    }
+
+    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
+        base_fee.map_or_else(
+            || self.max_fee_per_gas(),
+            |base_fee| {
+                // if the tip is greater than the max priority fee per gas, set it to the max
+                // priority fee per gas + base fee
+                let tip = self.max_fee_per_gas().saturating_sub(base_fee as u128);
+                if let Some(max_tip) = self.max_priority_fee_per_gas() {
+                    if tip > max_tip {
+                        max_tip + base_fee as u128
+                    } else {
+                        // otherwise return the max fee per gas
+                        self.max_fee_per_gas()
+                    }
+                } else {
+                    self.max_fee_per_gas()
+                }
+            },
+        )
+    }
+
+    fn is_dynamic_fee(&self) -> bool {
+        !matches!(
+            self.inner,
+            MockTransaction::Legacy { .. } | MockTransaction::Eip2930 { .. }
+        )
+    }
+
+    fn kind(&self) -> TxKind {
+        match &self.inner {
+            MockTransaction::Legacy { to, .. }
+            | MockTransaction::Eip1559 { to, .. }
+            | MockTransaction::Eip2930 { to, .. } => *to,
+            MockTransaction::Eip4844 { to, .. } | MockTransaction::Eip7702 { to, .. } => {
+                TxKind::Call(*to)
+            }
+        }
+    }
+
+    fn is_create(&self) -> bool {
+        match &self.inner {
+            MockTransaction::Legacy { to, .. }
+            | MockTransaction::Eip1559 { to, .. }
+            | MockTransaction::Eip2930 { to, .. } => to.is_create(),
+            MockTransaction::Eip4844 { .. } | MockTransaction::Eip7702 { .. } => false,
+        }
+    }
+
+    fn value(&self) -> U256 {
+        match &self.inner {
+            MockTransaction::Legacy { value, .. }
+            | MockTransaction::Eip1559 { value, .. }
+            | MockTransaction::Eip2930 { value, .. }
+            | MockTransaction::Eip4844 { value, .. }
+            | MockTransaction::Eip7702 { value, .. } => *value,
+        }
+    }
+
+    fn input(&self) -> &Bytes {
+        self.inner.get_input()
+    }
+
+    fn access_list(&self) -> Option<&AccessList> {
+        match &self.inner {
+            MockTransaction::Legacy { .. } => None,
+            MockTransaction::Eip1559 {
+                access_list: accesslist,
+                ..
+            }
+            | MockTransaction::Eip4844 {
+                access_list: accesslist,
+                ..
+            }
+            | MockTransaction::Eip2930 {
+                access_list: accesslist,
+                ..
+            }
+            | MockTransaction::Eip7702 {
+                access_list: accesslist,
+                ..
+            } => Some(accesslist),
+        }
+    }
+
+    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        match &self.inner {
+            MockTransaction::Eip4844 {
+                blob_versioned_hashes,
+                ..
+            } => Some(blob_versioned_hashes),
+            _ => None,
+        }
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        match &self.inner {
+            MockTransaction::Eip7702 {
+                authorization_list, ..
+            } => Some(authorization_list),
+            _ => None,
+        }
+    }
+}
+
+impl EthPoolTransaction for MockFbTransaction {
+    fn take_blob(&mut self) -> EthBlobTransactionSidecar {
+        match &self.inner {
+            MockTransaction::Eip4844 { sidecar, .. } => {
+                EthBlobTransactionSidecar::Present(sidecar.clone())
+            }
+            _ => EthBlobTransactionSidecar::None,
+        }
+    }
+
+    fn try_into_pooled_eip4844(
+        self,
+        sidecar: Arc<BlobTransactionSidecarVariant>,
+    ) -> Option<Recovered<Self::Pooled>> {
+        let (tx, signer) = self.into_consensus().into_parts();
+        tx.try_into_pooled_eip4844(Arc::unwrap_or_clone(sidecar))
+            .map(|tx| tx.with_signer(signer))
+            .ok()
+    }
+
+    fn try_from_eip4844(
+        tx: Recovered<Self::Consensus>,
+        sidecar: BlobTransactionSidecarVariant,
+    ) -> Option<Self> {
+        let (tx, signer) = tx.into_parts();
+        tx.try_into_pooled_eip4844(sidecar)
+            .map(|tx| tx.with_signer(signer))
+            .ok()
+            .map(Self::from_pooled)
+    }
+
+    fn validate_blob(
+        &self,
+        _blob: &BlobTransactionSidecarVariant,
+        _settings: &KzgSettings,
+    ) -> Result<(), alloy_eips::eip4844::BlobTransactionValidationError> {
+        match &self.inner {
+            MockTransaction::Eip4844 { .. } => Ok(()),
+            _ => Err(BlobTransactionValidationError::NotBlobTransaction(
+                self.inner.tx_type(),
+            )),
+        }
+    }
+}
+
+pub type PooledTransactionVariant =
+    alloy_consensus::EthereumTxEnvelope<TxEip4844WithSidecar<BlobTransactionSidecarVariant>>;
+
+impl MaybeFlashblockFilter for MockFbTransaction {
+    fn with_flashblock_number_min(mut self, flashblock_number_min: Option<u64>) -> Self {
+        self.flashblock_number_min = flashblock_number_min;
+        self
+    }
+
+    fn with_flashblock_number_max(mut self, flashblock_number_max: Option<u64>) -> Self {
+        self.flashblock_number_max = flashblock_number_max;
+        self
+    }
+
+    fn flashblock_number_min(&self) -> Option<u64> {
+        self.flashblock_number_min
+    }
+
+    fn flashblock_number_max(&self) -> Option<u64> {
+        self.flashblock_number_max
+    }
+}

--- a/crates/op-rbuilder/src/tx.rs
+++ b/crates/op-rbuilder/src/tx.rs
@@ -1,5 +1,3 @@
-use std::{borrow::Cow, sync::Arc};
-
 use alloy_consensus::{conditional::BlockConditionalAttributes, BlobTransactionValidationError};
 use alloy_eips::{eip7594::BlobTransactionSidecarVariant, eip7702::SignedAuthorization, Typed2718};
 use alloy_primitives::{Address, Bytes, TxHash, TxKind, B256, U256};
@@ -12,6 +10,7 @@ use reth_optimism_txpool::{
 use reth_primitives::{kzg::KzgSettings, Recovered};
 use reth_primitives_traits::InMemorySize;
 use reth_transaction_pool::{EthBlobTransactionSidecar, EthPoolTransaction, PoolTransaction};
+use std::{borrow::Cow, sync::Arc};
 
 pub trait FBPoolTransaction:
     MaybeRevertingTransaction + OpPooledTx + MaybeFlashblockFilter


### PR DESCRIPTION
## 📝 Summary

I removed bundle tx preservation. right now we will fetch bundle transactions from tx pool every time and check min/max flashblock

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
