### PR TITLE
feat: add configurable maximum flashblocks per block cap (default 10)

### DIFF
--- a/crates/op-rbuilder/src/args/op.rs
+++ b/crates/op-rbuilder/src/args/op.rs
@@ -166,6 +166,17 @@ pub struct FlashblocksArgs {
         env = "FLASHBLOCK_NUMBER_CONTRACT_ADDRESS"
     )]
     pub flashblocks_number_contract_address: Option<Address>,
+
+    /// Maximum number of flashblocks per block
+    ///
+    /// This caps the maximum number of flashblocks that can be produced per block,
+    /// regardless of the calculated number based on timing.
+    #[arg(
+        long = "flashblocks.max-per-block",
+        env = "FLASHBLOCKS_MAX_PER_BLOCK",
+        default_value = "10"
+    )]
+    pub flashblocks_max_per_block: u64,
 }
 
 impl Default for FlashblocksArgs {

--- a/crates/op-rbuilder/src/args/op.rs
+++ b/crates/op-rbuilder/src/args/op.rs
@@ -176,7 +176,7 @@ pub struct FlashblocksArgs {
         env = "FLASHBLOCKS_MAX_PER_BLOCK",
         default_value = "10"
     )]
-    pub flashblocks_max_per_block: u64,
+    pub max_flashblocks_per_block: u64,
 }
 
 impl Default for FlashblocksArgs {

--- a/crates/op-rbuilder/src/builders/flashblocks/config.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/config.rs
@@ -38,6 +38,12 @@ pub struct FlashblocksConfig {
     ///
     /// If set a builder tx will be added to the start of every flashblock instead of the regular builder tx.
     pub flashblocks_number_contract_address: Option<Address>,
+
+    /// Maximum number of flashblocks per block.
+    ///
+    /// This caps the maximum number of flashblocks that can be produced per block,
+    /// regardless of the calculated number based on timing.
+    pub max_flashblocks_per_block: u64,
 }
 
 impl Default for FlashblocksConfig {
@@ -49,6 +55,7 @@ impl Default for FlashblocksConfig {
             fixed: false,
             calculate_state_root: true,
             flashblocks_number_contract_address: None,
+            max_flashblocks_per_block: 10,
         }
     }
 }
@@ -73,6 +80,8 @@ impl TryFrom<OpRbuilderArgs> for FlashblocksConfig {
         let flashblocks_number_contract_address =
             args.flashblocks.flashblocks_number_contract_address;
 
+        let max_flashblocks_per_block = args.flashblocks.flashblocks_max_per_block;
+
         Ok(Self {
             ws_addr,
             interval,
@@ -80,6 +89,7 @@ impl TryFrom<OpRbuilderArgs> for FlashblocksConfig {
             fixed,
             calculate_state_root,
             flashblocks_number_contract_address,
+            max_flashblocks_per_block,
         })
     }
 }

