### PR TITLE
feat: add flashblock publish timing metric

### DIFF
--- a/crates/op-rbuilder/src/builder/payload.rs
+++ b/crates/op-rbuilder/src/builder/payload.rs
@@ -7,11 +7,11 @@ use crate::{
         builder_tx::BuilderTransactions,
         context::OpPayloadBuilderCtx,
         generator::{BuildArguments, PayloadBuilder},
-        timing::FlashblockScheduler,
+        timing::{FlashblockScheduler, compute_slot_offset_ms},
     },
     evm::OpBlockEvmFactory,
     gas_limiter::AddressGasLimiter,
-    metrics::OpRBuilderMetrics,
+    metrics::{OpRBuilderMetrics, record_flashblock_publish_timing},
     primitives::reth::ExecutionInfo,
     runtime_ext::RuntimeExt,
     tokio_metrics::FlashblocksTaskMetrics,
@@ -515,6 +515,11 @@ where
                 .ws_pub
                 .publish(&fb_payload)
                 .map_err(PayloadBuilderError::other)?;
+
+            let slot_offset_ms =
+                compute_slot_offset_ms(config.attributes.timestamp(), self.config.block_time);
+            record_flashblock_publish_timing(fb_payload.index, slot_offset_ms);
+
             if self.config.enable_tx_tracking_debug_logs {
                 debug!(
                     target: "tx_trace",
@@ -523,6 +528,7 @@ where
                     flashblock_index = fb_payload.index,
                     byte_size = flashblock_byte_size,
                     total_txs = info.executed_transactions.len(),
+                    slot_offset_ms,
                     stage = "fb_published"
                 );
             }
@@ -1084,6 +1090,12 @@ where
                     .ws_pub
                     .publish(&fb_payload)
                     .wrap_err("failed to publish flashblock via websocket")?;
+
+                // Record slot-relative publish timing (ms since slot start)
+                let slot_offset_ms =
+                    compute_slot_offset_ms(ctx.attributes().timestamp(), self.config.block_time);
+                record_flashblock_publish_timing(flashblock_index, slot_offset_ms);
+
                 if self.config.enable_tx_tracking_debug_logs {
                     debug!(
                         target: "tx_trace",
@@ -1092,6 +1104,7 @@ where
                         flashblock_index,
                         byte_size = flashblock_byte_size,
                         total_txs = info.executed_transactions.len(),
+                        slot_offset_ms,
                         stage = "fb_published"
                     );
                 }

--- a/crates/op-rbuilder/src/builder/timing.rs
+++ b/crates/op-rbuilder/src/builder/timing.rs
@@ -1,5 +1,5 @@
 use core::time::Duration;
-use std::ops::Rem;
+use std::{ops::Rem, time::SystemTime};
 
 use reth_payload_builder::PayloadId;
 use tokio::sync::mpsc;
@@ -249,6 +249,17 @@ impl std::fmt::Debug for FlashblockScheduler {
             }))
             .finish()
     }
+}
+
+/// Compute the elapsed time in ms since the start of the slot.
+/// Slot start defined as `payload_timestamp - block_time`.
+pub(super) fn compute_slot_offset_ms(payload_timestamp: u64, block_time: Duration) -> f64 {
+    let slot_start = SystemTime::UNIX_EPOCH + Duration::from_secs(payload_timestamp) - block_time;
+    SystemTime::now()
+        .duration_since(slot_start)
+        .unwrap_or_default()
+        .as_secs_f64()
+        * 1000.0
 }
 
 #[cfg(test)]

--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -244,6 +244,22 @@ impl OpRBuilderMetrics {
     }
 }
 
+/// Record the slot-relative time at which a flashblock was published.
+/// `offset_ms` is the time elapsed since slot start (payload_timestamp - block_time)
+pub fn record_flashblock_publish_timing(flashblock_index: u64, offset_ms: f64) {
+    static LABELS: &[&str] = &["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"];
+    let index_str = LABELS
+        .get(flashblock_index as usize)
+        .copied()
+        .unwrap_or("unknown");
+    let labels: [(&str, &str); 1] = [("flashblock_index", index_str)];
+    gauge!(
+        "op_rbuilder_flashblock_publish_timing_milliseconds",
+        &labels
+    )
+    .set(offset_ms);
+}
+
 /// Set gauge metrics for some flags so we can inspect which ones are set
 /// and which ones aren't.
 pub fn record_flag_gauge_metrics(builder_args: &OpRbuilderArgs) {

--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -2,7 +2,7 @@ use alloy_primitives::{Address, hex};
 use metrics::IntoF64;
 use reth_metrics::{
     Metrics,
-    metrics::{Counter, Gauge, Histogram, gauge},
+    metrics::{Counter, Gauge, Histogram, gauge, histogram},
 };
 
 use crate::{
@@ -247,17 +247,11 @@ impl OpRBuilderMetrics {
 /// Record the slot-relative time at which a flashblock was published.
 /// `offset_ms` is the time elapsed since slot start (payload_timestamp - block_time)
 pub fn record_flashblock_publish_timing(flashblock_index: u64, offset_ms: f64) {
-    static LABELS: &[&str] = &["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"];
-    let index_str = LABELS
-        .get(flashblock_index as usize)
-        .copied()
-        .unwrap_or("unknown");
-    let labels: [(&str, &str); 1] = [("flashblock_index", index_str)];
-    gauge!(
+    histogram!(
         "op_rbuilder_flashblock_publish_timing_milliseconds",
-        &labels
+        "flashblock_index" => flashblock_index.to_string()
     )
-    .set(offset_ms);
+    .record(offset_ms);
 }
 
 /// Set gauge metrics for some flags so we can inspect which ones are set


### PR DESCRIPTION
New `op_rbuilder_flashblock_publish_timing_milliseconds` gauge metric that records when each flashblock is published relative to slot start. This enable builder side flashblock delivery view and measurement of delivery latency between builder and flashblock websocket.