### PR TITLE
feat: default flashblocks.end-buffer-ms to 100

### DIFF
--- a/crates/op-rbuilder/src/args/op.rs
+++ b/crates/op-rbuilder/src/args/op.rs
@@ -194,13 +194,20 @@ pub struct FlashblocksArgs {
     )]
     pub flashblocks_send_offset_ms: i64,
 
-    /// Time in milliseconds to build the last flashblock early before the end of the slot
+    /// Time in milliseconds to build the last flashblock early before the end of the slot.
     /// This serves as a buffer time to account for the last flashblock being delayed
-    /// at the end of the slot due to processing the final block
+    /// at the end of the slot due to processing the final block.
+    ///
+    /// Default 100ms: with the 250ms flashblock interval default and a 2s block, the last
+    /// flashblock is scheduled at t=slot_end. With zero buffer it typically can't publish
+    /// before `getPayload` and is silently dropped, leaving one of the block's flashblock
+    /// slots permanently empty. 100ms of buffer gives the final flashblock enough headroom
+    /// to build and publish (measured p99 build time is ~6ms) while only moving the dead
+    /// zone at end-of-block earlier by 100ms.
     #[arg(
         long = "flashblocks.end-buffer-ms",
         env = "FLASHBLOCK_END_BUFFER_MS",
-        default_value = "0"
+        default_value = "100"
     )]
     pub flashblocks_end_buffer_ms: u64,
 

--- a/crates/op-rbuilder/src/args/op.rs
+++ b/crates/op-rbuilder/src/args/op.rs
@@ -195,15 +195,10 @@ pub struct FlashblocksArgs {
     pub flashblocks_send_offset_ms: i64,
 
     /// Time in milliseconds to build the last flashblock early before the end of the slot.
-    /// This serves as a buffer time to account for the last flashblock being delayed
-    /// at the end of the slot due to processing the final block.
-    ///
-    /// Default 100ms: with the 250ms flashblock interval default and a 2s block, the last
-    /// flashblock is scheduled at t=slot_end. With zero buffer it typically can't publish
-    /// before `getPayload` and is silently dropped, leaving one of the block's flashblock
-    /// slots permanently empty. 100ms of buffer gives the final flashblock enough headroom
-    /// to build and publish (measured p99 build time is ~6ms) while only moving the dead
-    /// zone at end-of-block earlier by 100ms.
+    /// This gives the final flashblock headroom to build and publish before `getPayload`;
+    /// without it the last flashblock is prone to being dropped, leaving one of the block's
+    /// flashblock slots empty. The trade-off is moving the end-of-block dead zone earlier
+    /// by the same amount.
     #[arg(
         long = "flashblocks.end-buffer-ms",
         env = "FLASHBLOCK_END_BUFFER_MS",

--- a/crates/op-rbuilder/src/builder/config.rs
+++ b/crates/op-rbuilder/src/builder/config.rs
@@ -72,7 +72,7 @@ impl Default for FlashblocksConfig {
             number_contract_address: None,
             number_contract_use_permit: false,
             send_offset_ms: 0,
-            end_buffer_ms: 0,
+            end_buffer_ms: 100,
             p2p_enabled: false,
             p2p_port: 9009,
             p2p_private_key_file: None,


### PR DESCRIPTION

## 📝 Summary

The flashblock scheduler generates `target_flashblocks = block_time / interval` trigger times, with the last one firing at `slot_end - end_buffer_ms`. With the default `end_buffer_ms=0`, the final flashblock fires at the slot deadline itself and almost always fails to publish before `getPayload` — so the scheduler allocates a slot that is silently dropped, leaving N-1 usable flashblocks per block instead of N.

Benchmarked on a 2s chain block with the default 250ms interval (8 flashblocks/ block), 100 agents at 100M gas for 120s:

  end_buffer_ms  | p95 backrun_sent→landed | idx=8 utilized | landed/120s
  ---------------+-------------------------+----------------+-------------
       0         |        482 ms           |        no      |    34,686
      50         |        482 ms           |        no      |    35,976
     100         |        331 ms (-31%)    |       yes      |    40,936
     150         |        381 ms           |       yes      |    39,393

50ms is not enough buffer for the build/publish; 100ms is the smallest value in {50,100,150} that lets idx=8 publish before the slot deadline. Larger values (150ms+) don't help because the extra buffer becomes a larger end-of-block dead zone that forces more bundles into the next block.

100ms of buffer costs ~5% of the final slot's bundle-intake window (100ms of 2000ms) in exchange for the entire slot being usable. Net effect: 31% lower p95 landing latency and 18% higher per-block throughput.


## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

Improves signal-boost backrun tail latencies.

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
