### PR TITLE
feat: top-of-block pre-simulation to filter reverting tx spam

### DIFF
--- a/crates/op-rbuilder/src/args/op.rs
+++ b/crates/op-rbuilder/src/args/op.rs
@@ -61,6 +61,15 @@ pub struct OpRbuilderArgs {
     )]
     pub exclude_reverts_between_flashblocks: bool,
 
+    /// Whether to pre-simulate bundle transactions against the current head state
+    /// and reject them if they revert, before adding to the pool.
+    #[arg(
+        long = "builder.pre-simulate-bundles",
+        default_value = "false",
+        env = "PRE_SIMULATE_BUNDLES"
+    )]
+    pub pre_simulate_bundles: bool,
+
     /// Enables logs to trace transaction lifecycle as it is added to the
     /// mempool and added to a block. Requires `RUST_LOG=tx_trace=debug` in
     /// addition to this flag.

--- a/crates/op-rbuilder/src/builder/payload.rs
+++ b/crates/op-rbuilder/src/builder/payload.rs
@@ -388,11 +388,12 @@ where
             extra_data,
         };
 
-        let evm_config = self.evm_config.clone();
-
-        let evm_env = evm_config
-            .next_evm_env(&config.parent_header, &block_env_attributes)
-            .wrap_err("failed to create next evm env")?;
+        let evm_factory = OpBlockEvmFactory::for_next_block(
+            self.evm_config.clone(),
+            &config.parent_header,
+            &block_env_attributes,
+        )
+        .wrap_err("failed to create next evm env")?;
 
         let backrun_ctx = BackrunBundlesPayloadCtx {
             pool: self
@@ -403,7 +404,7 @@ where
         };
 
         Ok(OpPayloadBuilderCtx {
-            evm_factory: OpBlockEvmFactory::new(self.evm_config.clone(), evm_env),
+            evm_factory,
             chain_spec,
             config,
             block_env_attributes,

--- a/crates/op-rbuilder/src/evm.rs
+++ b/crates/op-rbuilder/src/evm.rs
@@ -1,6 +1,7 @@
 use alloy_evm::Database;
 use reth_evm::{ConfigureEvm, EvmEnvFor, EvmFor};
 use reth_optimism_evm::OpEvmConfig;
+use reth_primitives_traits::HeaderTy;
 
 pub type OpBlockEvmFactory = BlockEvmFactory<OpEvmConfig>;
 
@@ -20,6 +21,15 @@ impl<C: ConfigureEvm> BlockEvmFactory<C> {
             evm_config,
             evm_env,
         }
+    }
+
+    pub fn for_next_block(
+        evm_config: C,
+        parent: &HeaderTy<C::Primitives>,
+        attributes: &C::NextBlockEnvCtx,
+    ) -> Result<Self, C::Error> {
+        let evm_env = evm_config.next_evm_env(parent, attributes)?;
+        Ok(Self::new(evm_config, evm_env))
     }
 
     pub fn evm<'a, DB: Database>(&self, db: &'a mut DB) -> EvmFor<C, &'a mut DB> {

--- a/crates/op-rbuilder/src/launcher.rs
+++ b/crates/op-rbuilder/src/launcher.rs
@@ -1,5 +1,9 @@
+use std::sync::Arc;
+
 use eyre::Result;
+use futures::FutureExt;
 use reth_optimism_rpc::OpEthApiBuilder;
+use tracing::info;
 
 use crate::{
     args::*,
@@ -7,8 +11,9 @@ use crate::{
         BackrunBundleApiServer, BackrunBundleRpc, maintain_backrun_bundle_pool_future,
     },
     builder::{BuilderConfig, FlashblocksServiceBuilder},
-    metrics::{VERSION, record_flag_gauge_metrics},
+    metrics::{OpRBuilderMetrics, VERSION, record_flag_gauge_metrics},
     monitor_tx_pool::monitor_tx_pool,
+    presim::{TopOfBlockSimulator, maintain_pending_simulations, maintain_tip_state},
     revert_protection::{EthApiExtServer, RevertProtectionExt},
     tx::FBPooledTransaction,
 };
@@ -18,11 +23,12 @@ use reth_cli_commands::launcher::Launcher;
 use reth_db::mdbx::DatabaseEnv;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_cli::chainspec::OpChainSpecParser;
+use reth_optimism_evm::OpEvmConfig;
 use reth_optimism_node::{
     OpNode,
     node::{OpAddOns, OpAddOnsBuilder, OpEngineValidatorBuilder, OpPoolBuilder},
 };
