### PR TITLE
chore: update op-rbuilder ci for prefixed tagging

### DIFF
--- a/.github/workflows/op_rbuilder_checks.yaml
+++ b/.github/workflows/op_rbuilder_checks.yaml
@@ -1,4 +1,4 @@
-name: Checks
+name: "[op-rbuilder] Checks"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/op_rbuilder_release.yaml
+++ b/.github/workflows/op_rbuilder_release.yaml
@@ -1,4 +1,4 @@
-name: Release Optimism
+name: "[op-rbuilder] Release"
 
 on:
   push:

--- a/.github/workflows/op_rbuilder_release.yaml
+++ b/.github/workflows/op_rbuilder_release.yaml
@@ -42,7 +42,7 @@ jobs:
         id: extract_version
         run: |
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            VERSION="${GITHUB_REF#refs/tags/}"
+            VERSION="${GITHUB_REF#refs/tags/op-rbuilder/}"
           else
             VERSION="$(echo ${GITHUB_SHA} | cut -c1-7)"
           fi

--- a/.github/workflows/tdx_quote_provider_checks.yaml
+++ b/.github/workflows/tdx_quote_provider_checks.yaml
@@ -1,4 +1,4 @@
-name: TDX Quote Provider CI
+name: [tdx-quote-provider] Checks
 
 on:
   push:

--- a/.github/workflows/tdx_quote_provider_release.yaml
+++ b/.github/workflows/tdx_quote_provider_release.yaml
@@ -1,4 +1,4 @@
-name: Release TDX Quote Provider
+name: [tdx-quote-provider] Release
 
 on:
   push:


### PR DESCRIPTION
## 📝 Summary

No-op changes mostly.  Renamed workflows, and fixed the release workflow for `op-rbuilder` to strip the `op-rbuilder/` prefix from the tag when deriving the version.

## 💡 Motivation and Context

We want good unambiguous tags and meaningful version strings.