--- a/crates/op-rbuilder/src/builders/flashblocks/config.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/config.rs
@@ -80,7 +80,7 @@ impl TryFrom<OpRbuilderArgs> for FlashblocksConfig {
         let flashblocks_number_contract_address =
             args.flashblocks.flashblocks_number_contract_address;
 
-        let max_flashblocks_per_block = args.flashblocks.flashblocks_max_per_block;
+        let max_flashblocks_per_block = args.flashblocks.max_flashblocks_per_block;
 
         Ok(Self {
             ws_addr,
@@ -103,6 +103,7 @@ impl FlashBlocksConfigExt for BuilderConfig<FlashblocksConfig> {
         if self.block_time.as_millis() == 0 {
             return 0;
         }
-        (self.block_time.as_millis() / self.specific.interval.as_millis()) as u64
+        let calculated = (self.block_time.as_millis() / self.specific.interval.as_millis()) as u64;
+        calculated.min(self.specific.max_flashblocks_per_block)
     }
 }

--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -807,62 +807,66 @@ where
     /// Calculate number of flashblocks.
     /// If dynamic is enabled this function will take time drift into the account.
     pub(super) fn calculate_flashblocks(&self, timestamp: u64) -> (u64, Duration) {
-        if self.config.specific.fixed {
-            return (
+        let (calculated_flashblocks, first_offset) = if self.config.specific.fixed {
+            (
                 self.config.flashblocks_per_block(),
                 // We adjust first FB to ensure that we have at least some time to make all FB in time
                 self.config.specific.interval - self.config.specific.leeway_time,
-            );
-        }
-        // We use this system time to determine remining time to build a block
-        // Things to consider:
-        // FCU(a) - FCU with attributes
-        // FCU(a) could arrive with `block_time - fb_time < delay`. In this case we could only produce 1 flashblock
-        // FCU(a) could arrive with `delay < fb_time` - in this case we will shrink first flashblock
-        // FCU(a) could arrive with `fb_time < delay < block_time - fb_time` - in this case we will issue less flashblocks
-        let target_time = std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(timestamp)
-            - self.config.specific.leeway_time;
-        let now = std::time::SystemTime::now();
-        let Ok(time_drift) = target_time.duration_since(now) else {
-            error!(
-                target: "payload_builder",
-                message = "FCU arrived too late or system clock are unsynced",
-                ?target_time,
-                ?now,
-            );
-            return (
-                self.config.flashblocks_per_block(),
-                self.config.specific.interval,
-            );
-        };
-        self.metrics.flashblocks_time_drift.record(
-            self.config
-                .block_time
-                .as_millis()
-                .saturating_sub(time_drift.as_millis()) as f64,
-        );
-        debug!(
-            target: "payload_builder",
-            message = "Time drift for building round",
-            ?target_time,
-            time_drift = self.config.block_time.as_millis().saturating_sub(time_drift.as_millis()),
-            ?timestamp
-        );
-        // This is extra check to ensure that we would account at least for block time in case we have any timer discrepancies.
-        let time_drift = time_drift.min(self.config.block_time);
-        let interval = self.config.specific.interval.as_millis() as u64;
-        let time_drift = time_drift.as_millis() as u64;
-        let first_flashblock_offset = time_drift.rem(interval);
-        if first_flashblock_offset == 0 {
-            // We have perfect division, so we use interval as first fb offset
-            (time_drift.div(interval), Duration::from_millis(interval))
-        } else {
-            // Non-perfect division, so we account for it.
-            (
-                time_drift.div(interval) + 1,
-                Duration::from_millis(first_flashblock_offset),
             )
-        }
+        } else {
+            // We use this system time to determine remining time to build a block
+            // Things to consider:
+            // FCU(a) - FCU with attributes
+            // FCU(a) could arrive with `block_time - fb_time < delay`. In this case we could only produce 1 flashblock
+            // FCU(a) could arrive with `delay < fb_time` - in this case we will shrink first flashblock
+            // FCU(a) could arrive with `fb_time < delay < block_time - fb_time` - in this case we will issue less flashblocks
+            let target_time = std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(timestamp)
+                - self.config.specific.leeway_time;
+            let now = std::time::SystemTime::now();
+            let Ok(time_drift) = target_time.duration_since(now) else {
+                error!(
+                    target: "payload_builder",
+                    message = "FCU arrived too late or system clock are unsynced",
+                    ?target_time,
+                    ?now,
+                );
+                let fallback_flashblocks = self.config.flashblocks_per_block().min(self.config.specific.max_flashblocks_per_block);
+                return (fallback_flashblocks, self.config.specific.interval);
+            };
+            self.metrics.flashblocks_time_drift.record(
+                self.config
+                    .block_time
+                    .as_millis()
+                    .saturating_sub(time_drift.as_millis()) as f64,
+            );
+            debug!(
+                target: "payload_builder",
+                message = "Time drift for building round",
+                ?target_time,
+                time_drift = self.config.block_time.as_millis().saturating_sub(time_drift.as_millis()),
+                ?timestamp
+            );
+            // This is extra check to ensure that we would account at least for block time in case we have any timer discrepancies.
+            let time_drift = time_drift.min(self.config.block_time);
+            let interval = self.config.specific.interval.as_millis() as u64;
+            let time_drift = time_drift.as_millis() as u64;
+            let first_flashblock_offset = time_drift.rem(interval);
+            if first_flashblock_offset == 0 {
+                // We have perfect division, so we use interval as first fb offset
+                (time_drift.div(interval), Duration::from_millis(interval))
+            } else {
+                // Non-perfect division, so we account for it.
+                (
+                    time_drift.div(interval) + 1,
+                    Duration::from_millis(first_flashblock_offset),
+                )
+            }
+        };
+
+        // Apply the maximum flashblocks per block cap
+        let final_flashblocks = calculated_flashblocks.min(self.config.specific.max_flashblocks_per_block);
+        
+        (final_flashblocks, first_offset)
     }
 }
 

--- a/crates/op-rbuilder/src/tests/flashblocks.rs
+++ b/crates/op-rbuilder/src/tests/flashblocks.rs
@@ -18,7 +18,7 @@ use crate::{
         flashblocks_fixed: false,
         flashblocks_calculate_state_root: true,
         flashblocks_number_contract_address: None,
-        flashblocks_max_per_block: 10,
+        max_flashblocks_per_block: 10,
     },
     ..Default::default()
 })]