-use reth_provider::CanonStateSubscriptions;
+use reth_provider::{CanonStateSubscriptions, ChainSpecProvider};
 use reth_transaction_pool::TransactionPool;
 pub fn launch() -> Result<()> {
     let cli = Cli::parsed();
@@ -94,8 +100,17 @@ impl Launcher<OpChainSpecParser, OpRbuilderArgs> for BuilderLauncher {
         let reverted_cache = Cache::builder().max_capacity(100).build();
         let reverted_cache_copy = reverted_cache.clone();
         let backrun_bundle_enabled = builder_args.backrun_bundle.backruns_enabled;
+        let block_time_secs = builder_config.block_time.as_millis() as u64 / 1000;
         let backrun_bundle_pool = builder_config.backrun_bundle_pool.clone();
         let backrun_bundle_pool_maintain = backrun_bundle_pool.clone();
+
+        let simulator = if builder_args.pre_simulate_bundles {
+            Some(Arc::new(TopOfBlockSimulator::new()))
+        } else {
+            None
+        };
+        let simulator_for_rpc = simulator.clone();
+        let simulator_for_maintenance = simulator.clone();
 
         let addons: OpAddOns<_, OpEthApiBuilder, OpEngineValidatorBuilder> =
             OpAddOnsBuilder::default()
@@ -128,7 +143,7 @@ impl Launcher<OpChainSpecParser, OpRbuilderArgs> for BuilderLauncher {
             .with_add_ons(addons)
             .extend_rpc_modules(move |ctx| {
                 if builder_args.enable_revert_protection {
-                    tracing::info!("Revert protection enabled");
+                    info!("Revert protection enabled");
 
                     let pool = ctx.pool().clone();
                     let provider = ctx.provider().clone();
@@ -137,6 +152,7 @@ impl Launcher<OpChainSpecParser, OpRbuilderArgs> for BuilderLauncher {
                         provider,
                         ctx.registry.eth_api().clone(),
                         reverted_cache,
+                        simulator_for_rpc,
                     );
 
                     ctx.modules
@@ -160,7 +176,7 @@ impl Launcher<OpChainSpecParser, OpRbuilderArgs> for BuilderLauncher {
             .on_node_started(move |ctx| {
                 VERSION.register_version_metrics();
                 if builder_args.log_pool_transactions {
-                    tracing::info!("Logging pool transactions");
+                    info!("Logging pool transactions");
                     let listener = ctx.pool.all_transactions_event_listener();
                     let task = monitor_tx_pool(
                         listener,
@@ -179,6 +195,34 @@ impl Launcher<OpChainSpecParser, OpRbuilderArgs> for BuilderLauncher {
                             chain_events,
                             task_executor,
                         ));
+                }
+
+                if let Some(simulator) = simulator_for_maintenance {
+                    let metrics = Arc::new(OpRBuilderMetrics::default());
+                    let chain_events = ctx.provider.canonical_state_stream();
+                    let evm_config = OpEvmConfig::optimism(ctx.provider.chain_spec());
+                    ctx.task_executor.spawn_task(
+                        maintain_tip_state(
+                            simulator.clone(),
+                            ctx.provider.clone(),
+                            evm_config,
+                            block_time_secs,
+                            metrics.clone(),
+                            chain_events,
+                        )
+                        .boxed(),
+                    );
+
+                    let pending_events = ctx.pool.all_transactions_event_listener();
+                    ctx.task_executor.spawn_task(
+                        maintain_pending_simulations(
+                            simulator,
+                            ctx.pool.clone(),
+                            metrics,
+                            pending_events,
+                        )
+                        .boxed(),
+                    );
                 }
 
                 Ok(())

--- a/crates/op-rbuilder/src/lib.rs
+++ b/crates/op-rbuilder/src/lib.rs
@@ -7,6 +7,7 @@ pub mod gas_limiter;
 pub mod launcher;
 pub mod metrics;
 mod monitor_tx_pool;
+pub mod presim;
 pub mod primitives;
 pub mod revert_protection;
 pub(crate) mod runtime_ext;

--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -159,6 +159,16 @@ pub struct OpRBuilderMetrics {
     pub bundles_reverted: Histogram,
     /// Histogram of eth_sendBundle request duration
     pub bundle_receive_duration: Histogram,
+    /// Number of bundles dropped by pre-simulation (reverted)
+    pub bundle_pre_simulation_reverts: Counter,
+    /// Number of bundles that passed pre-simulation
+    pub bundle_pre_simulation_passes: Counter,
+    /// Histogram of bundle pre-simulation duration
+    pub bundle_pre_simulation_duration: Histogram,
+    /// Number of updates to the tip state for the top of block simulator
+    pub presim_tip_state_updates: Counter,
+    /// Number of pending txs evicted due to failing top of block simulation
+    pub presim_pending_evictions: Counter,
     /// Transactions rejected by per-tx DA size limit
     pub tx_da_size_exceeded_total: Counter,
     /// Transactions rejected by cumulative block DA limit

--- a/crates/op-rbuilder/src/presim.rs
+++ b/crates/op-rbuilder/src/presim.rs
@@ -1,0 +1,408 @@
+use std::sync::Arc;
+
+use alloy_consensus::{BlockHeader, Header};
+use alloy_evm::{Evm, InvalidTxError};
+use alloy_op_evm::OpTx;
+use alloy_primitives::{Address, B256, Bytes};
+use eyre::Context;
+use futures_util::{Stream, StreamExt};
+use parking_lot::RwLock;
+use reth_chain_state::CanonStateNotification;
+use reth_evm::{EvmError, IntoTxEnv};
+use reth_optimism_chainspec::{OpChainSpec, OpHardforks};
+use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
+use reth_optimism_primitives::OpTransactionSigned;
+use reth_primitives_traits::{Block, NodePrimitives, Recovered, RecoveredBlock};
+use reth_provider::{BlockReaderIdExt, ChainSpecProvider, StateProvider, StateProviderFactory};
+use reth_revm::{State, database::StateProviderDatabase};
+use reth_transaction_pool::{FullTransactionEvent, PoolTransaction, TransactionPool};
+use revm::{context::result::ResultAndState, context_interface::result::InvalidTransaction};
+use tracing::{debug, error, warn};
+
+use crate::{evm::OpBlockEvmFactory, metrics::OpRBuilderMetrics, tx::FBPooledTransaction};
+
+/// Pre-simulates transactions against the current head state to filter out
+/// reverting transactions before they enter the pool.
+pub(crate) struct TopOfBlockSimulator {
+    tip_state: RwLock<Arc<Option<TipState>>>,
+}
+
+pub(crate) struct TipState {
+    evm_factory: OpBlockEvmFactory,
+    state_provider: Box<dyn StateProvider + Send + Sync>,
+}
+
+impl TopOfBlockSimulator {
+    pub(crate) fn new() -> Self {
+        Self {
+            tip_state: RwLock::new(Arc::new(None)),
+        }
+    }
+
+    pub(crate) async fn simulate_tx(
+        self: Arc<Self>,
+        tx: Recovered<OpTransactionSigned>,
+    ) -> eyre::Result<bool> {
+        tokio::task::spawn_blocking(move || self.simulate_tx_sync(tx))
+            .await
+            .wrap_err("simulate tx task panicked")
+    }
+
+    pub(crate) fn simulate_tx_sync(&self, tx: impl IntoTxEnv<OpTx>) -> bool {
+        let tip_state = {
+            let tip_state = self.tip_state.read();
+            tip_state.clone()
+        };
+
+        let Some(ref tip_state) = *tip_state else {
+            warn!("tip state for top of block simulator not initialized yet");
+            return true;
+        };
+
+        tip_state.run_simulation(tx)
+    }
+
+    pub(crate) fn update_tip(&self, tip_state: TipState) {
+        *self.tip_state.write() = Arc::new(Some(tip_state));
+    }
+}
+
+impl TipState {
+    fn create<B: Block<Header = alloy_consensus::Header>>(
+        provider: impl StateProviderFactory + ChainSpecProvider<ChainSpec = OpChainSpec>,
+        evm_config: OpEvmConfig,
+        block_time_secs: u64,
+        tip: &RecoveredBlock<B>,
+    ) -> eyre::Result<Self> {
+        let chain_spec = provider.chain_spec();
+        let timestamp = tip.timestamp() + block_time_secs;
+        let extra_data = if chain_spec.is_holocene_active_at_timestamp(timestamp) {
+            tip.extra_data().clone()
+        } else {
+            Bytes::default()
+        };
+
+        let block_env_attributes = OpNextBlockEnvAttributes {
+            timestamp,
+            // Use a random coinbase so attackers can't craft txs that behave
+            // differently during simulation vs block building
+            suggested_fee_recipient: Address::random(),
+            prev_randao: B256::ZERO,
+            gas_limit: tip.gas_limit(),
+            parent_beacon_block_root: tip.parent_beacon_block_root(),
+            extra_data,
+        };
+
+        let evm_factory =
+            OpBlockEvmFactory::for_next_block(evm_config, tip.header(), &block_env_attributes)?;
+        let state_provider = provider.state_by_block_hash(tip.hash_slow())?;
+
+        // SAFETY: reth's concrete StateProvider implementations are Send + Sync.
+        // StateProviderBox omits these bounds but the underlying types satisfy them.
+        let state_provider: Box<dyn StateProvider + Send + Sync> =
+            unsafe { std::mem::transmute::<Box<dyn StateProvider + Send>, _>(state_provider) };
+        // Compile-time assertion
+        const _: () = assert!(
+            std::mem::size_of::<Box<dyn StateProvider + Send>>()
+                == std::mem::size_of::<Box<dyn StateProvider + Send + Sync>>()
+                && std::mem::align_of::<Box<dyn StateProvider + Send>>()
+                    == std::mem::align_of::<Box<dyn StateProvider + Send + Sync>>()
+        );
+
+        Ok(Self {
+            evm_factory,
+            state_provider,
+        })
+    }
+
+    fn run_simulation(&self, tx: impl IntoTxEnv<OpTx>) -> bool {
+        let db = StateProviderDatabase::new(&*self.state_provider);
+        let mut state = State::builder().with_database(db).build();
+        let mut evm = self.evm_factory.evm(&mut state);
+
+        match evm.transact(tx) {
+            Ok(ResultAndState { result, .. }) => result.is_success(),
+            Err(err) => {
+                if err.as_invalid_tx_err().is_some_and(|err| {
+                    err.as_invalid_tx_err().is_some_and(|err| {
+                        matches!(
+                            err,
+                            InvalidTransaction::NonceTooLow { .. }
+                                | InvalidTransaction::NonceTooHigh { .. }
+                        )
+                    })
+                }) {
+                    // Nonce gap — tx may depend on pending state, let the pool handle it
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+    }
+}
+
+pub(crate) async fn maintain_tip_state<N, St, Provider>(
+    simulator: Arc<TopOfBlockSimulator>,
+    provider: Provider,
+    evm_config: OpEvmConfig,
+    block_time_secs: u64,
+    metrics: Arc<OpRBuilderMetrics>,
+    mut events: St,
+) where
+    N: NodePrimitives<Block: Block<Header = Header>>,
+    St: Stream<Item = CanonStateNotification<N>> + Send + Unpin + 'static,
+    Provider: StateProviderFactory
+        + ChainSpecProvider<ChainSpec = OpChainSpec>
+        + BlockReaderIdExt<Header = Header>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    loop {
+        let Some(event) = events.next().await else {
+            break;
+        };
+
+        match TipState::create(&provider, evm_config.clone(), block_time_secs, event.tip()) {
+            Ok(tip_state) => {
+                simulator.update_tip(tip_state);
+                metrics.presim_tip_state_updates.increment(1);
+            }
+            Err(e) => {
+                warn!(error = %e, "failed to create tip state for pre-simulation");
+            }
+        }
+    }
+}
+
+pub(crate) async fn maintain_pending_simulations<Pool, St>(
+    simulator: Arc<TopOfBlockSimulator>,
+    pool: Pool,
+    metrics: Arc<OpRBuilderMetrics>,
+    mut events: St,
+) where
+    Pool: TransactionPool<Transaction = FBPooledTransaction> + 'static,
+    St: Stream<Item = FullTransactionEvent<FBPooledTransaction>> + Send + Unpin + 'static,
+{
+    while let Some(event) = events.next().await {
+        let FullTransactionEvent::Pending(tx_hash) = event else {
+            continue;
+        };
+
+        // Fetch full tx from pool — may already be gone
+        let Some(tx) = pool.get(&tx_hash) else {
+            continue;
+        };
+
+        let simulator = simulator.clone();
+        let pool = pool.clone();
+        let metrics = metrics.clone();
+
+        tokio::spawn(async move {
+            let consensus_tx = tx.transaction.clone_into_consensus();
+            match simulator.simulate_tx(consensus_tx).await {
+                Ok(false) => {
+                    debug!(tx_hash = %tx_hash, "evicting reverting tx from pool");
+                    pool.remove_transactions(vec![tx_hash]);
+                    metrics.presim_pending_evictions.increment(1);
+                }
+                Ok(true) => {}
+                Err(e) => {
+                    error!(tx_hash = %tx_hash, error = ?e, "background simulation failed");
+                }
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::{SignableTransaction, TxEip1559};
+    use alloy_evm::EvmEnv;
+    use alloy_network::TxSignerSync;
+    use alloy_primitives::{Address, TxKind, U256, hex, map::HashMap};
+    use alloy_signer_local::PrivateKeySigner;
+    use op_alloy_consensus::OpTxEnvelope;
+    use op_revm::OpSpecId;
+    use reth_optimism_chainspec::BASE_MAINNET;
+    use reth_optimism_evm::OpEvmConfig;
+    use reth_primitives_traits::Account;
+    use reth_revm::test_utils::StateProviderTest;
+    use revm::context::CfgEnv;
+
+    const ONE_ETH: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
+    const CHAIN_ID: u64 = 8453; // Base mainnet
+
+    fn test_evm_config() -> OpEvmConfig {
+        OpEvmConfig::optimism(BASE_MAINNET.clone())
+    }
+
+    /// Create a TipState with a properly configured EVM env and the given state provider.
+    fn tip_state_with_provider(state_provider: StateProviderTest) -> TipState {
+        let evm_config = test_evm_config();
+        let cfg = CfgEnv::new_with_spec(OpSpecId::ECOTONE).with_chain_id(CHAIN_ID);
+        let evm_env = EvmEnv {
+            cfg_env: cfg,
+            ..Default::default()
+        };
+        let evm_factory = OpBlockEvmFactory::new(evm_config, evm_env);
+        TipState {
+            evm_factory,
+            state_provider: Box::new(state_provider),
+        }
+    }
+
+    fn sign_test_tx(signer: &PrivateKeySigner, tx: TxEip1559) -> Recovered<OpTransactionSigned> {
+        let mut tx = tx;
+        let signature = signer.sign_transaction_sync(&mut tx).unwrap();
+        let envelope = OpTxEnvelope::Eip1559(tx.into_signed(signature));
+        Recovered::new_unchecked(OpTransactionSigned::from(envelope), signer.address())
+    }
+
+    fn simple_transfer(signer: &PrivateKeySigner, nonce: u64) -> Recovered<OpTransactionSigned> {
+        sign_test_tx(
+            signer,
+            TxEip1559 {
+                chain_id: BASE_MAINNET.chain().id(),
+                nonce,
+                gas_limit: 21_000,
+                max_fee_per_gas: 20_000_000_000,
+                to: TxKind::Call(Address::random()),
+                ..Default::default()
+            },
+        )
+    }
+
+    fn reverting_create(signer: &PrivateKeySigner, nonce: u64) -> Recovered<OpTransactionSigned> {
+        sign_test_tx(
+            signer,
+            TxEip1559 {
+                chain_id: BASE_MAINNET.chain().id(),
+                nonce,
+                gas_limit: 100_000,
+                max_fee_per_gas: 20_000_000_000,
+                to: TxKind::Create,
+                // PUSH1 0x00 PUSH1 0x00 REVERT
+                input: hex!("60006000fd").into(),
+                ..Default::default()
+            },
+        )
+    }
+
+    fn funded_provider(address: Address) -> StateProviderTest {
+        let mut provider = StateProviderTest::default();
+        provider.insert_account(
+            address,
+            Account {
+                nonce: 0,
+                balance: ONE_ETH,
+                bytecode_hash: None,
+            },
+            None,
+            HashMap::default(),
+        );
+        provider
+    }
+
+    #[test]
+    fn successful_transfer_returns_true() {
+        let signer = PrivateKeySigner::random();
+        let provider = funded_provider(signer.address());
+        let tip_state = tip_state_with_provider(provider);
+
+        let tx = simple_transfer(&signer, 0);
+        assert!(tip_state.run_simulation(tx));
+    }
+
+    #[test]
+    fn reverting_tx_returns_false() {
+        let signer = PrivateKeySigner::random();
+        let provider = funded_provider(signer.address());
+        let tip_state = tip_state_with_provider(provider);
+
+        let tx = reverting_create(&signer, 0);
+        assert!(!tip_state.run_simulation(tx));
+    }
+
+    #[test]
+    fn nonce_too_high_passes_through() {
+        let signer = PrivateKeySigner::random();
+        let provider = funded_provider(signer.address());
+        let tip_state = tip_state_with_provider(provider);
+
+        // Account has nonce 0, tx uses nonce 5 — should pass (let pool handle it)
+        let tx = simple_transfer(&signer, 5);
+        assert!(tip_state.run_simulation(tx));
+    }
+
+    #[test]
+    fn insufficient_balance_returns_false() {
+        let signer = PrivateKeySigner::random();
+        // Account with zero balance
+        let mut provider = StateProviderTest::default();
+        provider.insert_account(
+            signer.address(),
+            Account {
+                nonce: 0,
+                balance: U256::ZERO,
+                bytecode_hash: None,
+            },
+            None,
+            HashMap::default(),
+        );
+        let tip_state = tip_state_with_provider(provider);
+
+        let tx = simple_transfer(&signer, 0);
+        assert!(!tip_state.run_simulation(tx));
+    }
+
+    #[test]
+    fn unknown_sender_returns_false() {
+        let signer = PrivateKeySigner::random();
+        // Empty state — sender doesn't exist
+        let provider = StateProviderTest::default();
+        let tip_state = tip_state_with_provider(provider);
+
+        let tx = simple_transfer(&signer, 0);
+        assert!(!tip_state.run_simulation(tx));
+    }
+
+    #[test]
+    fn no_tip_state_passes_through() {
+        let simulator = TopOfBlockSimulator::new();
+        let signer = PrivateKeySigner::random();
+        let tx = simple_transfer(&signer, 0);
+
+        assert!(simulator.simulate_tx_sync(tx));
+    }
+
+    #[test]
+    fn update_tip_makes_simulation_available() {
+        let simulator = TopOfBlockSimulator::new();
+        let signer = PrivateKeySigner::random();
+        let provider = funded_provider(signer.address());
+
+        // Before update — passes through
+        assert!(simulator.simulate_tx_sync(reverting_create(&signer, 0)));
+
+        // After update — successfully rejected
+        simulator.update_tip(tip_state_with_provider(provider));
+        assert!(!simulator.simulate_tx_sync(reverting_create(&signer, 0)));
+    }
+
+    #[test]
+    fn simulations_are_isolated() {
+        let signer = PrivateKeySigner::random();
+        let provider = funded_provider(signer.address());
+        let tip_state = tip_state_with_provider(provider);
+
+        // Run a transfer that mutates state (nonce advances)
+        assert!(tip_state.run_simulation(simple_transfer(&signer, 0)));
+
+        // Same nonce=0 tx should still succeed — state wasn't persisted
+        assert!(tip_state.run_simulation(simple_transfer(&signer, 0)));
+    }
+}

--- a/crates/op-rbuilder/src/revert_protection.rs
+++ b/crates/op-rbuilder/src/revert_protection.rs
@@ -2,9 +2,11 @@ use std::{sync::Arc, time::Instant};
 
 use crate::{
     metrics::OpRBuilderMetrics,
+    presim::TopOfBlockSimulator,
     primitives::bundle::{Bundle, BundleResult},
     tx::{FBPooledTransaction, MaybeFlashblockFilter},
 };
+use alloy_consensus::Header;
 use alloy_json_rpc::RpcObject;
 use alloy_primitives::B256;
 use jsonrpsee::{
@@ -12,9 +14,13 @@ use jsonrpsee::{
     proc_macros::rpc,
 };
 use moka::future::Cache;
+use op_alloy_consensus::OpTxEnvelope;
 use reth::rpc::api::eth::{RpcReceipt, helpers::FullEthApi};
+use reth_optimism_chainspec::OpChainSpec;
+use reth_optimism_primitives::OpTransactionSigned;
 use reth_optimism_txpool::{OpPooledTransaction, conditional::MaybeConditionalTransaction};
-use reth_provider::StateProviderFactory;
+use reth_primitives_traits::Recovered;
+use reth_provider::{BlockReaderIdExt, ChainSpecProvider, StateProviderFactory};
 use reth_rpc_eth_types::{EthApiError, utils::recover_raw_transaction};
 use reth_transaction_pool::{PoolTransaction, TransactionOrigin, TransactionPool};
 use tracing::error;
@@ -36,6 +42,7 @@ pub struct RevertProtectionExt<Pool, Provider, Eth> {
     eth_api: Eth,
     metrics: Arc<OpRBuilderMetrics>,
     reverted_cache: Cache<B256, ()>,
+    simulator: Option<Arc<TopOfBlockSimulator>>,
 }
 
 impl<Pool, Provider, Eth> RevertProtectionExt<Pool, Provider, Eth>
@@ -44,11 +51,12 @@ where
     Provider: Clone,
     Eth: Clone,
 {
-    pub fn new(
+    pub(crate) fn new(
         pool: Pool,
         provider: Provider,
         eth_api: Eth,
         reverted_cache: Cache<B256, ()>,
+        simulator: Option<Arc<TopOfBlockSimulator>>,
     ) -> Self {
         Self {
             pool,
@@ -56,6 +64,7 @@ where
             eth_api,
             metrics: Arc::new(OpRBuilderMetrics::default()),
             reverted_cache,
+            simulator,
         }
     }
 }
@@ -65,7 +74,13 @@ impl<Pool, Provider, Eth> EthApiExtServer<RpcReceipt<Eth::NetworkTypes>>
     for RevertProtectionExt<Pool, Provider, Eth>
 where
     Pool: TransactionPool<Transaction = FBPooledTransaction> + Clone + 'static,
-    Provider: StateProviderFactory + Send + Sync + Clone + 'static,
+    Provider: StateProviderFactory
+        + BlockReaderIdExt<Header = Header>
+        + ChainSpecProvider<ChainSpec = OpChainSpec>
+        + Send
+        + Sync
+        + Clone
+        + 'static,
     Eth: FullEthApi + Send + Sync + Clone + 'static,
 {
     async fn send_bundle(&self, bundle: Bundle) -> RpcResult<BundleResult> {
@@ -111,7 +126,13 @@ where
 impl<Pool, Provider, Eth> RevertProtectionExt<Pool, Provider, Eth>
 where
     Pool: TransactionPool<Transaction = FBPooledTransaction> + Clone + 'static,
-    Provider: StateProviderFactory + Send + Sync + Clone + 'static,
+    Provider: StateProviderFactory
+        + BlockReaderIdExt<Header = Header>
+        + ChainSpecProvider<ChainSpec = OpChainSpec>
+        + Send
+        + Sync
+        + Clone
+        + 'static,
     Eth: FullEthApi + Send + Sync + Clone + 'static,
 {
     async fn send_bundle_inner(&self, bundle: Bundle) -> RpcResult<BundleResult> {
@@ -141,9 +162,11 @@ where
             .conditional(last_block_number)
             .map_err(EthApiError::from)?;
 
-        let recovered = recover_raw_transaction(&bundle_transaction)?;
+        let recovered: Recovered<op_alloy_consensus::OpPooledTransaction> =
+            recover_raw_transaction(&bundle_transaction)?;
+
         let pool_transaction =
-            FBPooledTransaction::from(OpPooledTransaction::from_pooled(recovered))
+            FBPooledTransaction::from(OpPooledTransaction::from_pooled(recovered.clone()))
                 .with_reverted_hashes(bundle.reverting_tx_hashes.clone().unwrap_or_default())
                 .with_min_flashblock_number(conditional.min_flashblock_number)
                 .with_max_flashblock_number(conditional.max_flashblock_number)
@@ -154,6 +177,45 @@ where
             .add_transaction(TransactionOrigin::Local, pool_transaction)
             .await
             .map_err(EthApiError::from)?;
+
+        // Pre-simulate the transaction against current head state if:
+        // - pre-simulation is enabled (simulator is Some)
+        // - the tx is allowed to revert
+        if bundle
+            .reverting_tx_hashes
+            .as_ref()
+            .is_some_and(|hashes| !hashes.is_empty())
+            && let Some(simulator) = &self.simulator
+        {
+            let pool = self.pool.clone();
+            let metrics = self.metrics.clone();
+            let simulator = simulator.clone();
+            tokio::task::spawn(async move {
+                let sim_start = Instant::now();
+                let sim_tx: Recovered<OpTransactionSigned> = recovered
+                    .clone()
+                    .map(|tx| OpTransactionSigned::from(OpTxEnvelope::from(tx)));
+                let sim_tx_hash = *sim_tx.hash();
+                match simulator.clone().simulate_tx(sim_tx).await {
+                    Ok(true) => {
+                        metrics.bundle_pre_simulation_passes.increment(1);
+                    }
+                    Ok(false) => {
+                        metrics.bundle_pre_simulation_reverts.increment(1);
+                        metrics
+                            .bundle_pre_simulation_duration
+                            .record(sim_start.elapsed());
+                        pool.remove_transaction(sim_tx_hash);
+                    }
+                    Err(e) => {
+                        error!(error = ?e, "pre-simulation task failed");
+                    }
+                }
+                metrics
+                    .bundle_pre_simulation_duration
+                    .record(sim_start.elapsed());
+            });
+        }
 
         let result = BundleResult {
             bundle_hash: outcome.hash,

--- a/crates/op-rbuilder/src/tests/framework/instance.rs
+++ b/crates/op-rbuilder/src/tests/framework/instance.rs
@@ -2,6 +2,8 @@ use crate::{
     args::OpRbuilderArgs,
     backrun_bundle::{BackrunBundleApiServer, BackrunBundleRpc},
     builder::{BuilderConfig, FlashblocksServiceBuilder},
+    metrics::OpRBuilderMetrics,
+    presim::{TopOfBlockSimulator, maintain_pending_simulations, maintain_tip_state},
     revert_protection::{EthApiExtServer, RevertProtectionExt},
     tests::{
         EngineApi, Ipc, TEE_DEBUG_ADDRESS, TransactionPoolObserver, builder_signer, create_test_db,
@@ -37,11 +39,13 @@ use reth::{
 };
 use reth_node_builder::{NodeBuilder, NodeConfig};
 use reth_optimism_chainspec::OpChainSpec;
+use reth_optimism_evm::OpEvmConfig;
 use reth_optimism_node::{
     OpNode,
     node::{OpAddOns, OpAddOnsBuilder, OpEngineValidatorBuilder, OpPoolBuilder},
 };
 use reth_optimism_rpc::OpEthApiBuilder;
+use reth_provider::{CanonStateSubscriptions, ChainSpecProvider};
 use reth_transaction_pool::{AllTransactionsEvents, TransactionPool};
 use std::{
     net::SocketAddr,
@@ -112,6 +116,15 @@ impl LocalInstance {
         let da_config = builder_config.da_config.clone();
         let gas_limit_config = builder_config.gas_limit_config.clone();
         let backrun_bundle_pool = builder_config.backrun_bundle_pool.clone();
+        let block_time_secs = builder_config.block_time.as_millis() as u64 / 1000;
+
+        let simulator = if args.pre_simulate_bundles {
+            Some(Arc::new(TopOfBlockSimulator::new()))
+        } else {
+            None
+        };
+        let simulator_for_rpc = simulator.clone();
+        let simulator_for_maintenance = simulator.clone();
 
         let addons: OpAddOns<_, OpEthApiBuilder, OpEngineValidatorBuilder> =
             OpAddOnsBuilder::default()
@@ -143,6 +156,7 @@ impl LocalInstance {
                         provider,
                         ctx.registry.eth_api().clone(),
                         reverted_cache,
+                        simulator_for_rpc,
                     );
 
                     ctx.modules
@@ -170,6 +184,34 @@ impl LocalInstance {
                 txpool_ready_tx
                     .send(ctx.pool.all_transactions_event_listener())
                     .expect("Failed to send txpool ready signal");
+
+                if let Some(simulator) = simulator_for_maintenance {
+                    let metrics = Arc::new(OpRBuilderMetrics::default());
+                    let chain_events = ctx.provider.canonical_state_stream();
+                    let evm_config = OpEvmConfig::optimism(ctx.provider.chain_spec());
+                    ctx.task_executor.spawn_task(
+                        maintain_tip_state(
+                            simulator.clone(),
+                            ctx.provider.clone(),
+                            evm_config,
+                            block_time_secs,
+                            metrics.clone(),
+                            chain_events,
+                        )
+                        .boxed(),
+                    );
+
+                    let pending_events = ctx.pool.all_transactions_event_listener();
+                    ctx.task_executor.spawn_task(
+                        maintain_pending_simulations(
+                            simulator,
+                            ctx.pool.clone(),
+                            metrics,
+                            pending_events,
+                        )
+                        .boxed(),
+                    );
+                }
 
                 Ok(())
             });

--- a/crates/op-rbuilder/src/tests/revert.rs
+++ b/crates/op-rbuilder/src/tests/revert.rs
@@ -1,6 +1,7 @@
 use alloy_provider::{PendingTransactionBuilder, Provider};
 use macros::rb_test;
 use op_alloy_network::Optimism;
+use std::time::Duration;
 
 use crate::{
     args::OpRbuilderArgs,
@@ -437,6 +438,47 @@ async fn check_transaction_receipt_status_message(rbuilder: LocalInstance) -> ey
     let receipt = provider.get_transaction_receipt(*tx_hash).await;
 
     assert!(receipt.is_err());
+
+    Ok(())
+}
+
+/// Pre-simulation evicts reverting bundles from the pool asynchronously after
+/// they are accepted. The handler accepts the bundle immediately; a background
+/// task runs the simulation and removes the transaction when it reverts.
+#[rb_test(args = OpRbuilderArgs {
+    enable_revert_protection: true,
+    pre_simulate_bundles: true,
+    ..Default::default()
+})]
+async fn presim_rejects_reverting_bundle(rbuilder: LocalInstance) -> eyre::Result<()> {
+    let driver = rbuilder.driver().await?;
+    // Build a block to ensure the maintain_tip_state task has processed the
+    // canonical state notification and populated the simulator's tip state.
+    driver.build_new_block().await?;
+
+    // The handler accepts the bundle immediately; presim runs in the background
+    let bundle = driver
+        .create_transaction()
+        .random_reverting_transaction()
+        .with_reverted_hash()
+        .with_bundle(BundleOpts::default())
+        .send()
+        .await?;
+
+    let tx_hash = *bundle.tx_hash();
+
+    // Wait for the background pre-simulation task to evict the reverting tx
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if rbuilder.pool().is_dropped(tx_hash) {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "reverting bundle was not evicted by pre-simulation within timeout"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## 📝 Summary

Features:
- RPC layer filter: Bundle transactions marked as allowed to revert are now simulated against the current chain tip immediately following pool insertion. If they revert, then they're removed from the pool, saving compute from block building.
- Background pool eviction: A maintenance task listens for newly promoted pending transactions and evicts reverting ones, closing the nonce-gap bypass where adversaries could bypass RPC pre-simulation by entering their tx into the queued pool first.
- Random coinbase for simulation: Prevents attackers from crafting transactions that behave differently during simulation vs block building by checking block.coinbase.

Unit tests and a integration test added.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)