### PR TITLE
Feat: async-orchestrated payload builder with isolated blocking phases

### DIFF
--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -29,7 +29,7 @@ use op_alloy_rpc_types_engine::{
     OpFlashblockPayload, OpFlashblockPayloadBase, OpFlashblockPayloadDelta,
     OpFlashblockPayloadMetadata,
 };
-use reth::payload::PayloadBuilderAttributes;
+use reth::{payload::PayloadBuilderAttributes, tasks::TaskSpawner};
 use reth_basic_payload_builder::BuildOutcome;
 use reth_chainspec::EthChainSpec;
 use reth_evm::{ConfigureEvm, execute::BlockBuilder};
@@ -51,8 +51,8 @@ use reth_revm::{
 use reth_transaction_pool::TransactionPool;
 use reth_trie::{HashedPostState, updates::TrieUpdates};
 use revm::Database;
-use std::{collections::BTreeMap, sync::Arc, time::Instant};
-use tokio::sync::{mpsc, watch};
+use std::{collections::BTreeMap, ops::Deref, sync::Arc, time::Instant};
+use tokio::sync::{mpsc, oneshot, watch};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, metadata::Level, span, warn};
 
@@ -111,6 +111,26 @@ pub(super) struct FlashblocksState {
     /// Index into ExecutionInfo tracking the last consumed flashblock
     /// Used for slicing transactions/receipts per flashblock
     last_flashblock_tx_index: usize,
+}
+
+struct FallbackBuildOutput<Cache, Transition> {
+    ctx: OpPayloadBuilderCtx,
+    info: ExecutionInfo,
+    payload: OpBuiltPayload,
+    fb_payload: OpFlashblockPayload,
+    cache: Cache,
+    transition: Transition,
+    fb_state: FlashblocksState,
+}
+
+struct FlashblockBuildOutput<Cache, Transition> {
+    ctx: OpPayloadBuilderCtx,
+    build_result: eyre::Result<Option<(FlashblocksState, OpBuiltPayload)>>,
+    cache: Cache,
+    transition: Transition,
+    committed_txs: FlashblockCommittedTxs,
+    info: ExecutionInfo,
+    fb_state: FlashblocksState,
 }
 
 impl FlashblocksState {
@@ -226,36 +246,59 @@ impl FlashblocksState {
 // Flashblocks-specific helper methods moved to FlashblocksState
 
 /// Optimism's payload builder
-#[derive(Debug, Clone)]
-pub(super) struct OpPayloadBuilder<Pool, Client, BuilderTx> {
-    /// The type responsible for creating the evm.
-    pub evm_config: OpEvmConfig,
-    /// The transaction pool
-    pub pool: Pool,
-    /// Node client
-    pub client: Client,
-    /// Sender for sending built flashblock payloads to [`PayloadHandler`],
-    /// which broadcasts outgoing flashblock payloads via p2p.
-    pub built_fb_payload_tx: mpsc::Sender<OpBuiltPayload>,
-    /// Sender for sending built full block payloads to [`PayloadHandler`],
-    /// which updates the engine tree state.
-    pub built_payload_tx: mpsc::Sender<OpBuiltPayload>,
-    /// WebSocket publisher for broadcasting flashblocks
-    /// to all connected subscribers.
-    pub ws_pub: Arc<WebSocketPublisher>,
-    /// System configuration for the builder
-    pub config: BuilderConfig<FlashblocksConfig>,
-    /// The metrics for the builder
-    pub metrics: Arc<OpRBuilderMetrics>,
-    /// The end of builder transaction type
-    pub builder_tx: BuilderTx,
-    /// Rate limiting based on gas. This is an optional feature.
-    pub address_gas_limiter: AddressGasLimiter,
-    /// Tokio task metrics for monitoring spawned tasks
-    pub task_metrics: Arc<FlashblocksTaskMetrics>,
+#[derive(Debug)]
+pub(super) struct OpPayloadBuilder<Pool, Client, BuilderTx, Tasks> {
+    inner: Arc<OpPayloadBuilderInner<Pool, Client, BuilderTx, Tasks>>,
 }
 
-impl<Pool, Client, BuilderTx> OpPayloadBuilder<Pool, Client, BuilderTx> {
+#[derive(Debug)]
+pub(super) struct OpPayloadBuilderInner<Pool, Client, BuilderTx, Tasks> {
+    /// The type responsible for creating the evm.
+    evm_config: OpEvmConfig,
+    /// The transaction pool
+    pool: Pool,
+    /// Node client
+    client: Client,
+    /// Sender for sending built flashblock payloads to [`PayloadHandler`],
+    /// which broadcasts outgoing flashblock payloads via p2p.
+    built_fb_payload_tx: mpsc::Sender<OpBuiltPayload>,
+    /// Sender for sending built full block payloads to [`PayloadHandler`],
+    /// which updates the engine tree state.
+    built_payload_tx: mpsc::Sender<OpBuiltPayload>,
+    /// WebSocket publisher for broadcasting flashblocks
+    /// to all connected subscribers.
+    ws_pub: Arc<WebSocketPublisher>,
+    /// System configuration for the builder
+    config: BuilderConfig<FlashblocksConfig>,
+    /// The metrics for the builder
+    metrics: Arc<OpRBuilderMetrics>,
+    /// The end of builder transaction type
+    builder_tx: BuilderTx,
+    /// Rate limiting based on gas. This is an optional feature.
+    address_gas_limiter: AddressGasLimiter,
+    /// Tokio task metrics for monitoring spawned tasks
+    task_metrics: Arc<FlashblocksTaskMetrics>,
+    /// Task executor used to offload blocking work.
+    executor: Tasks,
+}
+
+impl<Pool, Client, BuilderTx, Tasks> Deref for OpPayloadBuilder<Pool, Client, BuilderTx, Tasks> {
+    type Target = OpPayloadBuilderInner<Pool, Client, BuilderTx, Tasks>;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner.as_ref()
+    }
+}
+
+impl<Pool, Client, BuilderTx, Tasks> Clone for OpPayloadBuilder<Pool, Client, BuilderTx, Tasks> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<Pool, Client, BuilderTx, Tasks> OpPayloadBuilder<Pool, Client, BuilderTx, Tasks> {
     /// `OpPayloadBuilder` constructor.
     #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
@@ -269,30 +312,35 @@ impl<Pool, Client, BuilderTx> OpPayloadBuilder<Pool, Client, BuilderTx> {
         ws_pub: Arc<WebSocketPublisher>,
         metrics: Arc<OpRBuilderMetrics>,
         task_metrics: Arc<FlashblocksTaskMetrics>,
+        executor: Tasks,
     ) -> Self {
         let address_gas_limiter = AddressGasLimiter::new(config.gas_limiter_config.clone());
         Self {
-            evm_config,
-            pool,
-            client,
-            built_fb_payload_tx,
-            built_payload_tx,
-            ws_pub,
-            config,
-            metrics,
-            builder_tx,
-            address_gas_limiter,
-            task_metrics,
+            inner: Arc::new(OpPayloadBuilderInner {
+                evm_config,
+                pool,
+                client,
+                built_fb_payload_tx,
+                built_payload_tx,
+                ws_pub,
+                config,
+                metrics,
+                builder_tx,
+                address_gas_limiter,
+                task_metrics,
+                executor,
+            }),
         }
     }
 }
 
-impl<Pool, Client, BuilderTx> reth_basic_payload_builder::PayloadBuilder
-    for OpPayloadBuilder<Pool, Client, BuilderTx>
+impl<Pool, Client, BuilderTx, Tasks> reth_basic_payload_builder::PayloadBuilder
+    for OpPayloadBuilder<Pool, Client, BuilderTx, Tasks>
 where
-    Pool: Clone + Send + Sync,
-    Client: Clone + Send + Sync,
-    BuilderTx: Clone + Send + Sync,
+    Pool: Clone + Send + Sync + 'static,
+    Client: Clone + Send + Sync + 'static,
+    BuilderTx: Send + Sync + 'static,
+    Tasks: Clone + Send + Sync + 'static,
 {
     type Attributes = OpPayloadBuilderAttributes<OpTransactionSigned>;
     type BuiltPayload = OpBuiltPayload;
@@ -315,12 +363,28 @@ where
     }
 }
 
-impl<Pool, Client, BuilderTx> OpPayloadBuilder<Pool, Client, BuilderTx>
+impl<Pool, Client, BuilderTx, Tasks> OpPayloadBuilder<Pool, Client, BuilderTx, Tasks>
 where
-    Pool: PoolBounds,
-    Client: ClientBounds,
-    BuilderTx: BuilderTransactions + Send + Sync,
+    Pool: PoolBounds + 'static,
+    Client: ClientBounds + 'static,
+    BuilderTx: BuilderTransactions + Send + Sync + 'static,
+    Tasks: TaskSpawner + Clone + Send + Sync + 'static,
 {
+    /// Helper to spawn a blocking task that returns T in a oneshot channel
+    async fn run_blocking_task<T, F>(&self, task: F) -> Result<T, PayloadBuilderError>
+    where
+        T: Send + 'static,
+        F: FnOnce() -> Result<T, PayloadBuilderError> + Send + 'static,
+    {
+        let (tx, rx) = oneshot::channel();
+        self.executor.spawn_blocking(Box::pin(async move {
+            let _ = tx.send(task());
+        }));
+
+        rx.await
+            .map_err(|_| PayloadBuilderError::Other("blocking task dropped".into()))?
+    }
+
     fn get_op_payload_builder_ctx(
         &self,
         config: reth_basic_payload_builder::PayloadConfig<
@@ -405,7 +469,7 @@ where
     ) -> Result<(), PayloadBuilderError> {
         let block_build_start_time = Instant::now();
         let BuildArguments {
-            mut cached_reads,
+            cached_reads,
             config,
             cancel: block_cancel,
         } = args;
@@ -438,56 +502,80 @@ where
 
         self.address_gas_limiter.refresh(ctx.block_number());
 
-        // Phase 1: Build the fallback block. state_provider and State<DB> are
-        // scoped here so they do not live across await points
-        let (mut info, payload, fb_payload, mut cache, mut transition) = {
-            let state_provider = self.client.state_by_block_hash(ctx.parent().hash())?;
-            let db = StateProviderDatabase::new(&state_provider);
+        // Phase 1: Build the fallback block.
+        let FallbackBuildOutput {
+            ctx,
+            mut info,
+            payload,
+            fb_payload,
+            mut cache,
+            mut transition,
+            fb_state: returned_fb_state,
+        } = self
+            .run_blocking_task({
+                let builder = self.clone();
+                let ctx = ctx;
+                let mut fb_state = fb_state;
+                move || {
+                    let state_provider = builder.client.state_by_block_hash(ctx.parent().hash())?;
+                    let db = StateProviderDatabase::new(&state_provider);
 
-            // 1. execute the pre steps and seal an early block with that
-            let sequencer_tx_start_time = Instant::now();
-            let mut state = State::builder()
-                .with_database(cached_reads.as_db_mut(db))
-                .with_bundle_update()
-                .build();
+                    // 1. execute the pre steps and seal an early block with that
+                    let sequencer_tx_start_time = Instant::now();
+                    let mut cached_reads = cached_reads;
+                    let mut state = State::builder()
+                        .with_database(cached_reads.as_db_mut(db))
+                        .with_bundle_update()
+                        .build();
 
-            let mut info = execute_pre_steps(&mut state, &ctx)?;
-            let sequencer_tx_time = sequencer_tx_start_time.elapsed();
-            ctx.metrics.sequencer_tx_duration.record(sequencer_tx_time);
-            ctx.metrics.sequencer_tx_gauge.set(sequencer_tx_time);
+                    let mut info = execute_pre_steps(&mut state, &ctx)?;
+                    let sequencer_tx_time = sequencer_tx_start_time.elapsed();
+                    ctx.metrics.sequencer_tx_duration.record(sequencer_tx_time);
+                    ctx.metrics.sequencer_tx_gauge.set(sequencer_tx_time);
 
-            // We add first builder tx right after deposits
-            if !ctx.attributes().no_tx_pool
-                && let Err(e) = self.builder_tx.add_builder_txs(
-                    &state_provider,
-                    &mut info,
-                    &ctx,
-                    &mut state,
-                    false,
-                    fb_state.is_first_flashblock(),
-                    fb_state.is_last_flashblock(),
-                )
-            {
-                error!(
-                    target: "payload_builder",
-                    "Error adding builder txs to fallback block: {}",
-                    e
-                );
-            };
+                    // We add first builder tx right after deposits
+                    if !ctx.attributes().no_tx_pool
+                        && let Err(e) = builder.builder_tx.add_builder_txs(
+                            &state_provider,
+                            &mut info,
+                            &ctx,
+                            &mut state,
+                            false,
+                            fb_state.is_first_flashblock(),
+                            fb_state.is_last_flashblock(),
+                        )
+                    {
+                        error!(
+                            target: "payload_builder",
+                            "Error adding builder txs to fallback block: {}",
+                            e
+                        );
+                    };
 
-            let (payload, fb_payload) = build_block(
-                &mut state,
-                &ctx,
-                Some(&mut fb_state),
-                &mut info,
-                !disable_state_root || ctx.attributes().no_tx_pool, // need to calculate state root for CL sync
-            )?;
+                    let (payload, fb_payload) = build_block(
+                        &mut state,
+                        &ctx,
+                        Some(&mut fb_state),
+                        &mut info,
+                        !disable_state_root || ctx.attributes().no_tx_pool, // need to calculate state root for CL sync
+                    )?;
 
-            // we can safely take from state as we drop it at the end of the scope
-            let cache = std::mem::take(&mut state.cache);
-            let transition = state.transition_state.take();
-            (info, payload, fb_payload, cache, transition)
-        };
+                    // we can safely take from state as we drop it at the end of the scope
+                    let cache = std::mem::take(&mut state.cache);
+                    let transition = state.transition_state.take();
+                    Ok(FallbackBuildOutput {
+                        ctx,
+                        info,
+                        payload,
+                        fb_payload,
+                        cache,
+                        transition,
+                        fb_state,
+                    })
+                }
+            })
+            .await?;
+        fb_state = returned_fb_state;
 
         self.built_fb_payload_tx
             .try_send(payload.clone())
@@ -651,36 +739,70 @@ where
             };
             let _entered = fb_span.enter();
 
-            // Build flashblock after receiving signal
-            let (build_result, new_cache, new_transition) = {
-                // reconstruct state
-                let state_provider = self.client.state_by_block_hash(parent_hash)?;
-                let mut state = State::builder()
-                    .with_database(StateProviderDatabase::new(&state_provider))
-                    .with_cached_prestate(cache)
-                    .with_bundle_update()
-                    .build();
-                state.transition_state = transition;
+            let FlashblockBuildOutput {
+                ctx: returned_ctx,
+                build_result,
+                cache: new_cache,
+                transition: new_transition,
+                committed_txs: new_committed,
+                info: new_info,
+                fb_state: returned_fb_state,
+            } = self
+                .run_blocking_task({
+                    let builder = self.clone();
+                    let ctx = ctx;
+                    let block_cancel = block_cancel.clone();
+                    let info = info;
+                    let cache = cache;
+                    let transition = transition;
+                    let mut committed_txs = committed_txs;
+                    let fb_state = fb_state;
+                    move || {
+                        // reconstruct state
+                        let state_provider = builder.client.state_by_block_hash(parent_hash)?;
+                        let mut state = State::builder()
+                            .with_database(StateProviderDatabase::new(&state_provider))
+                            .with_cached_prestate(cache)
+                            .with_bundle_update()
+                            .build();
+                        state.transition_state = transition;
 
-                let mut best_txs = FlashblockPoolTxCursor::new(&mut committed_txs);
+                        let mut best_txs = FlashblockPoolTxCursor::new(&mut committed_txs);
 
-                let result = self.build_next_flashblock(
-                    &ctx,
-                    &mut fb_state,
-                    &mut info,
-                    &mut state,
-                    &state_provider,
-                    &mut best_txs,
-                    &block_cancel,
-                );
+                        let mut info = info;
+                        let mut fb_state = fb_state;
+                        let result = builder.build_next_flashblock(
+                            &ctx,
+                            &mut fb_state,
+                            &mut info,
+                            &mut state,
+                            &state_provider,
+                            &mut best_txs,
+                            &block_cancel,
+                        );
 
-                let cache = std::mem::take(&mut state.cache);
-                let transition_state = state.transition_state.take();
-                (result, cache, transition_state)
-            }; // provider and state dropped
+                        let cache = std::mem::take(&mut state.cache);
+                        let transition_state = state.transition_state.take();
 
+                        Ok(FlashblockBuildOutput {
+                            ctx,
+                            build_result: result,
+                            cache,
+                            transition: transition_state,
+                            committed_txs,
+                            info,
+                            fb_state,
+                        })
+                    }
+                })
+                .await?;
+
+            ctx = returned_ctx;
+            fb_state = returned_fb_state;
+            info = new_info;
             cache = new_cache;
             transition = new_transition;
+            committed_txs = new_committed;
 
             let next_flashblock_state = match build_result {
                 Ok(Some((next_flashblock_state, new_payload))) => {
@@ -985,11 +1107,13 @@ where
 }
 
 #[async_trait::async_trait]
-impl<Pool, Client, BuilderTx> PayloadBuilder for OpPayloadBuilder<Pool, Client, BuilderTx>
+impl<Pool, Client, BuilderTx, Tasks> PayloadBuilder
+    for OpPayloadBuilder<Pool, Client, BuilderTx, Tasks>
 where
-    Pool: PoolBounds,
-    Client: ClientBounds,
-    BuilderTx: BuilderTransactions + Clone + Send + Sync,
+    Pool: PoolBounds + 'static,
+    Client: ClientBounds + 'static,
+    BuilderTx: BuilderTransactions + Send + Sync + 'static,
+    Tasks: TaskSpawner + Clone + Send + Sync + 'static,
 {
     type Attributes = OpPayloadBuilderAttributes<OpTransactionSigned>;
     type BuiltPayload = OpBuiltPayload;

--- a/crates/op-rbuilder/src/builders/flashblocks/service.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/service.rs
@@ -126,6 +126,7 @@ impl FlashblocksServiceBuilder {
             ws_pub.clone(),
             metrics.clone(),
             task_metrics.clone(),
+            ctx.task_executor().clone(),
         );
         let payload_job_config = BasicPayloadJobGeneratorConfig::default();
 

--- a/crates/op-rbuilder/src/builders/generator.rs
+++ b/crates/op-rbuilder/src/builders/generator.rs
@@ -318,7 +318,9 @@ where
         let (watch_tx, watch_rx) = watch::channel(None);
         self.payload_rx = Some(watch_rx);
         let cached_reads = self.cached_reads.take().unwrap_or_default();
-        self.executor.spawn_blocking(Box::pin(async move {
+        // try_build is not in a blocking task!
+        // We have to make sure any blocking work is handled individually within payload builder
+        self.executor.spawn(Box::pin(async move {
             let args = BuildArguments {
                 cached_reads,
                 config: payload_config,
@@ -426,7 +428,7 @@ mod tests {
     use alloy_eips::eip7685::Requests;
     use alloy_primitives::U256;
     use rand::rng;
-    use reth::tasks::TokioTaskExecutor;
+    use reth::tasks::{TaskSpawner, TokioTaskExecutor};
     use reth_node_api::NodePrimitives;
     use reth_optimism_payload_builder::{OpPayloadPrimitives, payload::OpPayloadBuilderAttributes};
     use reth_optimism_primitives::OpPrimitives;
@@ -434,7 +436,58 @@ mod tests {
     use reth_primitives::SealedBlock;
     use reth_provider::test_utils::MockEthProvider;
     use reth_testing_utils::generators::{BlockRangeParams, random_block_range};
-    use tokio::time::{Duration, sleep, timeout};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::{
+        task::JoinHandle,
+        time::{Duration, sleep, timeout},
+    };
+
+    #[derive(Debug, Clone, Default)]
+    struct CountingTaskExecutor {
+        spawn_calls: Arc<AtomicUsize>,
+        spawn_blocking_calls: Arc<AtomicUsize>,
+    }
+
+    impl CountingTaskExecutor {
+        fn spawn_calls(&self) -> usize {
+            self.spawn_calls.load(Ordering::Relaxed)
+        }
+
+        fn spawn_blocking_calls(&self) -> usize {
+            self.spawn_blocking_calls.load(Ordering::Relaxed)
+        }
+    }
+
+    impl TaskSpawner for CountingTaskExecutor {
+        fn spawn(&self, fut: futures_util::future::BoxFuture<'static, ()>) -> JoinHandle<()> {
+            self.spawn_calls.fetch_add(1, Ordering::Relaxed);
+            tokio::task::spawn(fut)
+        }
+
+        fn spawn_critical(
+            &self,
+            _name: &'static str,
+            fut: futures_util::future::BoxFuture<'static, ()>,
+        ) -> JoinHandle<()> {
+            self.spawn(fut)
+        }
+
+        fn spawn_blocking(
+            &self,
+            fut: futures_util::future::BoxFuture<'static, ()>,
+        ) -> JoinHandle<()> {
+            self.spawn_blocking_calls.fetch_add(1, Ordering::Relaxed);
+            tokio::task::spawn_blocking(move || tokio::runtime::Handle::current().block_on(fut))
+        }
+
+        fn spawn_critical_blocking(
+            &self,
+            _name: &'static str,
+            fut: futures_util::future::BoxFuture<'static, ()>,
+        ) -> JoinHandle<()> {
+            self.spawn_blocking(fut)
+        }
+    }
 
     #[derive(Debug, Clone)]
     struct MockBuilder<N> {
@@ -593,6 +646,48 @@ mod tests {
             let events = builder.get_events();
             assert_eq!(events, vec![BlockEvent::Started, BlockEvent::Cancelled]);
         }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_spawn_build_job_uses_async_executor() -> eyre::Result<()> {
+        let mut rng = rng();
+
+        let client = MockEthProvider::default();
+        let executor = CountingTaskExecutor::default();
+        let config = BasicPayloadJobGeneratorConfig::default();
+        let builder = MockBuilder::<OpPrimitives>::new();
+
+        let blocks = random_block_range(
+            &mut rng,
+            1..=1,
+            BlockRangeParams {
+                tx_count: 0..1,
+                ..Default::default()
+            },
+        );
+        client.extend_blocks(blocks.iter().cloned().map(|b| (b.hash(), b.unseal())));
+
+        let generator = BlockPayloadJobGenerator::with_builder(
+            client.clone(),
+            executor.clone(),
+            config,
+            builder,
+            false,
+            Duration::from_secs(1),
+        );
+
+        let mut attr = OpPayloadBuilderAttributes::default();
+        attr.payload_attributes.parent = client.latest_header()?.unwrap().hash();
+
+        let mut job = generator.new_payload_job(attr)?;
+
+        assert_eq!(executor.spawn_calls(), 1);
+        assert_eq!(executor.spawn_blocking_calls(), 0);
+
+        let _ = job.resolve();
+        let _ = job.await;
 
         Ok(())
     }


### PR DESCRIPTION
## 📝 Summary

- Generator orchestration moved off blocking pool
    - BlockPayloadJob::spawn_build_job now uses spawn instead of spawn_blocking
- Task executor moved into flashblocks payload builder
    - OpPayloadBuilder now has direct access to task executor for internal blocking phases orchestration
- Blocking phase isolation inside payload builder
    - Extracted heavy phases in blocking boundaries:
        - fallback block build
        - per-flashblock candidate build
- OpPayloadBuilder uses O(1) cloning with Arc-backed inner to be easily moved in tasks

## 💡 Motivation and Context

Even with async migration in #394 and #397, build_payload still contains long blocking sections (state reconstruction, transaction execution, state root calculation, block sealing), that reduces runtime responsiveness and makes cancellation/timing control a bit hard to reason about and to react to in time.

To unlock robust select!-based control flow (which will be useful for more reactive building patterns), we need a clear separation:
- async control loop and timing management on main payload building worker job
- blocking phases on the blocking pool

This PR moves toward a model where:
- payload builder has full control over job orchestration in async-native way
- blocking work is explicitly isolated into bounded blocking tasks
- state handoff between phases is explicit and typed (i believe we can still do some refactor there)
    - This still using cache + transition states to reconstruct state in each block, with the ability to apply/commit back to the main building job back, but there might be even better way to do that.