### PR TITLE
fix:  release-plz don't publish op-rbuilder to cargo.io

### DIFF
--- a/.github/workflows/release-plz.yaml
+++ b/.github/workflows/release-plz.yaml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.ref }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -16,7 +16,8 @@ pr_labels = ["release"]
 
 [[package]]
 name = "op-rbuilder"
-# Main package to release
+# Main package to release (binary only, not published to crates.io)
+publish = false
 changelog_include = ["p2p", "tdx-quote-provider"]
 
 [[package]]
@@ -29,4 +30,10 @@ release = false
 [[package]]
 name = "tdx-quote-provider"
 # Has its own release workflow
+release = false
+
+[[package]]
+name = "macros"
+# Test infrastructure - don't publish or release
+publish = false
 release = false

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.92.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
