### PR TITLE
feat: skip re-simulation of reverted txs between flashblocks

### DIFF
--- a/crates/op-rbuilder/src/args/op.rs
+++ b/crates/op-rbuilder/src/args/op.rs
@@ -53,6 +53,14 @@ pub struct OpRbuilderArgs {
     #[arg(long = "builder.enable-revert-protection", default_value = "false")]
     pub enable_revert_protection: bool,
 
+    /// Skip re-simulating reverted transactions in subsequent flashblocks within the same block.
+    #[arg(
+        long = "builder.exclude-reverts-between-flashblocks",
+        default_value = "false",
+        env = "BUILDER_EXCLUDE_REVERTS_BETWEEN_FLASHBLOCKS"
+    )]
+    pub exclude_reverts_between_flashblocks: bool,
+
     /// Enables logs to trace transaction lifecycle as it is added to the
     /// mempool and added to a block. Requires `RUST_LOG=tx_trace=debug` in
     /// addition to this flag.

--- a/crates/op-rbuilder/src/builder/best_txs.rs
+++ b/crates/op-rbuilder/src/builder/best_txs.rs
@@ -16,6 +16,9 @@ where
     // Transactions that were already commited to the state. Using them again would cause NonceTooLow
     // so we skip them
     commited_transactions: HashSet<TxHash>,
+    // Transactions that reverted and were excluded. Skipped in subsequent flashblocks to avoid
+    // redundant re-simulation.
+    excluded_tx_hashes: HashSet<TxHash>,
 }
 
 impl<T, I> BestFlashblocksTxs<T, I>
@@ -28,6 +31,7 @@ where
             inner,
             current_flashblock_number: 0,
             commited_transactions: Default::default(),
+            excluded_tx_hashes: Default::default(),
         }
     }
 
@@ -60,6 +64,11 @@ where
             let tx = self.inner.next(ctx)?;
             // Skip transaction we already included
             if self.commited_transactions.contains(tx.hash()) {
+                continue;
+            }
+
+            // Skip transactions that reverted in a previous flashblock
+            if self.excluded_tx_hashes.contains(tx.hash()) {
                 continue;
             }
 
@@ -97,6 +106,15 @@ where
     /// Proxy to inner iterator
     fn mark_invalid(&mut self, sender: Address, nonce: u64) {
         self.inner.mark_invalid(sender, nonce);
+    }
+}
+
+impl<I> crate::traits::PayloadTxsBounds for BestFlashblocksTxs<crate::tx::FBPooledTransaction, I>
+where
+    I: Iterator<Item = Arc<ValidPoolTransaction<crate::tx::FBPooledTransaction>>>,
+{
+    fn mark_excluded(&mut self, hash: TxHash) {
+        self.excluded_tx_hashes.insert(hash);
     }
 }
 
