### PR TITLE
[breaking-change] Fix arg for calculating state root

### DIFF
--- a/crates/op-rbuilder/src/args/op.rs
+++ b/crates/op-rbuilder/src/args/op.rs
@@ -151,11 +151,11 @@ pub struct FlashblocksArgs {
 
     /// Whether to disable state root calculation for each flashblock
     #[arg(
-        long = "flashblocks.disable-calculate-state-root",
+        long = "flashblocks.disable-state-root",
         default_value = "false",
-        env = "FLASHBLOCKS_DISABLE_STATE_ROOT_CALCULATION"
+        env = "FLASHBLOCKS_DISABLE_STATE_ROOT"
     )]
-    pub flashblocks_calculate_state_root: bool,
+    pub flashblocks_disable_state_root: bool,
 
     /// Flashblocks number contract address
     ///

--- a/crates/op-rbuilder/src/builders/flashblocks/config.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/config.rs
@@ -31,8 +31,8 @@ pub struct FlashblocksConfig {
     /// Disables dynamic flashblocks number adjustment based on FCU arrival time
     pub fixed: bool,
 
-    /// Should we calculate state root for each flashblock
-    pub calculate_state_root: bool,
+    /// Should we disable state root calculation for each flashblock
+    pub disable_state_root: bool,
 
     /// The address of the flashblocks number contract.
     ///
@@ -65,7 +65,7 @@ impl Default for FlashblocksConfig {
             interval: Duration::from_millis(250),
             leeway_time: Duration::from_millis(50),
             fixed: false,
-            calculate_state_root: true,
+            disable_state_root: false,
             flashblocks_number_contract_address: None,
             flashblocks_number_contract_use_permit: false,
             p2p_enabled: false,
@@ -92,7 +92,7 @@ impl TryFrom<OpRbuilderArgs> for FlashblocksConfig {
 
         let fixed = args.flashblocks.flashblocks_fixed;
 
-        let calculate_state_root = args.flashblocks.flashblocks_calculate_state_root;
+        let disable_state_root = args.flashblocks.flashblocks_disable_state_root;
 
         let flashblocks_number_contract_address =
             args.flashblocks.flashblocks_number_contract_address;
@@ -105,7 +105,7 @@ impl TryFrom<OpRbuilderArgs> for FlashblocksConfig {
             interval,
             leeway_time,
             fixed,
-            calculate_state_root,
+            disable_state_root,
             flashblocks_number_contract_address,
             flashblocks_number_contract_use_permit,
             p2p_enabled: args.flashblocks.p2p.p2p_enabled,

--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -87,8 +87,8 @@ pub struct FlashblocksExtraCtx {
     gas_per_batch: u64,
     /// DA bytes limit per flashblock
     da_per_batch: Option<u64>,
-    /// Whether to calculate the state root for each flashblock
-    calculate_state_root: bool,
+    /// Whether to disable state root calculation for each flashblock
+    disable_state_root: bool,
 }
 
 impl FlashblocksExtraCtx {
@@ -299,14 +299,14 @@ where
         );
 
         let timestamp = config.attributes.timestamp();
-        let calculate_state_root = self.config.specific.calculate_state_root;
+        let disable_state_root = self.config.specific.disable_state_root;
         let ctx = self
             .get_op_payload_builder_ctx(
                 config.clone(),
                 block_cancel.clone(),
                 FlashblocksExtraCtx {
                     target_flashblock_count: self.config.flashblocks_per_block(),
-                    calculate_state_root,
+                    disable_state_root,
                     ..Default::default()
                 },
             )
@@ -355,7 +355,7 @@ where
             &mut state,
             &ctx,
             &mut info,
-            calculate_state_root || ctx.attributes().no_tx_pool, // need to calculate state root for CL sync
+            !disable_state_root || ctx.attributes().no_tx_pool, // need to calculate state root for CL sync
         )?;
 
         self.payload_tx
@@ -450,7 +450,7 @@ where
             target_da_for_batch,
             gas_per_batch,
             da_per_batch,
-            calculate_state_root,
+            disable_state_root,
         };
 
         let mut fb_cancel = block_cancel.child_token();
@@ -699,7 +699,7 @@ where
             state,
             ctx,
             info,
-            ctx.extra_ctx.calculate_state_root || ctx.attributes().no_tx_pool,
+            !ctx.extra_ctx.disable_state_root || ctx.attributes().no_tx_pool,
         );
         let total_block_built_duration = total_block_built_duration.elapsed();
         ctx.metrics

--- a/crates/op-rbuilder/src/tests/flashblocks.rs
+++ b/crates/op-rbuilder/src/tests/flashblocks.rs
@@ -419,7 +419,7 @@ async fn test_flashblock_min_max_filtering(rbuilder: LocalInstance) -> eyre::Res
         flashblocks_block_time: 200,
         flashblocks_leeway_time: 100,
         flashblocks_fixed: false,
-        flashblocks_calculate_state_root: false,
+        flashblocks_disable_state_root: true,
         ..Default::default()
     },
     ..Default::default()
@@ -436,7 +436,7 @@ async fn test_flashblocks_no_state_root_calculation(rbuilder: LocalInstance) -> 
         .send()
         .await?;
 
-    // Build a block with current timestamp (not historical) and calculate_state_root: false
+    // Build a block with current timestamp (not historical) and disable_state_root: true
     let block = driver.build_new_block_with_current_timestamp(None).await?;
 
     // Verify that flashblocks are still produced (block should have transactions)
@@ -449,7 +449,7 @@ async fn test_flashblocks_no_state_root_calculation(rbuilder: LocalInstance) -> 
     assert_eq!(
         block.header.state_root,
         B256::ZERO,
-        "State root should be zero when calculate_state_root is false"
+        "State root should be zero when disable_state_root is true"
     );
 
     Ok(())


### PR DESCRIPTION
## 📝 Summary

```
op-rbuilder node --flashblocks.calculate-state-root=false
error: unexpected value 'false' for '--flashblocks.calculate-state-root' found; no more were expected

Usage: op-rbuilder node --flashblocks.calculate-state-root
```

default for boolean flags should be false, otherwise clap does not recognise true / false passed into the arg

updates the cli flag from `--flashblocks.calculate-state-root` to `--flashblocks.disable-calculate-state-root` and the corresponding env flag.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
