### PR TITLE
fix: remove Box::leak in TEE metrics recording

### DIFF
--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -280,30 +280,17 @@ pub fn record_tee_metrics(raw_quote: &[u8], tee_address: &Address) -> eyre::Resu
     let parsed_quote = parse_report_body(raw_quote)?;
     let workload_id = compute_workload_id_from_parsed(&parsed_quote);
 
-    let workload_id_hex = hex::encode(workload_id);
-    let mr_td_hex = hex::encode(parsed_quote.mr_td);
-    let rt_mr0_hex = hex::encode(parsed_quote.rt_mr0);
-
-    let tee_address_static: &'static str = Box::leak(tee_address.to_string().into_boxed_str());
-    let workload_id_static: &'static str = Box::leak(workload_id_hex.into_boxed_str());
-    let mr_td_static: &'static str = Box::leak(mr_td_hex.into_boxed_str());
-    let rt_mr0_static: &'static str = Box::leak(rt_mr0_hex.into_boxed_str());
-
     // Record TEE address
-    let tee_address_labels: [(&str, &str); 1] = [("tee_address", tee_address_static)];
-    gauge!("op_rbuilder_tee_address", &tee_address_labels).set(1);
+    gauge!("op_rbuilder_tee_address", "tee_address" => tee_address.to_string()).set(1);
 
     // Record workload ID
-    let workload_labels: [(&str, &str); 1] = [("workload_id", workload_id_static)];
-    gauge!("op_rbuilder_tee_workload_id", &workload_labels).set(1);
+    gauge!("op_rbuilder_tee_workload_id", "workload_id" => hex::encode(workload_id)).set(1);
 
     // Record MRTD (TEE measurement)
-    let mr_td_labels: [(&str, &str); 1] = [("mr_td", mr_td_static)];
-    gauge!("op_rbuilder_tee_mr_td", &mr_td_labels).set(1);
+    gauge!("op_rbuilder_tee_mr_td", "mr_td" => hex::encode(parsed_quote.mr_td)).set(1);
 
     // Record RTMR0 (runtime measurement register 0)
-    let rt_mr0_labels: [(&str, &str); 1] = [("rt_mr0", rt_mr0_static)];
-    gauge!("op_rbuilder_tee_rt_mr0", &rt_mr0_labels).set(1);
+    gauge!("op_rbuilder_tee_rt_mr0", "rt_mr0" => hex::encode(parsed_quote.rt_mr0)).set(1);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Replace manual `Box::leak(String::into_boxed_str())` with the `metrics` macro's native `"key" => value` label syntax, which accepts owned `String` (interned internally via `SharedString`).
- Eliminates 4 intentional memory leaks per call in `record_tee_metrics`.
- Net: ~13 lines → ~4 lines, behavior unchanged (same metric names, same label keys/values).

Called once at startup from `flashtestations/service.rs:75`, so the prior leaks were bounded but still unnecessary.