@@ -233,5 +251,135 @@ mod tests {
         assert_eq!(tx3.hash(), &tx_3_hash);
         // Check that it's empty
         assert!(iterator.next(()).is_none(), "Iterator should be empty");
+    }
+
+    /// Excluded txs persist across flashblocks (refresh_iterator) within the same block,
+    /// but a new iterator (new block) starts with a clean excluded set.
+    #[test]
+    fn test_excluded_txs_persist_within_block_cleared_between_blocks() {
+        let mut pool = PendingPool::new(CoinbaseTipOrdering::<MockFbTransaction>::default());
+        let mut f = MockFbTransactionFactory::default();
+
+        let tx_1 = f.create_eip1559();
+        let tx_1_hash = *tx_1.hash();
+        let tx_2 = f.create_eip1559();
+        let tx_2_hash = *tx_2.hash();
+        let tx_3 = f.create_eip1559();
+        let tx_3_hash = *tx_3.hash();
+        pool.add_transaction(Arc::new(tx_1), 0);
+        pool.add_transaction(Arc::new(tx_2), 0);
+        pool.add_transaction(Arc::new(tx_3), 0);
+
+        // === Block 1 ===
+        let mut iter = BestFlashblocksTxs::new(BestPayloadTransactions::new(pool.best()));
+
+        // Flashblock 0: all 3 returned, tx_2 reverts so we exclude it
+        iter.refresh_iterator(BestPayloadTransactions::new(pool.best()), 0);
+        let got_1 = iter.next(()).unwrap();
+        assert_eq!(got_1.hash(), &tx_1_hash);
+        let got_2 = iter.next(()).unwrap();
+        assert_eq!(got_2.hash(), &tx_2_hash);
+        // tx_2 reverted — exclude it
+        iter.excluded_tx_hashes.insert(tx_2_hash);
+        let got_3 = iter.next(()).unwrap();
+        assert_eq!(got_3.hash(), &tx_3_hash);
+        assert!(iter.next(()).is_none());
+        // Commit successful txs
+        iter.mark_commited(vec![tx_1_hash, tx_3_hash]);
+
+        // Flashblock 1: tx_1/tx_3 committed, tx_2 excluded — nothing returned
+        iter.refresh_iterator(BestPayloadTransactions::new(pool.best()), 1);
+        assert!(iter.next(()).is_none(), "tx_2 should be excluded");
+
+        // Flashblock 2: tx_2 still excluded
+        iter.refresh_iterator(BestPayloadTransactions::new(pool.best()), 2);
+        assert!(iter.next(()).is_none(), "tx_2 should still be excluded");
+
+        // === Block 2: fresh iterator, exclusions cleared ===
+        let mut iter2 = BestFlashblocksTxs::new(BestPayloadTransactions::new(pool.best()));
+        iter2.refresh_iterator(BestPayloadTransactions::new(pool.best()), 0);
+        let mut count = 0;
+        while iter2.next(()).is_some() {
+            count += 1;
+        }
+        assert_eq!(
+            count, 3,
+            "New block should see all 3 txs — exclusions not inherited"
+        );
+    }
+
+    /// Only the excluded tx is skipped — other txs in the pool are unaffected.
+    #[test]
+    fn test_excluded_tx_does_not_affect_other_txs() {
+        let mut pool = PendingPool::new(CoinbaseTipOrdering::<MockFbTransaction>::default());
+        let mut f = MockFbTransactionFactory::default();
+
+        let tx_1 = f.create_eip1559();
+        let tx_1_hash = *tx_1.hash();
+        let tx_2 = f.create_eip1559();
+        let tx_2_hash = *tx_2.hash();
+        let tx_3 = f.create_eip1559();
+        let tx_3_hash = *tx_3.hash();
+        pool.add_transaction(Arc::new(tx_1), 0);
+        pool.add_transaction(Arc::new(tx_2), 0);
+        pool.add_transaction(Arc::new(tx_3), 0);
+
+        let mut iter = BestFlashblocksTxs::new(BestPayloadTransactions::new(pool.best()));
+
+        // Flashblock 0: exclude tx_1 only
+        iter.refresh_iterator(BestPayloadTransactions::new(pool.best()), 0);
+        let got_1 = iter.next(()).unwrap();
+        assert_eq!(got_1.hash(), &tx_1_hash);
+        iter.excluded_tx_hashes.insert(tx_1_hash);
+        // tx_2 and tx_3 should still be returned
+        let got_2 = iter.next(()).unwrap();
+        assert_eq!(got_2.hash(), &tx_2_hash);
+        let got_3 = iter.next(()).unwrap();
+        assert_eq!(got_3.hash(), &tx_3_hash);
+        assert!(iter.next(()).is_none());
+
+        // Flashblock 1: tx_1 excluded, tx_2 and tx_3 available
+        iter.refresh_iterator(BestPayloadTransactions::new(pool.best()), 1);
+        let got = iter.next(()).unwrap();
+        assert_eq!(got.hash(), &tx_2_hash);
+        let got = iter.next(()).unwrap();
+        assert_eq!(got.hash(), &tx_3_hash);
+        assert!(iter.next(()).is_none(), "only tx_1 should be excluded");
+    }
+
+    /// Multiple txs can be excluded independently.
+    #[test]
+    fn test_multiple_excluded_txs() {
+        let mut pool = PendingPool::new(CoinbaseTipOrdering::<MockFbTransaction>::default());
+        let mut f = MockFbTransactionFactory::default();
+
+        let tx_1 = f.create_eip1559();
+        let tx_1_hash = *tx_1.hash();
+        let tx_2 = f.create_eip1559();
+        let tx_2_hash = *tx_2.hash();
+        let tx_3 = f.create_eip1559();
+        let tx_3_hash = *tx_3.hash();
+        pool.add_transaction(Arc::new(tx_1), 0);
+        pool.add_transaction(Arc::new(tx_2), 0);
+        pool.add_transaction(Arc::new(tx_3), 0);
+
+        let mut iter = BestFlashblocksTxs::new(BestPayloadTransactions::new(pool.best()));
+
+        // Flashblock 0: exclude tx_1 and tx_3
+        iter.refresh_iterator(BestPayloadTransactions::new(pool.best()), 0);
+        iter.next(()).unwrap(); // tx_1
+        iter.excluded_tx_hashes.insert(tx_1_hash);
+        iter.next(()).unwrap(); // tx_2
+        iter.next(()).unwrap(); // tx_3
+        iter.excluded_tx_hashes.insert(tx_3_hash);
+
+        // Flashblock 1: only tx_2 should be returned
+        iter.refresh_iterator(BestPayloadTransactions::new(pool.best()), 1);
+        let got = iter.next(()).unwrap();
+        assert_eq!(got.hash(), &tx_2_hash);
+        assert!(
+            iter.next(()).is_none(),
+            "tx_1 and tx_3 should both be excluded"
+        );
     }
 }

