### PR TITLE
rename `reverted_hashes` to `allowed_revert_hashes` for clarity

### DIFF
--- a/crates/op-rbuilder/src/builder/context.rs
+++ b/crates/op-rbuilder/src/builder/context.rs
@@ -447,7 +447,7 @@ impl OpPayloadBuilderCtx {
 
         while let Some(tx) = best_txs.next(()) {
             let interop = tx.interop_deadline();
-            let reverted_hashes = tx.reverted_hashes().clone();
+            let allowed_revert_hashes = tx.allowed_revert_hashes().clone();
             let conditional = tx.conditional().cloned();
 
             let tx_da_size = tx.estimated_da_size();
@@ -466,12 +466,13 @@ impl OpPayloadBuilderCtx {
             }
 
             // exclude reverting transaction if:
-            // - the transaction comes from a bundle (is_some) and the hash **is not** in reverted hashes
-            // Note that we need to use the Option to signal whether the transaction comes from a bundle,
-            // otherwise, we would exclude all transactions that are not in the reverted hashes.
-            let is_bundle_tx = reverted_hashes.is_some();
+            // - the transaction comes from a bundle (is_some) and the hash **is not** in the
+            //   bundle's allowed-revert list.
+            // the Option distinguishes bundle vs non-bundle txs; otherwise non-bundle txs would
+            // also be excluded on revert since they're never in the list.
+            let is_bundle_tx = allowed_revert_hashes.is_some();
             let exclude_reverting_txs =
-                is_bundle_tx && !reverted_hashes.unwrap().contains(&tx_hash);
+                is_bundle_tx && !allowed_revert_hashes.unwrap().contains(&tx_hash);
 
             let log_txn = |result: TxnExecutionResult| {
                 debug!(

--- a/crates/op-rbuilder/src/builder/context.rs
+++ b/crates/op-rbuilder/src/builder/context.rs
@@ -447,10 +447,23 @@ impl OpPayloadBuilderCtx {
 
         while let Some(tx) = best_txs.next(()) {
             let interop = tx.interop_deadline();
-            let allowed_revert_hashes = tx.allowed_revert_hashes().clone();
             let conditional = tx.conditional().cloned();
-
             let tx_da_size = tx.estimated_da_size();
+
+            // exclude reverting transaction if:
+            // - the transaction comes from a bundle (is_some) and the hash **is not** in the
+            //   bundle's allowed-revert list.
+            // the Option distinguishes bundle vs non-bundle txs; otherwise non-bundle txs would
+            // also be excluded on revert since they're never in the list.
+            //
+            // computed via a borrow while the pool tx is still in scope, so we don't clone the
+            // allowed-revert list per tx.
+            let is_bundle_tx = tx.allowed_revert_hashes().is_some();
+            let exclude_reverting_txs = tx
+                .allowed_revert_hashes()
+                .as_ref()
+                .is_some_and(|allowed| !allowed.contains(tx.hash()));
+
             let tx = tx.into_consensus();
             let tx_hash = tx.tx_hash();
             let tx_uncompressed_size = tx.encode_2718_len() as u64;
@@ -464,15 +477,6 @@ impl OpPayloadBuilderCtx {
                     stage = "builder_popped"
                 );
             }
-
-            // exclude reverting transaction if:
-            // - the transaction comes from a bundle (is_some) and the hash **is not** in the
-            //   bundle's allowed-revert list.
-            // the Option distinguishes bundle vs non-bundle txs; otherwise non-bundle txs would
-            // also be excluded on revert since they're never in the list.
-            let is_bundle_tx = allowed_revert_hashes.is_some();
-            let exclude_reverting_txs =
-                is_bundle_tx && !allowed_revert_hashes.unwrap().contains(&tx_hash);
 
             let log_txn = |result: TxnExecutionResult| {
                 debug!(

--- a/crates/op-rbuilder/src/revert_protection.rs
+++ b/crates/op-rbuilder/src/revert_protection.rs
@@ -144,7 +144,7 @@ where
         let recovered = recover_raw_transaction(&bundle_transaction)?;
         let pool_transaction =
             FBPooledTransaction::from(OpPooledTransaction::from_pooled(recovered))
-                .with_reverted_hashes(bundle.reverting_tx_hashes.clone().unwrap_or_default())
+                .with_allowed_revert_hashes(bundle.reverting_tx_hashes.clone().unwrap_or_default())
                 .with_min_flashblock_number(conditional.min_flashblock_number)
                 .with_max_flashblock_number(conditional.max_flashblock_number)
                 .with_conditional(conditional.transaction_conditional);

--- a/crates/op-rbuilder/src/tx.rs
+++ b/crates/op-rbuilder/src/tx.rs
@@ -19,10 +19,11 @@ pub struct WithFlashbotsMetadata<T> {
     #[deref]
     inner: T,
 
-    /// Reverted hashes for bundle transactions. If the transaction is a bundle,
-    /// this is the list of hashes of the transactions that reverted. If the
-    /// transaction is not a bundle, this is `None`.
-    reverted_hashes: Option<Vec<B256>>,
+    /// Hashes within a bundle that the submitter permits to revert without
+    /// causing the bundle to be excluded. Sourced from the bundle's
+    /// `reverting_tx_hashes` field. `None` for non-bundle transactions;
+    /// `Some(vec![])` for bundles that permit no reverts.
+    allowed_revert_hashes: Option<Vec<B256>>,
 
     /// Minimum flashblock number constraint
     min_flashblock_number: Option<u64>,
@@ -36,19 +37,19 @@ impl<T> WithFlashbotsMetadata<T> {
     pub fn new(inner: T) -> Self {
         Self {
             inner,
-            reverted_hashes: None,
+            allowed_revert_hashes: None,
             min_flashblock_number: None,
             max_flashblock_number: None,
         }
     }
 
-    pub fn with_reverted_hashes(mut self, reverted_hashes: Vec<B256>) -> Self {
-        self.reverted_hashes = Some(reverted_hashes);
+    pub fn with_allowed_revert_hashes(mut self, allowed_revert_hashes: Vec<B256>) -> Self {
+        self.allowed_revert_hashes = Some(allowed_revert_hashes);
         self
     }
 
-    pub fn reverted_hashes(&self) -> &Option<Vec<B256>> {
-        &self.reverted_hashes
+    pub fn allowed_revert_hashes(&self) -> &Option<Vec<B256>> {
+        &self.allowed_revert_hashes
     }
 }
 


### PR DESCRIPTION
## 📝 Summary

previously, the comment on `reverted_hashes` was inaccurate, it said "if the transaction is a bundle, this is the list of hashes of the transactions that reverted.". however in the building code, it was being used as the list of tx hashes in the bundle that are *allowed* to revert. this renames `reverted_hashes` to `allowed_revert_hashes` for clarity and updates the code comment.

## 💡 Motivation and Context

comment/variable name were misleading.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
