### PR TITLE
fix: remove ws publishing from synced flashblocks

### DIFF
--- a/crates/op-rbuilder/src/builders/flashblocks/ctx.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/ctx.rs
@@ -56,10 +56,6 @@ impl OpPayloadSyncerCtx {
         self.max_gas_per_txn
     }
 
-    pub(super) fn metrics(&self) -> &Arc<OpRBuilderMetrics> {
-        &self.metrics
-    }
-
     pub(super) fn into_op_payload_builder_ctx(
         self,
         payload_config: PayloadConfig<OpPayloadBuilderAttributes<OpTransactionSigned>>,

--- a/crates/op-rbuilder/src/builders/flashblocks/service.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/service.rs
@@ -150,7 +150,6 @@ impl FlashblocksServiceBuilder {
             outgoing_message_tx,
             payload_service.payload_events_handle(),
             syncer_ctx,
-            ws_pub,
             ctx.provider().clone(),
             cancel,
         );


### PR DESCRIPTION
## 📝 Summary

removal of logic in #310 

## 💡 Motivation and Context

we don't want non-active builders to publish flashblocks to ws, as it requires additional rollup-boost changes.

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