--- a/crates/op-rbuilder/src/builder/context.rs
+++ b/crates/op-rbuilder/src/builder/context.rs
@@ -72,6 +72,8 @@ pub struct OpPayloadBuilderCtx {
     pub address_gas_limiter: AddressGasLimiter,
     /// Backrun bundles context.
     pub backrun_ctx: BackrunBundlesPayloadCtx,
+    /// Skip reverted txs in subsequent flashblocks
+    pub exclude_reverts_between_flashblocks: bool,
     /// Enable tx tracking logs
     pub enable_tx_tracking_debug_logs: bool,
 }
@@ -625,6 +627,10 @@ impl OpPayloadBuilderCtx {
                         result = ?result,
                         "skipping reverted transaction"
                     );
+                    if self.exclude_reverts_between_flashblocks {
+                        best_txs.mark_excluded(B256::new(*tx_hash));
+                        info.reverted_bundle_tx_hashes.push(B256::new(*tx_hash));
+                    }
                     best_txs.mark_invalid(tx.signer(), tx.nonce());
                     continue;
                 } else {

--- a/crates/op-rbuilder/src/builder/mod.rs
+++ b/crates/op-rbuilder/src/builder/mod.rs
@@ -97,6 +97,9 @@ pub struct BuilderConfig {
     /// Flashblocks configuration
     pub flashblocks_config: FlashblocksConfig,
 
+    /// Skip re-simulating reverted transactions in subsequent flashblocks
+    pub exclude_reverts_between_flashblocks: bool,
+
     /// Enable transaction tracking logs
     pub enable_tx_tracking_debug_logs: bool,
 }
@@ -118,6 +121,7 @@ impl Default for BuilderConfig {
             backrun_bundle_pool: BackrunBundleGlobalPool::new(false),
             backrun_bundle_args: BackrunBundleArgs::default(),
             flashblocks_config: FlashblocksConfig::default(),
+            exclude_reverts_between_flashblocks: false,
             enable_tx_tracking_debug_logs: false,
         }
     }
@@ -146,6 +150,7 @@ impl TryFrom<OpRbuilderArgs> for BuilderConfig {
             ),
             backrun_bundle_args: args.backrun_bundle,
             flashblocks_config,
+            exclude_reverts_between_flashblocks: args.exclude_reverts_between_flashblocks,
             enable_tx_tracking_debug_logs: false,
         })
     }

--- a/crates/op-rbuilder/src/builder/payload.rs
+++ b/crates/op-rbuilder/src/builder/payload.rs
@@ -362,6 +362,7 @@ where
             max_uncompressed_block_size: self.config.max_uncompressed_block_size,
             address_gas_limiter: self.address_gas_limiter.clone(),
             backrun_ctx,
+            exclude_reverts_between_flashblocks: self.config.exclude_reverts_between_flashblocks,
             enable_tx_tracking_debug_logs: self.config.enable_tx_tracking_debug_logs,
         })
     }
@@ -800,6 +801,12 @@ where
             .map(|tx| tx.tx_hash())
             .collect();
         best_txs.mark_commited(new_transactions);
