### PR TITLE
chore(op-alloy): Update to use op-alloy flashblock types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,11 +167,11 @@ rollup-boost = { git = "https://github.com/flashbots/rollup-boost", tag = "v0.7.
 # optimism
 alloy-op-evm = { version = "0.23.0", default-features = false }
 alloy-op-hardforks = "0.4.4"
-op-alloy-rpc-types = { version = "0.22.0", default-features = false }
-op-alloy-rpc-types-engine = { version = "0.22.0", default-features = false }
-op-alloy-rpc-jsonrpsee = { version = "0.22.0", default-features = false }
-op-alloy-network = { version = "0.22.0", default-features = false }
-op-alloy-consensus = { version = "0.22.0", default-features = false }
+op-alloy-rpc-types = { version = "0.22.4", default-features = false }
+op-alloy-rpc-types-engine = { version = "0.22.4", default-features = false }
+op-alloy-rpc-jsonrpsee = { version = "0.22.4", default-features = false }
+op-alloy-network = { version = "0.22.4", default-features = false }
+op-alloy-consensus = { version = "0.22.4", default-features = false }
 op-alloy-flz = { version = "0.13.1", default-features = false }
 
 async-trait = { version = "0.1.83" }

--- a/crates/op-rbuilder/src/builders/flashblocks/payload_handler.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload_handler.rs
@@ -9,6 +9,7 @@ use alloy_evm::eth::receipt_builder::ReceiptBuilderCtx;
 use alloy_primitives::B64;
 use eyre::{WrapErr as _, bail};
 use op_alloy_consensus::OpTxEnvelope;
+use op_alloy_rpc_types_engine::OpFlashblockPayload;
 use reth::revm::{State, database::StateProviderDatabase};
 use reth_basic_payload_builder::PayloadConfig;
 use reth_evm::FromRecoveredTx;
@@ -19,7 +20,6 @@ use reth_optimism_node::{OpEngineTypes, OpPayloadBuilderAttributes};
 use reth_optimism_payload_builder::OpBuiltPayload;
 use reth_optimism_primitives::{OpReceipt, OpTransactionSigned};
 use reth_payload_builder::EthPayloadBuilderAttributes;
-use rollup_boost::FlashblocksPayloadV1;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::warn;
@@ -135,7 +135,7 @@ fn execute_flashblock<Client>(
     ctx: OpPayloadSyncerCtx,
     client: Client,
     cancel: tokio_util::sync::CancellationToken,
-) -> eyre::Result<(OpBuiltPayload, FlashblocksPayloadV1)>
+) -> eyre::Result<(OpBuiltPayload, OpFlashblockPayload)>
 where
     Client: ClientBounds,
 {

--- a/crates/op-rbuilder/src/builders/flashblocks/wspub.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/wspub.rs
@@ -5,7 +5,7 @@ use core::{
 };
 use futures::SinkExt;
 use futures_util::StreamExt;
-use rollup_boost::FlashblocksPayloadV1;
+use op_alloy_rpc_types_engine::OpFlashblockPayload;
 use std::{io, net::TcpListener, sync::Arc};
 use tokio::{
     net::TcpStream,
@@ -25,7 +25,7 @@ use crate::metrics::OpRBuilderMetrics;
 /// A WebSockets publisher that accepts connections from client websockets and broadcasts to them
 /// updates about new flashblocks. It maintains a count of sent messages and active subscriptions.
 ///
-/// This is modelled as a `futures::Sink` that can be used to send `FlashblocksPayloadV1` messages.
+/// This is modelled as a `futures::Sink` that can be used to send `OpFlashblockPayload` messages.
 pub(super) struct WebSocketPublisher {
     sent: Arc<AtomicUsize>,
     subs: Arc<AtomicUsize>,
@@ -59,7 +59,7 @@ impl WebSocketPublisher {
         })
     }
 
-    pub(super) fn publish(&self, payload: &FlashblocksPayloadV1) -> io::Result<usize> {
+    pub(super) fn publish(&self, payload: &OpFlashblockPayload) -> io::Result<usize> {
         // Serialize the payload to a UTF-8 string
         // serialize only once, then just copy around only a pointer
         // to the serialized data for each subscription.


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->

## 💡 Motivation and Context

Update to use op-alloy flashblock types. For consistency across repos.

* Corresponding rollup-boost PR: https://github.com/flashbots/rollup-boost/pull/441
* Reth reference: https://github.com/paradigmxyz/reth/pull/19608

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