@@ -58,7 +58,7 @@ async fn smoke_dynamic_base(rbuilder: LocalInstance) -> eyre::Result<()> {
         flashblocks_fixed: false,
         flashblocks_calculate_state_root: true,
         flashblocks_number_contract_address: None,
-        flashblocks_max_per_block: 10,
+        max_flashblocks_per_block: 10,
     },
     ..Default::default()
 })]
@@ -98,7 +98,7 @@ async fn smoke_dynamic_unichain(rbuilder: LocalInstance) -> eyre::Result<()> {
         flashblocks_fixed: true,
         flashblocks_calculate_state_root: true,
         flashblocks_number_contract_address: None,
-        flashblocks_max_per_block: 10,
+        max_flashblocks_per_block: 10,
     },
     ..Default::default()
 })]
@@ -138,7 +138,7 @@ async fn smoke_classic_unichain(rbuilder: LocalInstance) -> eyre::Result<()> {
         flashblocks_fixed: true,
         flashblocks_calculate_state_root: true,
         flashblocks_number_contract_address: None,
-        flashblocks_max_per_block: 10,
+        max_flashblocks_per_block: 10,
     },
     ..Default::default()
 })]
@@ -178,7 +178,7 @@ async fn smoke_classic_base(rbuilder: LocalInstance) -> eyre::Result<()> {
         flashblocks_fixed: false,
         flashblocks_calculate_state_root: true,
         flashblocks_number_contract_address: None,
-        flashblocks_max_per_block: 10,
+        max_flashblocks_per_block: 10,
     },
     ..Default::default()
 })]
@@ -225,7 +225,7 @@ async fn unichain_dynamic_with_lag(rbuilder: LocalInstance) -> eyre::Result<()> 
         flashblocks_fixed: false,
         flashblocks_calculate_state_root: true,
         flashblocks_number_contract_address: None,
-        flashblocks_max_per_block: 10,
+        max_flashblocks_per_block: 10,
     },
     ..Default::default()
 })]
@@ -265,7 +265,7 @@ async fn dynamic_with_full_block_lag(rbuilder: LocalInstance) -> eyre::Result<()
         flashblocks_fixed: false,
         flashblocks_calculate_state_root: true,
         flashblocks_number_contract_address: None,
-        flashblocks_max_per_block: 10,
+        max_flashblocks_per_block: 10,
     },
     ..Default::default()
 })]
@@ -327,7 +327,7 @@ async fn test_flashblock_min_filtering(rbuilder: LocalInstance) -> eyre::Result<
         flashblocks_fixed: false,
         flashblocks_calculate_state_root: true,
         flashblocks_number_contract_address: None,
-        flashblocks_max_per_block: 10,
+        max_flashblocks_per_block: 10,
     },
     ..Default::default()
 })]
@@ -385,7 +385,7 @@ async fn test_flashblock_max_filtering(rbuilder: LocalInstance) -> eyre::Result<
         flashblocks_fixed: false,
         flashblocks_calculate_state_root: true,
         flashblocks_number_contract_address: None,
-        flashblocks_max_per_block: 10,
+        max_flashblocks_per_block: 10,
     },
     ..Default::default()
 })]
@@ -432,7 +432,7 @@ async fn test_flashblock_min_max_filtering(rbuilder: LocalInstance) -> eyre::Res
         flashblocks_fixed: false,
         flashblocks_calculate_state_root: false,
         flashblocks_number_contract_address: None,
-        flashblocks_max_per_block: 10,
+        max_flashblocks_per_block: 10,
     },
     ..Default::default()
 })]
@@ -478,7 +478,7 @@ async fn test_flashblocks_no_state_root_calculation(rbuilder: LocalInstance) -> 
         flashblocks_fixed: true,
         flashblocks_calculate_state_root: true,
         flashblocks_number_contract_address: None,
-        flashblocks_max_per_block: 3, // Cap at 3 flashblocks instead of default 5
+        max_flashblocks_per_block: 3, // Cap at 3 flashblocks instead of default 5
     },
     ..Default::default()
 })]
@@ -498,15 +498,27 @@ async fn test_max_flashblocks_per_block_cap(rbuilder: LocalInstance) -> eyre::Re
     // Build a block - normally would produce 5 flashblocks (1000ms / 200ms = 5)
     // But with max_flashblocks_per_block: 3, it should cap at 3
     let block = driver.build_new_block().await?;