+
+        // Remove reverted bundle txs from the pool so they aren't re-simulated in future blocks
+        if !info.reverted_bundle_tx_hashes.is_empty() {
+            let hashes = info.reverted_bundle_tx_hashes.drain(..).collect();
+            self.pool.remove_transactions(hashes);
+        }
 
         // We got block cancelled, we won't need anything from the block at this point
         // Caution: this assume that block cancel token only cancelled when new FCU is received

--- a/crates/op-rbuilder/src/builder/syncer_ctx.rs
+++ b/crates/op-rbuilder/src/builder/syncer_ctx.rs
@@ -36,6 +36,8 @@ pub(super) struct OpPayloadSyncerCtx {
     backrun_bundle_pool: BackrunBundleGlobalPool,
     /// Backrun bundle configuration
     backrun_bundle_args: BackrunBundleArgs,
+    /// Skip reverted txs in subsequent flashblocks
+    exclude_reverts_between_flashblocks: bool,
     /// Enable transaction tracking logs
     enable_tx_tracking_debug_logs: bool,
 }
@@ -60,6 +62,7 @@ impl OpPayloadSyncerCtx {
             metrics,
             backrun_bundle_pool: builder_config.backrun_bundle_pool.clone(),
             backrun_bundle_args: builder_config.backrun_bundle_args.clone(),
+            exclude_reverts_between_flashblocks: builder_config.exclude_reverts_between_flashblocks,
             enable_tx_tracking_debug_logs: builder_config.enable_tx_tracking_debug_logs,
         })
     }
@@ -116,6 +119,7 @@ impl OpPayloadSyncerCtx {
             max_uncompressed_block_size: self.max_uncompressed_block_size,
             address_gas_limiter: AddressGasLimiter::new(GasLimiterArgs::default()),
             backrun_ctx,
+            exclude_reverts_between_flashblocks: self.exclude_reverts_between_flashblocks,
             enable_tx_tracking_debug_logs: self.enable_tx_tracking_debug_logs,
         }
     }

--- a/crates/op-rbuilder/src/primitives/reth/execution.rs
+++ b/crates/op-rbuilder/src/primitives/reth/execution.rs
@@ -1,5 +1,5 @@
 //! Heavily influenced by [reth](https://github.com/paradigmxyz/reth/blob/1e965caf5fa176f244a31c0d2662ba1b590938db/crates/optimism/payload/src/builder.rs#L570)
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, TxHash, U256};
 use core::fmt::Debug;
 use derive_more::Display;
 use reth_optimism_primitives::{OpReceipt, OpTransactionSigned};
@@ -50,6 +50,8 @@ pub struct ExecutionInfo {
     pub da_footprint_scalar: Option<u16>,
     /// Optional blob fields for payload validation
     pub optional_blob_fields: Option<(Option<u64>, Option<u64>)>,
+    /// Reverted bundle tx hashes to remove from the pool after each flashblock.
+    pub reverted_bundle_tx_hashes: Vec<TxHash>,
 }
 
 impl ExecutionInfo {
@@ -65,6 +67,7 @@ impl ExecutionInfo {
             total_fees: U256::ZERO,
             da_footprint_scalar: None,
             optional_blob_fields: None,
+            reverted_bundle_tx_hashes: Vec::new(),
         }
     }
 

--- a/crates/op-rbuilder/src/traits.rs
+++ b/crates/op-rbuilder/src/traits.rs
@@ -70,6 +70,7 @@ impl<T> ClientBounds for T where
 {
 }
 
-pub trait PayloadTxsBounds: PayloadTransactions<Transaction = FBPooledTransaction> {}
-
-impl<T> PayloadTxsBounds for T where T: PayloadTransactions<Transaction = FBPooledTransaction> {}
+pub trait PayloadTxsBounds: PayloadTransactions<Transaction = FBPooledTransaction> {
+    /// Mark a transaction hash as excluded so it is skipped in subsequent flashblocks.
+    fn mark_excluded(&mut self, _hash: alloy_primitives::TxHash) {}
+}


### PR DESCRIPTION
Add --builder.exclude-reverts-between-flashblocks flag that prevents bundle txs from being re-simulated in subsequent flashblocks within the same block if reverted.