### PR TITLE
fix(flashblocks): handle missing parent_beacon_block_root

### DIFF
--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -1176,7 +1176,7 @@ where
                 .attributes()
                 .payload_attributes
                 .parent_beacon_block_root
-                .unwrap(),
+                .unwrap_or_default(),
             parent_hash: ctx.parent().hash(),
             fee_recipient: ctx.attributes().suggested_fee_recipient(),
             prev_randao: ctx.attributes().payload_attributes.prev_randao,


### PR DESCRIPTION
## Summary
Replace `unwrap()` with `unwrap_or_default()` to prevent panic when `parent_beacon_block_root` is None.

## Changes
- `crates/op-rbuilder/src/builders/flashblocks/payload.rs`: Use `unwrap_or_default()` instead of `unwrap()` for `parent_beacon_block_root`

Closes #194