### PR TITLE
Add remote quote provider arg for flashtestations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6311,6 +6311,7 @@ dependencies = [
  "jsonrpsee 0.26.0",
  "jsonrpsee-core 0.26.0",
  "jsonrpsee-types 0.26.0",
+ "k256",
  "macros",
  "metrics",
  "moka",

--- a/crates/op-rbuilder/Cargo.toml
+++ b/crates/op-rbuilder/Cargo.toml
@@ -126,6 +126,7 @@ http = "1.0"
 sha3 = "0.10"
 hex = "0.4"
 ureq = "2.10"
+k256 = "0.13.4"
 
 rollup-boost = { git = "http://github.com/flashbots/rollup-boost", rev = "b86af43969557bee18f17ec1d6bcd3e984f910b2" }
 

--- a/crates/op-rbuilder/src/flashtestations/args.rs
+++ b/crates/op-rbuilder/src/flashtestations/args.rs
@@ -23,17 +23,24 @@ pub struct FlashtestationsArgs {
     )]
     pub debug: bool,
 
-    // Debug url for attestations
-    #[arg(long = "flashtestations.debug-url", env = "FLASHTESTATIONS_DEBUG_URL")]
-    pub debug_url: Option<String>,
+    // Debug static key for the tee key. DO NOT USE IN PRODUCTION
+    #[arg(
+        long = "flashtestations.debug-tee-key-seed",
+        env = "FLASHTESTATIONS_DEBUG_TEE_KEY_SEED",
+        default_value = "debug"
+    )]
+    pub debug_tee_key_seed: String,
+
+    // Remote url for attestations
+    #[arg(
+        long = "flashtestations.quote-provider",
+        env = "FLASHTESTATIONS_QUOTE_PROVIDER"
+    )]
+    pub quote_provider: Option<String>,
 
     /// The rpc url to post the onchain attestation requests to
-    #[arg(
-        long = "flashtestations.rpc-url",
-        env = "FLASHTESTATIONS_RPC_URL",
-        default_value = "http://localhost:8545"
-    )]
-    pub rpc_url: String,
+    #[arg(long = "flashtestations.rpc-url", env = "FLASHTESTATIONS_RPC_URL")]
+    pub rpc_url: Option<String>,
 
     /// Funding key for the TEE key
     #[arg(

--- a/crates/op-rbuilder/src/flashtestations/attestation.rs
+++ b/crates/op-rbuilder/src/flashtestations/attestation.rs
@@ -9,8 +9,8 @@ const DEBUG_QUOTE_SERVICE_URL: &str = "http://ns31695324.ip-141-94-163.eu:10080/
 pub struct AttestationConfig {
     /// If true, uses the debug HTTP service instead of real TDX hardware
     pub debug: bool,
-    /// The URL of the debug HTTP service
-    pub debug_url: Option<String>,
+    /// The URL of the quote provider
+    pub quote_provider: Option<String>,
 }
 
 /// Trait for attestation providers
@@ -18,18 +18,18 @@ pub trait AttestationProvider {
     fn get_attestation(&self, report_data: [u8; 64]) -> eyre::Result<Vec<u8>>;
 }
 
-/// Debug HTTP service attestation provider
-pub struct DebugAttestationProvider {
+/// Remote attestation provider
+pub struct RemoteAttestationProvider {
     service_url: String,
 }
 
-impl DebugAttestationProvider {
+impl RemoteAttestationProvider {
     pub fn new(service_url: String) -> Self {
         Self { service_url }
     }
 }
 
-impl AttestationProvider for DebugAttestationProvider {
+impl AttestationProvider for RemoteAttestationProvider {
     fn get_attestation(&self, report_data: [u8; 64]) -> eyre::Result<Vec<u8>> {
         let report_data_hex = hex::encode(report_data);
         let url = format!("{}/{}", self.service_url, report_data_hex);
@@ -51,15 +51,16 @@ pub fn get_attestation_provider(
     config: AttestationConfig,
 ) -> Box<dyn AttestationProvider + Send + Sync> {
     if config.debug {
-        Box::new(DebugAttestationProvider::new(
+        Box::new(RemoteAttestationProvider::new(
             config
-                .debug_url
+                .quote_provider
                 .unwrap_or(DEBUG_QUOTE_SERVICE_URL.to_string()),
         ))
     } else {
-        // TODO: replace with real attestation provider
-        Box::new(DebugAttestationProvider::new(
-            DEBUG_QUOTE_SERVICE_URL.to_string(),
+        Box::new(RemoteAttestationProvider::new(
+            config
+                .quote_provider
+                .expect("remote quote provider must be specified when not in debug mode"),
         ))
     }
 }

--- a/crates/op-rbuilder/src/flashtestations/service.rs
+++ b/crates/op-rbuilder/src/flashtestations/service.rs
@@ -47,14 +47,15 @@ impl FlashtestationsService {
 
         let attestation_provider = Arc::new(get_attestation_provider(AttestationConfig {
             debug: args.debug,
-            debug_url: args.debug_url,
+            quote_provider: args.quote_provider,
         }));
 
         let tx_manager = TxManager::new(
             tee_service_signer,
             args.funding_key
                 .expect("funding key required when flashtestations enabled"),
-            args.rpc_url,
+            args.rpc_url
+                .expect("external rpc url required when flashtestations enabled"),
             args.registry_address
                 .expect("registry address required when flashtestations enabled"),
             args.builder_policy_address


### PR DESCRIPTION
## 📝 Summary

* Replaces --debug-url with --quote_provider arg

## 💡 Motivation and Context

Allow the external tdx provider to fetch attestations

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
