### PR TITLE
Flag to save tee key to local file

### DIFF
--- a/crates/op-rbuilder/src/flashtestations/args.rs
+++ b/crates/op-rbuilder/src/flashtestations/args.rs
@@ -33,6 +33,14 @@ pub struct FlashtestationsArgs {
     )]
     pub debug_tee_key_seed: String,
 
+    /// Path to save ephemeral TEE key between restarts
+    #[arg(
+        long = "flashtestations.key-path",
+        env = "FLASHTESTATIONS_KEY_PATH",
+        default_value = "/run/flashtestation.key"
+    )]
+    pub flashtestations_key_path: String,
+
     // Remote url for attestations
     #[arg(
         long = "flashtestations.quote-provider",

--- a/crates/op-rbuilder/src/tx_signer.rs
+++ b/crates/op-rbuilder/src/tx_signer.rs
@@ -74,7 +74,7 @@ impl FromStr for Signer {
     }
 }
 
-pub fn generate_ethereum_keypair() -> (SecretKey, PublicKey, Address) {
+pub fn generate_signer() -> Signer {
     let secp = Secp256k1::new();
 
     // Generate cryptographically secure random private key
@@ -86,7 +86,11 @@ pub fn generate_ethereum_keypair() -> (SecretKey, PublicKey, Address) {
     // Derive Ethereum address
     let address = public_key_to_address(&public_key);
 
-    (private_key, public_key, address)
+    Signer {
+        address,
+        pubkey: public_key,
+        secret: private_key,
+    }
 }
 
 /// Converts a public key to an Ethereum address
@@ -103,7 +107,7 @@ pub fn public_key_to_address(public_key: &PublicKey) -> Address {
 
 // Generate a key deterministically from a seed for debug and testing
 // Do not use in production
-pub fn generate_key_from_seed(seed: &str) -> (SecretKey, PublicKey, Address) {
+pub fn generate_key_from_seed(seed: &str) -> Signer {
     // Hash the seed
     let mut hasher = Sha256::new();
     hasher.update(seed.as_bytes());
@@ -115,7 +119,11 @@ pub fn generate_key_from_seed(seed: &str) -> (SecretKey, PublicKey, Address) {
     let public_key = PublicKey::from_secret_key(&secp, &private_key);
     let address = public_key_to_address(&public_key);
 
-    (private_key, public_key, address)
+    Signer {
+        address,
+        pubkey: public_key,
+        secret: private_key,
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 📝 Summary
Resolves https://github.com/flashbots/op-rbuilder/issues/284

## 💡 Motivation and Context

Adding arg to save the key in local fs between restarts. File is guaranteed to never leave the TEE by the image measurements that includes all the config of the builder

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
