### PR TITLE
fix: release name

### DIFF
--- a/.github/workflows/op_rbuilder_release.yaml
+++ b/.github/workflows/op_rbuilder_release.yaml
@@ -114,7 +114,7 @@ jobs:
     needs: [extract-version, build-binary]
     runs-on: warp-ubuntu-latest-x64-16x
     env:
-      VERSION: op-${{ needs.extract-version.outputs.VERSION }}
+      VERSION: op-rbuilder/${{ needs.extract-version.outputs.VERSION }}
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## 📝 Summary

Prepend `op-rbuilder/` (instead of `op-`) to `op-rbuilder'` release names