### PR TITLE
Release v0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6208,7 +6208,7 @@ dependencies = [
 
 [[package]]
 name = "macros"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7011,7 +7011,7 @@ dependencies = [
 
 [[package]]
 name = "op-rbuilder"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -7303,7 +7303,7 @@ dependencies = [
 
 [[package]]
 name = "p2p"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "derive_more",
  "eyre",
@@ -12977,7 +12977,7 @@ dependencies = [
 
 [[package]]
 name = "tdx-quote-provider"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT OR Apache-2.0"

--- a/crates/op-rbuilder/CHANGELOG.md
+++ b/crates/op-rbuilder/CHANGELOG.md
@@ -7,12 +7,12 @@ All notable changes to this project will be documented in this file.
 
 - Skip re-simulation of reverted txs between flashblocks ([#462](https://github.com/flashbots/op-rbuilder/pull/462))
 - Metrics: record fcu delay ([#443](https://github.com/flashbots/op-rbuilder/pull/443))
+- Add enable_tx_tracking_debug_logs flag to not check env vars during runtime ([#452](https://github.com/flashbots/op-rbuilder/pull/452))
 
 ### Chore
 
 - Upgrade reth to 2.0 ([#459](https://github.com/flashbots/op-rbuilder/pull/459))
 - Standardize logging ([#456](https://github.com/flashbots/op-rbuilder/pull/456))
-- Add enable_tx_tracking_debug_logs flag to not check env vars during runtime ([#452](https://github.com/flashbots/op-rbuilder/pull/452))
 - Use derive_more::Deref for WithFlashbotsMetadata ([#453](https://github.com/flashbots/op-rbuilder/pull/453))
 - Remove reth_basic_payload_builder::PayloadBuilder impl ([#454](https://github.com/flashbots/op-rbuilder/pull/454))
 - Remove unused file ([#455](https://github.com/flashbots/op-rbuilder/pull/455))

--- a/crates/op-rbuilder/CHANGELOG.md
+++ b/crates/op-rbuilder/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.4.2] - 2026-04-13
+
+### Bug Fixes
+
+- Accumulate reverted gas as u64 for payload metrics ([#451](https://github.com/flashbots/op-rbuilder/pull/451))
+
+### Features
+
+- Add signer to revert log message ([#461](https://github.com/flashbots/op-rbuilder/pull/461))
+- Skip re-simulation of reverted txs between flashblocks ([#462](https://github.com/flashbots/op-rbuilder/pull/462))
+- Metrics: record fcu delay ([#443](https://github.com/flashbots/op-rbuilder/pull/443))
+
+### Chore
+
+- Upgrade reth to 2.0 ([#459](https://github.com/flashbots/op-rbuilder/pull/459))
+- Standardize logging ([#456](https://github.com/flashbots/op-rbuilder/pull/456))
+- Add enable_tx_tracking_debug_logs flag to not check env vars during runtime ([#452](https://github.com/flashbots/op-rbuilder/pull/452))
+- Use derive_more::Deref for WithFlashbotsMetadata ([#453](https://github.com/flashbots/op-rbuilder/pull/453))
+- Remove reth_basic_payload_builder::PayloadBuilder impl ([#454](https://github.com/flashbots/op-rbuilder/pull/454))
+- Remove unused file ([#455](https://github.com/flashbots/op-rbuilder/pull/455))
+- Enable redundant_clone clippy lint ([#460](https://github.com/flashbots/op-rbuilder/pull/460))
+
+### Refactor
+
+- Create BlockEvmFactory abstraction ([#457](https://github.com/flashbots/op-rbuilder/pull/457))
+
 ## [0.4.1] - 2026-03-30
 
 ### Bug Fixes

--- a/crates/op-rbuilder/CHANGELOG.md
+++ b/crates/op-rbuilder/CHANGELOG.md
@@ -3,13 +3,8 @@
 All notable changes to this project will be documented in this file.
 ## [0.4.2] - 2026-04-13
 
-### Bug Fixes
-
-- Accumulate reverted gas as u64 for payload metrics ([#451](https://github.com/flashbots/op-rbuilder/pull/451))
-
 ### Features
 
-- Add signer to revert log message ([#461](https://github.com/flashbots/op-rbuilder/pull/461))
 - Skip re-simulation of reverted txs between flashblocks ([#462](https://github.com/flashbots/op-rbuilder/pull/462))
 - Metrics: record fcu delay ([#443](https://github.com/flashbots/op-rbuilder/pull/443))
 
@@ -22,10 +17,9 @@ All notable changes to this project will be documented in this file.
 - Remove reth_basic_payload_builder::PayloadBuilder impl ([#454](https://github.com/flashbots/op-rbuilder/pull/454))
 - Remove unused file ([#455](https://github.com/flashbots/op-rbuilder/pull/455))
 - Enable redundant_clone clippy lint ([#460](https://github.com/flashbots/op-rbuilder/pull/460))
-
-### Refactor
-
 - Create BlockEvmFactory abstraction ([#457](https://github.com/flashbots/op-rbuilder/pull/457))
+- Add signer to revert log message ([#461](https://github.com/flashbots/op-rbuilder/pull/461))
+- Accumulate reverted gas as u64 for payload metrics ([#451](https://github.com/flashbots/op-rbuilder/pull/451))
 
 ## [0.4.1] - 2026-03-30
 


### PR DESCRIPTION
## Summary

- Bump op-rbuilder version `0.4.1` → `0.4.2`
- Update CHANGELOG with changes since v0.4.1
- Update Cargo.lock

## Highlights

- Skip re-simulation of reverted bundle txs between flashblocks (#462)
- Add signer to revert log message (#461)
- Upgrade reth to 2.0 (#459)
- Record FCU delay metric (#443)
- Standardize logging (#456)

## Test plan

- [ ] CI passes
- [ ] Once merged, release-plz creates `op-rbuilder/v0.4.2` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)