### PR TITLE
add metrics to track gas used by reverting txs

### DIFF
--- a/crates/op-rbuilder/src/builders/context.rs
+++ b/crates/op-rbuilder/src/builders/context.rs
@@ -325,6 +325,7 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
         let mut num_txs_simulated_success = 0;
         let mut num_txs_simulated_fail = 0;
         let mut num_bundles_reverted = 0;
+        let mut reverted_gas_used = 0;
         let base_fee = self.base_fee();
         let tx_da_limit = self.da_config.max_da_tx_size();
         let mut evm = self.evm_config.evm_with_env(&mut *db, self.evm_env.clone());
@@ -442,7 +443,7 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
                     }
                     // this is an error that we should treat as fatal for this attempt
                     log_txn(TxnExecutionResult::EvmError);
-                    return Err(PayloadBuilderError::EvmExecutionError(Box::new(err)));
+                    return Err(PayloadBuilderError::evm(err));
                 }
             };
 
@@ -469,8 +470,11 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
             if result.is_success() {
                 log_txn(TxnExecutionResult::Success);
                 num_txs_simulated_success += 1;
+                self.metrics.successful_tx_gas_used.record(gas_used as f64);
             } else {
                 num_txs_simulated_fail += 1;
+                reverted_gas_used += gas_used as i32;
+                self.metrics.reverted_tx_gas_used.record(gas_used as f64);
                 if is_bundle_tx {
                     num_bundles_reverted += 1;
                 }
@@ -530,6 +534,7 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
             num_txs_simulated_success,
             num_txs_simulated_fail,
             num_bundles_reverted,
+            reverted_gas_used,
         );
 
         debug!(

--- a/crates/op-rbuilder/src/builders/context.rs
+++ b/crates/op-rbuilder/src/builders/context.rs
@@ -337,15 +337,6 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
             block_gas_limit = ?block_gas_limit,
         );
 
-        // Remove once we merge Reth 1.4.4
-        // Fixed in https://github.com/paradigmxyz/reth/pull/16514
-        self.metrics
-            .da_block_size_limit
-            .set(block_da_limit.map_or(-1.0, |v| v as f64));
-        self.metrics
-            .da_tx_size_limit
-            .set(tx_da_limit.map_or(-1.0, |v| v as f64));
-
         let block_attr = BlockConditionalAttributes {
             number: self.block_number(),
             timestamp: self.attributes().timestamp(),

--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -127,10 +127,6 @@ pub struct OpRBuilderMetrics {
     pub tx_simulation_duration: Histogram,
     /// Byte size of transactions
     pub tx_byte_size: Histogram,
-    /// Da block size limit
-    pub da_block_size_limit: Gauge,
-    /// Da tx size limit
-    pub da_tx_size_limit: Gauge,
     /// How much less flashblocks we issue to be on time with block construction
     pub reduced_flashblocks_number: Histogram,
     /// How much less flashblocks we issued in reality, comparing to calculated number for block

--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -123,6 +123,12 @@ pub struct OpRBuilderMetrics {
     pub payload_num_tx_simulated_fail: Histogram,
     /// Latest number of transactions in the payload that failed simulation
     pub payload_num_tx_simulated_fail_gauge: Gauge,
+    /// Histogram of gas used by successful transactions
+    pub successful_tx_gas_used: Histogram,
+    /// Histogram of gas used by reverted transactions
+    pub reverted_tx_gas_used: Histogram,
+    /// Gas used by reverted transactions in the latest block
+    pub payload_reverted_tx_gas_used: Gauge,
     /// Histogram of tx simulation duration
     pub tx_simulation_duration: Histogram,
     /// Byte size of transactions
@@ -148,6 +154,7 @@ pub struct OpRBuilderMetrics {
 }
 
 impl OpRBuilderMetrics {
+    #[expect(clippy::too_many_arguments)]
     pub fn set_payload_builder_metrics(
         &self,
         payload_tx_simulation_time: impl IntoF64 + Copy,
@@ -156,6 +163,7 @@ impl OpRBuilderMetrics {
         num_txs_simulated_success: impl IntoF64 + Copy,
         num_txs_simulated_fail: impl IntoF64 + Copy,
         num_bundles_reverted: impl IntoF64,
+        reverted_gas_used: impl IntoF64,
     ) {
         self.payload_tx_simulation_duration
             .record(payload_tx_simulation_time);
@@ -174,6 +182,7 @@ impl OpRBuilderMetrics {
         self.payload_num_tx_simulated_fail_gauge
             .set(num_txs_simulated_fail);
         self.bundles_reverted.record(num_bundles_reverted);
+        self.payload_reverted_tx_gas_used.set(reverted_gas_used);
     }
 }
 


### PR DESCRIPTION
## 📝 Summary
So we have a good idea of how much execution resources is taken up by reverting txs

## 💡 Motivation and Context

Unfortunately reth only tracks gas used by blocks, which isn't accurate for us since we don't include reverting txs in the block: https://github.com/paradigmxyz/reth/blob/main/crates/evm/evm/src/metrics.rs

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
