### PR TITLE
chore: add `unused_async` clippy lint, deny `unreachable_pub`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,10 @@ codegen-units = 1
 incremental = false
 
 [workspace.lints.rust]
-unreachable_pub = "warn"
+unreachable_pub = "deny"
+
+[workspace.lints.clippy]
+unused_async = "warn"
 
 [workspace.dependencies]
 reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.8.2" }

--- a/crates/op-rbuilder/src/bin/tester/main.rs
+++ b/crates/op-rbuilder/src/bin/tester/main.rs
@@ -50,7 +50,7 @@ async fn main() -> eyre::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Genesis { output } => generate_genesis(output).await,
+        Commands::Genesis { output } => generate_genesis(output),
         Commands::Run { validation, .. } => run_system(validation).await,
         Commands::Deposit { address, amount } => {
             let engine_api = EngineApi::with_http("http://localhost:4444");

--- a/crates/op-rbuilder/src/tests/framework/apis.rs
+++ b/crates/op-rbuilder/src/tests/framework/apis.rs
@@ -205,7 +205,7 @@ pub trait BlockApi {
     ) -> RpcResult<Option<alloy_rpc_types_eth::Block>>;
 }
 
-pub async fn generate_genesis(output: Option<String>) -> eyre::Result<()> {
+pub fn generate_genesis(output: Option<String>) -> eyre::Result<()> {
     // Read the template file
     let template = include_str!("artifacts/genesis.json.tmpl");
 


### PR DESCRIPTION
## 📝 Summary

-  add `unused_async` clippy lint
- deny `unreachable_pub`; this previously was not being caught by CI, as it's a rust lint, and the CI was running `make lint` and only denying on clippy warnings 

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

code quality

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
