### PR TITLE
Remove non permit flashtestation calls

### DIFF
--- a/crates/op-rbuilder/src/builders/flashblocks/service.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/service.rs
@@ -92,7 +92,7 @@ where
         let flashtestations_builder_tx = if let Some(builder_key) = signer
             && self.0.flashtestations_config.flashtestations_enabled
         {
-            match bootstrap_flashtestations(self.0.flashtestations_config.clone(), builder_key, ctx)
+            match bootstrap_flashtestations(self.0.flashtestations_config.clone(), builder_key)
                 .await
             {
                 Ok(builder_tx) => Some(builder_tx),

--- a/crates/op-rbuilder/src/builders/standard/service.rs
+++ b/crates/op-rbuilder/src/builders/standard/service.rs
@@ -75,7 +75,7 @@ where
         let flashtestations_builder_tx = if let Some(builder_key) = signer
             && self.0.flashtestations_config.flashtestations_enabled
         {
-            match bootstrap_flashtestations(self.0.flashtestations_config.clone(), builder_key, ctx)
+            match bootstrap_flashtestations(self.0.flashtestations_config.clone(), builder_key)
                 .await
             {
                 Ok(builder_tx) => Some(builder_tx),

--- a/crates/op-rbuilder/src/flashtestations/args.rs
+++ b/crates/op-rbuilder/src/flashtestations/args.rs
@@ -1,8 +1,8 @@
-use alloy_primitives::{Address, U256, utils::parse_ether};
+use alloy_primitives::Address;
 use clap::Parser;
 use reth_optimism_cli::commands::Commands;
 
-use crate::{args::Cli, tx_signer::Signer};
+use crate::args::Cli;
 
 /// Parameters for Flashtestations configuration
 /// The names in the struct are prefixed with `flashtestations`
@@ -52,23 +52,6 @@ pub struct FlashtestationsArgs {
     #[arg(long = "flashtestations.rpc-url", env = "FLASHTESTATIONS_RPC_URL")]
     pub rpc_url: Option<String>,
 
-    /// Funding key for the TEE key
-    #[arg(
-        long = "flashtestations.funding-key",
-        env = "FLASHTESTATIONS_FUNDING_KEY",
-        required_if_eq("flashtestations_enabled", "true")
-    )]
-    pub funding_key: Option<Signer>,
-
-    /// Funding amount for the generated signer
-    #[arg(
-        long = "flashtestations.funding-amount",
-        env = "FLASHTESTATIONS_FUNDING_AMOUNT",
-        default_value = "1",
-        value_parser = parse_ether
-    )]
-    pub funding_amount: U256,
-
     /// Enable end of block TEE proof
     #[arg(
         long = "flashtestations.enable-block-proofs",
@@ -100,14 +83,6 @@ pub struct FlashtestationsArgs {
         default_value = "1"
     )]
     pub builder_proof_version: u8,