-    assert_eq!(block.transactions.len(), 8, "Block should contain all transactions"); // 5 normal txn + deposit + 2 builder txn
+    assert_eq!(
+        block.transactions.len(),
+        8,
+        "Block should contain all transactions"
+    ); // 5 normal txn + deposit + 2 builder txn
 
     let flashblocks = flashblocks_listener.get_flashblocks();
     // Should produce only 3 flashblocks + 1 base flashblock = 4 total
-    assert_eq!(4, flashblocks.len(), "Should be capped at 3 flashblocks + 1 base = 4 total");
+    assert_eq!(
+        4,
+        flashblocks.len(),
+        "Should be capped at 3 flashblocks + 1 base = 4 total"
+    );
 
     // Verify flashblock indices are within expected range
     for fb in &flashblocks {
-        assert!(fb.index <= 3, "Flashblock index should not exceed 3, got index {}", fb.index);
+        assert!(
+            fb.index <= 3,
+            "Flashblock index should not exceed 3, got index {}",
+            fb.index
+        );
     }
 
     flashblocks_listener.stop().await
@@ -523,7 +535,7 @@ async fn test_max_flashblocks_per_block_cap(rbuilder: LocalInstance) -> eyre::Re
         flashblocks_fixed: false,
         flashblocks_calculate_state_root: true,
         flashblocks_number_contract_address: None,
-        flashblocks_max_per_block: 5, // Cap at 5 flashblocks
+        max_flashblocks_per_block: 5, // Cap at 5 flashblocks
     },
     ..Default::default()
 })]
@@ -544,15 +556,26 @@ async fn test_max_flashblocks_dynamic_timing(rbuilder: LocalInstance) -> eyre::R
     // Would normally create ~20 flashblocks (2000ms / 100ms = 20)
     // But should be capped at 5
     let block = driver.build_new_block_with_current_timestamp(None).await?;
-    assert!(block.transactions.len() >= 5, "Block should contain transactions");
+    assert!(
+        block.transactions.len() >= 5,
+        "Block should contain transactions"
+    );
 
     let flashblocks = flashblocks_listener.get_flashblocks();
     // Should be capped at 5 flashblocks + 1 base = 6 total
-    assert!(flashblocks.len() <= 6, "Should be capped at 5 flashblocks + 1 base = 6 total, got {}", flashblocks.len());
+    assert!(
+        flashblocks.len() <= 6,
+        "Should be capped at 5 flashblocks + 1 base = 6 total, got {}",
+        flashblocks.len()
+    );
 
     // Verify no flashblock index exceeds the cap
     for fb in &flashblocks {
-        assert!(fb.index <= 5, "Flashblock index should not exceed 5, got index {}", fb.index);
+        assert!(
+            fb.index <= 5,
+            "Flashblock index should not exceed 5, got index {}",
+            fb.index
+        );
     }
 
     flashblocks_listener.stop().await


### PR DESCRIPTION
## 📝 Summary
Adds a configurable maximum limit for the number of flashblocks that can be produced per block, ensures the maximum cannot exceed 10.

## 💡 Motivation and Context
The flashblock count was previously determined purely by timing calculations (`block_time / flashblock_interval`), which doesn't prevent the count go over 10 when using flashblock_interval < 200 for a 2s block time chain.

  ## Changes
  - **CLI Flag**: Added `--flashblocks.max-per-block` with default value of 10
  - **Environment Variable**: `FLASHBLOCKS_MAX_PER_BLOCK` support
  - **Configuration**: Added `max_flashblocks_per_block` field to `FlashblocksConfig`
  - **Logic**: Applied cap in both fixed and dynamic timing modes:
    - Fixed mode: Cap applied in `flashblocks_per_block()` method
    - Dynamic mode: Cap applied at the end of timing calculations
  - **Tests**: Added comprehensive test coverage for both timing modes

  ## Implementation Details
  The cap is applied in two places:
  1. `FlashBlocksConfigExt::flashblocks_per_block()` - handles fixed timing mode
  2. End of `calculate_flashblocks()` - handles dynamic timing mode calculations

  This approach ensures consistent behavior across both modes without restructuring the existing timing logic.

  ## Testing

  - ✅ test_max_flashblocks_per_block_cap - tests fixed timing mode with cap of 3
  - ✅ test_max_flashblocks_dynamic_timing - tests dynamic timing mode with cap of 5
  - ✅ All existing flashblocks tests continue to pass
