### PR TITLE
feat: reshape log levels

### DIFF
--- a/crates/op-rbuilder/src/builder/context.rs
+++ b/crates/op-rbuilder/src/builder/context.rs
@@ -432,7 +432,7 @@ impl OpPayloadBuilderCtx {
 
         debug!(
             target: "payload_builder",
-            id = ?self.payload_id(),
+            id = %self.payload_id(),
             block_da_limit = ?block_da_limit,
             tx_da_limit = ?tx_da_limit,
             block_gas_limit = ?block_gas_limit,
@@ -474,12 +474,12 @@ impl OpPayloadBuilderCtx {
                 is_bundle_tx && !reverted_hashes.unwrap().contains(&tx_hash);
 
             let log_txn = |result: TxnExecutionResult| {
-                debug!(
+                trace!(
                     target: "payload_builder",
-                    id = ?self.payload_id(),
+                    id = %self.payload_id(),
                     tx_hash = %tx_hash,
-                    tx_da_size = ?tx_da_size,
-                    exclude_reverting_txs = ?exclude_reverting_txs,
+                    tx_da_size,
+                    exclude_reverting_txs,
                     result = %result,
                     "Considering transaction",
                 );
@@ -621,11 +621,11 @@ impl OpPayloadBuilderCtx {
                 }
                 if exclude_reverting_txs {
                     log_txn(TxnExecutionResult::RevertedAndExcluded);
-                    info!(
+                    trace!(
                         target: "payload_builder",
                         tx_hash = %tx.tx_hash(),
                         signer = %tx.signer(),
-                        result = ?result,
+                        gas_used,
                         "skipping reverted transaction"
                     );
                     if self.exclude_reverts_between_flashblocks {
@@ -761,7 +761,7 @@ impl OpPayloadBuilderCtx {
                     let br_hash = bundle.backrun_tx.hash();
 
                     let log_br_txn = |result: TxnExecutionResult| {
-                        debug!(
+                        trace!(
                             target: "payload_builder",
                             message = "Considering backrun",
                             tx_hash = %br_hash,
@@ -941,9 +941,9 @@ impl OpPayloadBuilderCtx {
             backrun_processing_time,
         );
 
-        debug!(
+        info!(
             target: "payload_builder",
-            id = ?self.payload_id(),
+            id = %self.payload_id(),
             txs_executed = num_txs_considered,
             txs_applied = num_txs_simulated_success,
             txs_rejected = num_txs_simulated_fail,

--- a/crates/op-rbuilder/src/builder/payload.rs
+++ b/crates/op-rbuilder/src/builder/payload.rs
@@ -569,13 +569,13 @@ where
             config.attributes.timestamp(),
         );
 
+        let target_flashblocks = flashblock_scheduler.target_flashblocks();
         info!(
             target: "payload_builder",
             id = %fb_payload.payload_id,
-            schedule = ?flashblock_scheduler,
+            target_flashblocks,
             "Computed flashblock timing schedule"
         );
-        let target_flashblocks = flashblock_scheduler.target_flashblocks();
 
         let expected_flashblocks = self
             .config
@@ -817,7 +817,7 @@ where
                         id = %fb_payload.payload_id,
                         flashblock_index = fb_state.flashblock_index(),
                         block_number = ctx.block_number(),
-                        ?err,
+                        %err,
                         "Failed to build flashblock",
                     );
                     return Err(PayloadBuilderError::Other(err.into()));
@@ -1157,17 +1157,6 @@ where
                     target_da_footprint_for_batch,
                 );
 
-                info!(
-                    target: "payload_builder",
-                    event = "flashblock_built",
-                    id = %ctx.payload_id(),
-                    flashblock_index = flashblock_index,
-                    current_gas = info.cumulative_gas_used,
-                    current_da = info.cumulative_da_bytes_used,
-                    target_flashblocks = fb_state.target_flashblock_count(),
-                    "Flashblock built"
-                );
-
                 Ok(Some((next_flashblock_state, new_payload)))
             }
         }
@@ -1377,6 +1366,10 @@ where
         .as_deref()
         .map(|s| s.flashblock_index())
         .unwrap_or(0);
+    let target_flashblock_count_for_trace = fb_state
+        .as_deref()
+        .map(|s| s.target_flashblock_count())
+        .unwrap_or(0);
 
     if calculate_state_root {
         let _state_root_span = span!(Level::INFO, "state_root").entered();
@@ -1567,23 +1560,26 @@ where
         ),
         hashed_state: either::Either::Left(Arc::new(hashed_state)),
     };
-    debug!(
-        target: "payload_builder",
-        id = %ctx.payload_id(),
-        "Executed block created"
-    );
 
     let seal_start = Instant::now();
     let sealed_block = Arc::new(block.seal_slow());
     let seal_duration = seal_start.elapsed();
-    debug!(
+    let block_hash = sealed_block.hash();
+
+    info!(
         target: "payload_builder",
         id = %ctx.payload_id(),
-        ?sealed_block,
-        "Sealed built block"
+        block_number = ctx.block_number(),
+        block_hash = %block_hash,
+        flashblock_index = flashblock_index_for_trace,
+        target_flashblocks = target_flashblock_count_for_trace,
+        tx_count = info.executed_transactions.len(),
+        gas_used = info.cumulative_gas_used,
+        da_used = info.cumulative_da_bytes_used,
+        state_root = %state_root,
+        seal_duration_us = seal_duration.as_micros() as u64,
+        "Block sealed"
     );
-
-    let block_hash = sealed_block.hash();
 
     if enable_tx_tracking_debug_logs {
         debug!(

--- a/crates/op-rbuilder/src/builder/wspub.rs
+++ b/crates/op-rbuilder/src/builder/wspub.rs
@@ -74,7 +74,7 @@ impl WebSocketPublisher {
         // Serialize the payload to a UTF-8 string
         // serialize only once, then just copy around only a pointer
         // to the serialized data for each subscription.
-        info!(
+        debug!(
             target: "payload_builder",
             event = "flashblock_sent",
             message = "Sending flashblock to rollup-boost",


### PR DESCRIPTION
## Summary

Cut production log volume by reshaping level usage across builder hot path. Per-flashblock INFO lines drop from ~3-5 to 2, per-tx DEBUG lines move to TRACE, and `?struct` Debug dumps are stripped or projected.

### Level mental model
- **INFO**: block/flashblock-level summaries only
- **DEBUG**: control flow markers within block/flashblock, no data dumps
- **TRACE**: per-tx, full dumps

### Changes
- **New consolidated INFO** in `build_block`, `"Block sealed"` with `block_number, block_hash, flashblock_index, target_flashblocks, tx_count, gas_used, da_used, state_root, seal_duration_us`.
- **Promoted to INFO**: `"Completed executing best transactions"` (tx/revert/backrun counters).
- **Removed redundant INFO**: `"Flashblock built"`, `"Executed block created"`, `"Sealed built block"`, covered by a consolidated summary log.
- **Demoted INFO → DEBUG**: `wspub.rs` `"Sending flashblock to rollup-boost"` (fires per FB, redundant).
- **Demoted DEBUG → TRACE**: `log_txn` and `log_br_txn` (per-tx, high volume).
- **Demoted INFO → TRACE**: `"skipping reverted transaction"` (per-tx, unbounded).
- **Display over Debug**: `PayloadId`, `err`, `block_hash`, `%` instead of `?` to avoid `PayloadId(0x...)` wrapping and field-by-field struct expansion.
- **Dropped large struct dumps**: `?sealed_block`, `?result` (ExecutionResult), `?flashblock_scheduler`.