-
-    /// Use permit for the flashtestation builder tx
-    #[arg(
-        long = "flashtestations.use-permit",
-        env = "FLASHTESTATIONS_USE_PERMIT",
-        default_value = "false"
-    )]
-    pub flashtestations_use_permit: bool,
 }
 
 impl Default for FlashtestationsArgs {

--- a/crates/op-rbuilder/src/flashtestations/builder_tx.rs
+++ b/crates/op-rbuilder/src/flashtestations/builder_tx.rs
@@ -1,27 +1,23 @@
-use alloy_consensus::TxEip1559;
 use alloy_eips::Encodable2718;
 use alloy_evm::Database;
 use alloy_op_evm::OpEvm;
-use alloy_primitives::{Address, B256, Bytes, Signature, TxKind, U256, keccak256};
+use alloy_primitives::{Address, B256, Bytes, Signature, U256, keccak256};
 use alloy_rpc_types_eth::TransactionInput;
 use alloy_sol_types::{SolCall, SolEvent, SolValue};
 use core::fmt::Debug;
-use op_alloy_consensus::OpTypedTransaction;
 use op_alloy_rpc_types::OpTransactionRequest;
-use reth_evm::{ConfigureEvm, Evm, EvmError, precompiles::PrecompilesMap};
+use reth_evm::{ConfigureEvm, Evm, precompiles::PrecompilesMap};
 use reth_optimism_primitives::OpTransactionSigned;
 use reth_provider::StateProvider;
 use reth_revm::{State, database::StateProviderDatabase};
-use revm::{
-    DatabaseCommit, DatabaseRef, context::result::ResultAndState, inspector::NoOpInspector,
-};
+use revm::{DatabaseCommit, DatabaseRef, inspector::NoOpInspector};
 use std::sync::{Arc, atomic::AtomicBool};
 use tracing::{debug, info, warn};
 
 use crate::{
     builders::{
         BuilderTransactionCtx, BuilderTransactionError, BuilderTransactions, OpPayloadBuilderCtx,
-        SimulationSuccessResult, get_balance, get_nonce,
+        SimulationSuccessResult, get_nonce,
     },
     flashtestations::{
         BlockData,
@@ -37,14 +33,11 @@ pub struct FlashtestationsBuilderTxArgs {
     pub attestation: Vec<u8>,
     pub extra_registration_data: Bytes,
     pub tee_service_signer: Signer,
-    pub funding_key: Signer,
-    pub funding_amount: U256,
     pub registry_address: Address,
     pub builder_policy_address: Address,
     pub builder_proof_version: u8,
     pub enable_block_proofs: bool,
     pub registered: bool,
-    pub use_permit: bool,
     pub builder_key: Signer,
 }
 
@@ -60,10 +53,6 @@ where
     extra_registration_data: Bytes,
     // TEE service generated key
     tee_service_signer: Signer,
-    // Funding key for the TEE signer
-    funding_key: Signer,
-    // Funding amount for the TEE signer
-    funding_amount: U256,
     // Registry address for the attestation
     registry_address: Address,
     // Builder policy address for the block builder proof
@@ -74,8 +63,6 @@ where
     registered: Arc<AtomicBool>,
     // Whether block proofs are enabled
     enable_block_proofs: bool,
-    // Whether to use permit for the flashtestation builder tx
-    use_permit: bool,
     // Builder key for the flashtestation permit tx
     builder_signer: Signer,
     // Extra context and data
@@ -92,14 +79,11 @@ where
             attestation: args.attestation,
             extra_registration_data: args.extra_registration_data,
             tee_service_signer: args.tee_service_signer,
-            funding_key: args.funding_key,
-            funding_amount: args.funding_amount,
             registry_address: args.registry_address,
             builder_policy_address: args.builder_policy_address,
             builder_proof_version: args.builder_proof_version,
             registered: Arc::new(AtomicBool::new(args.registered)),
             enable_block_proofs: args.enable_block_proofs,
-            use_permit: args.use_permit,
             builder_signer: args.builder_key,
             _marker: std::marker::PhantomData,
         }
@@ -135,136 +119,6 @@ where
 
         let encoded = block_data.abi_encode();
         keccak256(&encoded)
-    }
-
-    // TODO: deprecate in favour of permit calls
-    fn fund_tee_service_tx(
-        &self,
-        ctx: &OpPayloadBuilderCtx<ExtraCtx>,
-        evm: &mut OpEvm<&mut State<impl Database + DatabaseRef>, NoOpInspector, PrecompilesMap>,
-    ) -> Result<Option<BuilderTransactionCtx>, BuilderTransactionError> {
-        let balance = get_balance(evm.db(), self.tee_service_signer.address)?;
-        if balance.is_zero() {
-            let funding_nonce = get_nonce(evm.db(), self.funding_key.address)?;
-            let tx = OpTypedTransaction::Eip1559(TxEip1559 {
-                chain_id: ctx.chain_id(),
-                nonce: funding_nonce,
-                gas_limit: 21000,
-                max_fee_per_gas: ctx.base_fee().into(),
-                to: TxKind::Call(self.tee_service_signer.address),
-                value: self.funding_amount,
-                ..Default::default()
-            });
-            let funding_tx = self.funding_key.sign_tx(tx)?;
-            let da_size =
-                op_alloy_flz::tx_estimated_size_fjord_bytes(funding_tx.encoded_2718().as_slice());
-            let ResultAndState { state, .. } = match evm.transact(&funding_tx) {
-                Ok(res) => res,
-                Err(err) => {
-                    if err.is_invalid_tx_err() {
-                        return Err(BuilderTransactionError::InvalidTransactionError(Box::new(
-                            err,
-                        )));
-                    } else {
-                        return Err(BuilderTransactionError::EvmExecutionError(Box::new(err)));
-                    }
-                }
-            };
-            info!(target: "flashtestations", block_number = ctx.block_number(), tx_hash = ?funding_tx.tx_hash(), "adding funding tx to builder txs");
-            evm.db_mut().commit(state);
-            Ok(Some(BuilderTransactionCtx {
-                gas_used: 21000,
-                da_size,
-                signed_tx: funding_tx,
-                is_top_of_block: false,
-            }))
-        } else {
-            Ok(None)
-        }
-    }
-
-    // TODO: deprecate in favour of permit calls
-    fn register_tee_service_tx(
-        &self,
-        ctx: &OpPayloadBuilderCtx<ExtraCtx>,
-        evm: &mut OpEvm<&mut State<impl Database + DatabaseRef>, NoOpInspector, PrecompilesMap>,
-    ) -> Result<BuilderTransactionCtx, BuilderTransactionError> {
-        let calldata = IFlashtestationRegistry::registerTEEServiceCall {
-            rawQuote: self.attestation.clone().into(),
-            extendedRegistrationData: self.extra_registration_data.clone(),
-        };
-        let SimulationSuccessResult {
-            gas_used,
-            state_changes,
-            ..
-        } = self.flashtestation_call(
-            self.registry_address,
-            calldata.clone(),
-            vec![TEEServiceRegistered::SIGNATURE_HASH],
-            ctx,
-            evm,
-        )?;
-        let signed_tx = self.sign_tx(
-            self.registry_address,
-            self.tee_service_signer,
-            gas_used,
-            calldata.abi_encode().into(),
-            ctx,
-            evm.db(),
-        )?;
-        let da_size =
-            op_alloy_flz::tx_estimated_size_fjord_bytes(signed_tx.encoded_2718().as_slice());
-        // commit the register transaction state so the block proof transaction can succeed
-        evm.db_mut().commit(state_changes);
-        Ok(BuilderTransactionCtx {
-            gas_used,
-            da_size,
-            signed_tx,
-            is_top_of_block: false,
-        })
-    }
-
-    // TODO: remove in favour of permit calls
-    fn verify_block_proof_tx(
-        &self,
-        transactions: Vec<OpTransactionSigned>,
-        ctx: &OpPayloadBuilderCtx<ExtraCtx>,
-        evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
-    ) -> Result<BuilderTransactionCtx, BuilderTransactionError> {
-        let block_content_hash = Self::compute_block_content_hash(
-            &transactions,
-            ctx.parent_hash(),
-            ctx.block_number(),
-            ctx.timestamp(),
-        );
-
-        let calldata = IBlockBuilderPolicy::verifyBlockBuilderProofCall {
-            blockContentHash: block_content_hash,
-            version: self.builder_proof_version,
-        };
-        let SimulationSuccessResult { gas_used, .. } = self.flashtestation_call(
-            self.builder_policy_address,
-            calldata.clone(),
-            vec![BlockBuilderProofVerified::SIGNATURE_HASH],
-            ctx,
-            evm,
-        )?;
-        let signed_tx = self.sign_tx(
-            self.builder_policy_address,
-            self.tee_service_signer,
-            gas_used,
-            calldata.abi_encode().into(),
-            ctx,
-            evm.db(),
-        )?;
-        let da_size =
-            op_alloy_flz::tx_estimated_size_fjord_bytes(signed_tx.encoded_2718().as_slice());
-        Ok(BuilderTransactionCtx {
-            gas_used,
-            da_size,
-            signed_tx,
-            is_top_of_block: false,
-        })
     }
 
     fn set_registered(
@@ -534,35 +388,18 @@ where
 
         if !self.registered.load(std::sync::atomic::Ordering::SeqCst) {
             info!(target: "flashtestations", "tee service not registered yet, attempting to register");
-            let register_tx = if self.use_permit {
-                self.signed_registration_permit_tx(ctx, &mut evm)?
-            } else {
-                builder_txs.extend(self.fund_tee_service_tx(ctx, &mut evm)?);
-                self.register_tee_service_tx(ctx, &mut evm)?
-            };
+            let register_tx = self.signed_registration_permit_tx(ctx, &mut evm)?;
             builder_txs.push(register_tx);
         }
 
         // don't return on error for block proof as previous txs in builder_txs will not be returned
         if self.enable_block_proofs {
-            if self.use_permit {
-                debug!(target: "flashtestations", "adding permit verify block proof tx");
-                match self.signed_block_proof_permit_tx(&info.executed_transactions, ctx, &mut evm)
-                {
-                    Ok(block_proof_tx) => builder_txs.push(block_proof_tx),
-                    Err(e) => {
-                        warn!(target: "flashtestations", error = ?e, "failed to add permit block proof transaction")
-                    }
+            debug!(target: "flashtestations", "adding permit verify block proof tx");
+            match self.signed_block_proof_permit_tx(&info.executed_transactions, ctx, &mut evm) {
+                Ok(block_proof_tx) => builder_txs.push(block_proof_tx),
+                Err(e) => {
+                    warn!(target: "flashtestations", error = ?e, "failed to add permit block proof transaction")
                 }
-            } else {
-                // add verify block proof tx
-                match self.verify_block_proof_tx(info.executed_transactions.clone(), ctx, &mut evm)
-                {
-                    Ok(block_proof_tx) => builder_txs.push(block_proof_tx),
-                    Err(e) => {
-                        warn!(target: "flashtestations", error = ?e, "failed to add block proof transaction")
-                    }
-                };
             }
         }
         Ok(builder_txs)

--- a/crates/op-rbuilder/src/flashtestations/service.rs
+++ b/crates/op-rbuilder/src/flashtestations/service.rs
@@ -1,5 +1,4 @@
 use alloy_primitives::{B256, Bytes, keccak256};
-use reth_node_builder::BuilderContext;
 use std::{
     fs::{self, OpenOptions},
     io::Write,
@@ -15,18 +14,15 @@ use super::{
 };
 use crate::{
     flashtestations::builder_tx::{FlashtestationsBuilderTx, FlashtestationsBuilderTxArgs},
-    traits::NodeBounds,
     tx_signer::{Signer, generate_key_from_seed, generate_signer},
 };
 use std::fmt::Debug;
 
-pub async fn bootstrap_flashtestations<Node, ExtraCtx, Extra>(
+pub async fn bootstrap_flashtestations<ExtraCtx, Extra>(
     args: FlashtestationsArgs,
     builder_key: Signer,
-    ctx: &BuilderContext<Node>,
 ) -> eyre::Result<FlashtestationsBuilderTx<ExtraCtx, Extra>>
 where
-    Node: NodeBounds,
     ExtraCtx: Debug + Default,
     Extra: Debug + Default,
 {
@@ -41,9 +37,6 @@ where
         tee_service_signer.address
     );
 
-    let funding_key = args
-        .funding_key
-        .expect("funding key required when flashtestations enabled");
     let registry_address = args
         .registry_address
         .expect("registry address required when flashtestations enabled");
@@ -81,69 +74,40 @@ where
     info!(target: "flashtestations", "requesting TDX attestation");
     let attestation = attestation_provider.get_attestation(report_data).await?;
 
-    // TODO: support permit with an external rpc, skip this step if using permit signatures
-    // since the permit txs are signed by the builder key and will result in nonce issues
-    let (tx_manager, registered) = if let Some(rpc_url) = args.rpc_url
-        && !args.flashtestations_use_permit
-    {
+    // Use an external rpc when the builder is not the same as the builder actively building blocks onchain
+    let registered = if let Some(rpc_url) = args.rpc_url {
         let tx_manager = TxManager::new(
             tee_service_signer,
-            funding_key,
+            builder_key,
             rpc_url.clone(),
             registry_address,
         );
         // Submit report onchain by registering the key of the tee service
         match tx_manager
-            .fund_and_register_tee_service(
-                attestation.clone(),
-                ext_data.clone(),
-                args.funding_amount,
-            )
+            .register_tee_service(attestation.clone(), ext_data.clone())
             .await
         {
-            Ok(_) => (Some(tx_manager), true),
+            Ok(_) => true,
             Err(e) => {
                 warn!(error = %e, "Failed to register tee service via rpc");
-                (Some(tx_manager), false)
+                false
             }
         }
     } else {
-        (None, false)
+        false
     };
 
     let flashtestations_builder_tx = FlashtestationsBuilderTx::new(FlashtestationsBuilderTxArgs {
         attestation,
         extra_registration_data: ext_data,
         tee_service_signer,
-        funding_key,
-        funding_amount: args.funding_amount,
         registry_address,
         builder_policy_address,
         builder_proof_version: args.builder_proof_version,
         enable_block_proofs: args.enable_block_proofs,
         registered,
-        use_permit: args.flashtestations_use_permit,
         builder_key,
     });
-
-    ctx.task_executor()
-        .spawn_critical_with_graceful_shutdown_signal(
-            "flashtestations clean up task",
-            |shutdown| {
-                Box::pin(async move {
-                    let graceful_guard = shutdown.await;
-                    if let Some(tx_manager) = tx_manager {
-                        if let Err(e) = tx_manager.clean_up().await {
-                            warn!(
-                                error = %e,
-                                "Failed to complete clean up for flashtestations service",
-                            );
-                        }
-                    }
-                    drop(graceful_guard)
-                })
-            },
-        );
 
     Ok(flashtestations_builder_tx)
 }

--- a/crates/op-rbuilder/src/flashtestations/tx_manager.rs
+++ b/crates/op-rbuilder/src/flashtestations/tx_manager.rs
@@ -1,6 +1,6 @@
 use alloy_json_rpc::RpcError;
 use alloy_network::ReceiptResponse;
-use alloy_primitives::{Address, Bytes, TxHash, TxKind, U256};
+use alloy_primitives::{Address, B256, Bytes, TxHash, TxKind, U256};
 use alloy_rpc_types_eth::TransactionRequest;
 use alloy_sol_types::SolCall;
 use alloy_transport::{TransportError, TransportErrorKind, TransportResult};
@@ -14,7 +14,13 @@ use alloy_signer_local::PrivateKeySigner;
 use op_alloy_network::Optimism;
 use tracing::{debug, info, warn};
 
-use crate::{flashtestations::IFlashtestationRegistry, tx_signer::Signer};
+use crate::{
+    flashtestations::{
+        IERC20Permit::{self},
+        IFlashtestationRegistry,
+    },
+    tx_signer::Signer,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum TxManagerError {
@@ -28,12 +34,14 @@ pub enum TxManagerError {
     TxRpcError(RpcError<TransportErrorKind>),
     #[error("signer error: {0}")]
     SignerError(ecdsa::Error),
+    #[error("error signing message: {0}")]
+    SignatureError(secp256k1::Error),
 }
 
 #[derive(Debug, Clone)]
 pub struct TxManager {
     tee_service_signer: Signer,
-    funding_signer: Signer,
+    builder_signer: Signer,
     rpc_url: String,
     registry_address: Address,
 }
@@ -41,78 +49,27 @@ pub struct TxManager {
 impl TxManager {
     pub fn new(
         tee_service_signer: Signer,
-        funding_signer: Signer,
+        builder_signer: Signer,
         rpc_url: String,
         registry_address: Address,
     ) -> Self {
         Self {
             tee_service_signer,
-            funding_signer,
+            builder_signer,
             rpc_url,
             registry_address,
         }
     }
 
-    pub async fn fund_address(
-        &self,
-        from: Signer,
-        to: Address,
-        amount: U256,
-    ) -> Result<(), TxManagerError> {
-        let funding_wallet = PrivateKeySigner::from_bytes(&from.secret.secret_bytes().into())
-            .map_err(TxManagerError::SignerError)?;
-        let provider = ProviderBuilder::new()
-            .disable_recommended_fillers()
-            .fetch_chain_id()
-            .with_gas_estimation()
-            .with_cached_nonce_management()
-            .wallet(funding_wallet)
-            .network::<Optimism>()
-            .connect(self.rpc_url.as_str())
-            .await?;
-
-        // Create funding transaction
-        let funding_tx = TransactionRequest {
-            from: Some(from.address),
-            to: Some(TxKind::Call(to)),
-            value: Some(amount),
-            gas: Some(21_000), // Standard gas for ETH transfer
-            ..Default::default()
-        };
-
-        // Send funding transaction
-        match Self::process_pending_tx(provider.send_transaction(funding_tx.into()).await).await {
-            Ok(tx_hash) => {
-                info!(target: "flashtestations", tx_hash = %tx_hash, "funding transaction confirmed successfully");
-                Ok(())
-            }
-            Err(e) => {
-                warn!(target: "flashtestations", error = %e, "funding transaction failed");
-                Err(e)
-            }
-        }
-    }
-
-    pub async fn fund_and_register_tee_service(
+    pub async fn register_tee_service(
         &self,
         attestation: Vec<u8>,
         extra_registration_data: Bytes,
-        funding_amount: U256,
     ) -> Result<(), TxManagerError> {
         info!(target: "flashtestations", "funding TEE address at {}", self.tee_service_signer.address);
-        self.fund_address(
-            self.funding_signer,
-            self.tee_service_signer.address,
-            funding_amount,
-        )
-        .await
-        .unwrap_or_else(|e| {
-            warn!(target: "flashtestations", error = %e, "Failed to fund TEE address, attempting to register without funding");
-        });
-
         let quote_bytes = Bytes::from(attestation);
         let wallet =
-            PrivateKeySigner::from_bytes(&self.tee_service_signer.secret.secret_bytes().into())
+            PrivateKeySigner::from_bytes(&self.builder_signer.secret.secret_bytes().into())
                 .map_err(TxManagerError::SignerError)?;
         let provider = ProviderBuilder::new()
             .disable_recommended_fillers()
@@ -126,9 +83,63 @@ impl TxManager {
 
         info!(target: "flashtestations", "submitting quote to registry at {}", self.registry_address);
 
-        let calldata = IFlashtestationRegistry::registerTEEServiceCall {
+        // Get permit nonce
+        let nonce_call = IERC20Permit::noncesCall {
+            owner: self.tee_service_signer.address,
+        };
+        let nonce_tx = TransactionRequest {
+            to: Some(TxKind::Call(self.registry_address)),
+            input: nonce_call.abi_encode().into(),
+            ..Default::default()
+        };
+        let nonce = U256::from_be_slice(provider.call(nonce_tx.into()).await?.as_ref());
+
+        // Set deadline 1 hour from now
+        let deadline = U256::from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
+                + 3600,
+        );
+
+        // Call computeStructHash to get the struct hash
+        let struct_hash_call = IFlashtestationRegistry::computeStructHashCall {
+            rawQuote: quote_bytes.clone(),
+            extendedRegistrationData: extra_registration_data.clone(),
+            nonce,
+            deadline,
+        };
+        let struct_hash_tx = TransactionRequest {
+            to: Some(TxKind::Call(self.registry_address)),
+            input: struct_hash_call.abi_encode().into(),
+            ..Default::default()
+        };
+        let struct_hash = B256::from_slice(provider.call(struct_hash_tx.into()).await?.as_ref());
+
+        // Get typed data hash
+        let typed_hash_call = IFlashtestationRegistry::hashTypedDataV4Call {
+            structHash: struct_hash,
+        };
+        let typed_hash_tx = TransactionRequest {
+            to: Some(TxKind::Call(self.registry_address)),
+            input: typed_hash_call.abi_encode().into(),
+            ..Default::default()
+        };
+        let message_hash = B256::from_slice(provider.call(typed_hash_tx.into()).await?.as_ref());
+
+        // Sign the hash
+        let signature = self
+            .tee_service_signer
+            .sign_message(message_hash)
+            .map_err(TxManagerError::SignatureError)?;
+
+        let calldata = IFlashtestationRegistry::permitRegisterTEEServiceCall {
             rawQuote: quote_bytes,
             extendedRegistrationData: extra_registration_data,
+            nonce,
+            deadline,
+            signature: signature.as_bytes().into(),
         }
         .abi_encode();
         let tx = TransactionRequest {
@@ -147,30 +158,6 @@ impl TxManager {
                 Err(e)
             }
         }
-    }
-
-    pub async fn clean_up(&self) -> Result<(), TxManagerError> {
-        info!(target: "flashtestations", "sending funds back from TEE generated key to funding address");
-        let provider = ProviderBuilder::new()
-            .disable_recommended_fillers()
-            .network::<Optimism>()
-            .connect(self.rpc_url.as_str())
-            .await?;
-        let balance = provider
-            .get_balance(self.tee_service_signer.address)
-            .await?;
-        let gas_estimate = 21_000u128;
-        let gas_price = provider.get_gas_price().await?;
-        let gas_cost = U256::from(gas_estimate * gas_price);
-        if balance.gt(&gas_cost) {
-            self.fund_address(
-                self.tee_service_signer,
-                self.funding_signer.address,
-                balance.saturating_sub(gas_cost),
-            )
-            .await?;
-        }
-        Ok(())
     }
 
     /// Processes a pending transaction and logs whether the transaction succeeded or not


### PR DESCRIPTION
## 📝 Summary

Remove non permit calls and mark to be deprecated

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
