### PR TITLE
Fix div zero panic from zero fb calculation (#35)

### DIFF
--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -876,7 +876,11 @@ where
         let target_time = std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(timestamp)
             - self.config.specific.leeway_time;
         let now = std::time::SystemTime::now();
-        let Ok(time_drift) = target_time.duration_since(now) else {
+        let Some(time_drift) = target_time
+            .duration_since(now)
+            .ok()
+            .filter(|duration| duration.as_millis() > 0)
+        else {
             error!(
                 target: "payload_builder",
                 message = "FCU arrived too late or system clock are unsynced",


### PR DESCRIPTION
## 📝 Summary

This PR resolves the issue found on stress test where if the FCU arrives time=nice target_time-leeway_time, time drift calculated will be zero. This results in during calculate_flashblocks operation, the number of flashblocks to be built to be equal to zero, causing a panic on subsequent gas limit calculation due to a div-zero error.

The PR fixes handling on calculating time drift to additionally check if time drift is > 0.

**Context of the issue:**
![img_v3_00sl_2e02e473-6625-44f5-a1bd-a7d4534266hu](https://github.com/user-attachments/assets/c4910830-5840-4546-beca-1c6480ddb35c)


## ✅ I have completed the following steps:

* [ ✅ ] Run `make lint`
* [✅  ] Run `make test`
* [ ] Added tests (if applicable)
