### PR TITLE
fix: dont mangle artifact binary name

### DIFF
--- a/.github/workflows/tdx_quote_provider_release.yaml
+++ b/.github/workflows/tdx_quote_provider_release.yaml
@@ -89,7 +89,6 @@ jobs:
           git config --global --add safe.directory "$(pwd)"
           . $HOME/.cargo/env
           cargo build --release --features=${{ matrix.features }} --target ${{ matrix.configs.target }} --package tdx-quote-provider
-          stat target/${{ matrix.configs.target }}/release/tdx-quote-provider
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tdx_quote_provider_release.yaml
+++ b/.github/workflows/tdx_quote_provider_release.yaml
@@ -89,14 +89,13 @@ jobs:
           git config --global --add safe.directory "$(pwd)"
           . $HOME/.cargo/env
           cargo build --release --features=${{ matrix.features }} --target ${{ matrix.configs.target }} --package tdx-quote-provider
-          mkdir -p artifacts
-          mv target/${{ matrix.configs.target }}/release/tdx-quote-provider artifacts/tdx-quote-provider-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}${{ matrix.features && '-' }}${{ matrix.features }}
+          stat target/${{ matrix.configs.target }}/release/tdx-quote-provider
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: tdx-quote-provider-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}${{ matrix.features && '-' }}${{ matrix.features }}
-          path: artifacts
+          path: target/${{ matrix.configs.target }}/release/tdx-quote-provider
 
   draft-release:
     name: Draft release
@@ -120,8 +119,15 @@ jobs:
       - name: Record artifacts checksums
         working-directory: artifacts
         run: |
+          for dir in $( find . -type d -name "tdx-quote-provider-*" -printf "%f\n" ); do
+            mv    ./$dir                        ./$dir.bak
+            mv    ./$dir.bak/tdx-quote-provider ./$dir
+            rm -r ./$dir.bak
+          done
           find ./ || true
-          for file in *; do sha256sum "$file" >> sha256sums.txt; done;
+          for file in $( find ./ -type f ); do
+            sha256sum "$file" >> sha256sums.txt
+          done;
           cat sha256sums.txt
 
       - name: Create release draft


### PR DESCRIPTION
## 📝 Summary

Upload build artifacts of `tdx-quote-provider` w/o altering their names.
