### PR TITLE
chore: follow-up log reshape across builder/flashtestations

### DIFF
--- a/crates/op-rbuilder/src/builder/best_txs.rs
+++ b/crates/op-rbuilder/src/builder/best_txs.rs
@@ -121,8 +121,8 @@ where
             {
                 debug!(
                     target: "payload_builder",
-                    tx_hash = ?tx.hash(),
-                    sender = ?tx.sender(),
+                    tx_hash = %tx.hash(),
+                    sender = %tx.sender(),
                     nonce = tx.nonce(),
                     current_flashblock = self.current_flashblock_number,
                     max_flashblock = max,

--- a/crates/op-rbuilder/src/builder/builder_tx.rs
+++ b/crates/op-rbuilder/src/builder/builder_tx.rs
@@ -221,7 +221,7 @@ pub trait BuilderTransactions {
                             trace!(
                                 target: "payload_builder",
                                 error = %err,
-                                builder_tx = ?builder_tx.signed_tx,
+                                tx_hash = %builder_tx.signed_tx.tx_hash(),
                                 "skipping nonce too low builder transaction"
                             );
                         } else {
@@ -230,7 +230,7 @@ pub trait BuilderTransactions {
                             trace!(
                                 target: "payload_builder",
                                 error = %err,
-                                builder_tx = ?builder_tx.signed_tx,
+                                tx_hash = %builder_tx.signed_tx.tx_hash(),
                                 "skipping invalid builder transaction and its descendants"
                             );
                             invalid.insert(builder_tx.signed_tx.signer());

--- a/crates/op-rbuilder/src/builder/context.rs
+++ b/crates/op-rbuilder/src/builder/context.rs
@@ -474,15 +474,17 @@ impl OpPayloadBuilderCtx {
                 is_bundle_tx && !reverted_hashes.unwrap().contains(&tx_hash);
 
             let log_txn = |result: TxnExecutionResult| {
-                trace!(
-                    target: "payload_builder",
-                    id = %self.payload_id(),
-                    tx_hash = %tx_hash,
-                    tx_da_size,
-                    exclude_reverting_txs,
-                    result = %result,
-                    "Considering transaction",
-                );
+                if self.enable_tx_tracking_debug_logs {
+                    debug!(
+                        target: "tx_trace",
+                        id = %self.payload_id(),
+                        tx_hash = %tx_hash,
+                        tx_da_size,
+                        exclude_reverting_txs,
+                        result = %result,
+                        "Considering transaction",
+                    );
+                }
             };
 
             num_txs_considered += 1;
@@ -761,12 +763,14 @@ impl OpPayloadBuilderCtx {
                     let br_hash = bundle.backrun_tx.hash();
 
                     let log_br_txn = |result: TxnExecutionResult| {
-                        trace!(
-                            target: "payload_builder",
-                            message = "Considering backrun",
-                            tx_hash = %br_hash,
-                            result = %result,
-                        )
+                        if self.enable_tx_tracking_debug_logs {
+                            debug!(
+                                target: "tx_trace",
+                                message = "Considering backrun",
+                                tx_hash = %br_hash,
+                                result = %result,
+                            )
+                        }
                     };
 
                     num_txs_considered += 1;

--- a/crates/op-rbuilder/src/builder/flashblocks_builder_tx.rs
+++ b/crates/op-rbuilder/src/builder/flashblocks_builder_tx.rs
@@ -114,7 +114,7 @@ impl BuilderTransactions for FlashblocksBuilderTx {
                     Err(e) => {
                         warn!(
                             target: "flashtestations",
-                            error = ?e,
+                            error = %e,
                             "failed to add flashtestations builder tx"
                         )
                     }
@@ -301,7 +301,7 @@ impl BuilderTransactions for FlashblocksNumberBuilderTx {
                 Err(e) => {
                     warn!(
                         target: "builder_tx",
-                        error = ?e,
+                        error = %e,
                         "flashblocks number contract tx simulation failed, defaulting to fallback builder tx"
                     );
                     self.base_builder_tx
@@ -338,7 +338,7 @@ impl BuilderTransactions for FlashblocksNumberBuilderTx {
                 Err(e) => {
                     warn!(
                         target: "flashtestations",
-                        error = ?e,
+                        error = %e,
                         "failed to add flashtestations builder tx"
                     )
                 }

--- a/crates/op-rbuilder/src/builder/payload_handler.rs
+++ b/crates/op-rbuilder/src/builder/payload_handler.rs
@@ -105,7 +105,7 @@ where
                     if let Err(e) = payload_events_handle.send(Events::BuiltPayload(payload.clone())) {
                         warn!(
                             target: "payload_builder",
-                            error = ?e,
+                            error = %e,
                             "failed to send BuiltPayload event"
                         );
                     }
@@ -139,7 +139,7 @@ where
                                         if let Err(e) = payload_events_handle.send(Events::BuiltPayload(payload)) {
                                             warn!(
                                                 target: "payload_builder",
-                                                error = ?e,
+                                                error = %e,
                                                 "failed to send BuiltPayload event on synced block"
                                             );
                                         }
@@ -147,7 +147,7 @@ where
                                     Err(e) => {
                                         error!(
                                             target: "payload_builder",
-                                            error = ?e,
+                                            error = %e,
                                             "failed to execute external received flashblock"
                                         );
                                     }
@@ -179,7 +179,8 @@ where
 
     info!(
         target: "payload_builder",
-        header = ?payload.block().header(),
+        block_hash = %payload.block().hash(),
+        block_number = payload.block().header().number(),
         "executing external flashblock"
     );
 
@@ -242,7 +243,7 @@ where
                 trace!(
                     target: "payload_builder",
                     len = extra_data.len(),
-                    data = ?extra_data,
+                    data = %extra_data,
                     "invalid extra data length in flashblock for jovian fork"
                 );
                 bail!("extra data length should be 17 bytes");
@@ -258,7 +259,7 @@ where
                 trace!(
                     target: "payload_builder",
                     len = extra_data.len(),
-                    data = ?extra_data,
+                    data = %extra_data,
                     "invalid extra data length in flashblock for holocene fork"
                 );
                 bail!("extra data length should be 9 bytes");
@@ -269,7 +270,7 @@ where
                 trace!(
                     target: "payload_builder",
                     len = extra_data.len(),
-                    data = ?extra_data,
+                    data = %extra_data,
                     "invalid extra data length in flashblock for pre holocene fork"
                 );
                 bail!("extra data length should be 0 bytes");
@@ -347,7 +348,8 @@ where
 
     info!(
         target: "payload_builder",
-        header = ?built_payload.block().header(),
+        block_hash = %built_payload.block().hash(),
+        block_number = built_payload.block().header().number(),
         "successfully executed external flashblock"
     );
     Ok((built_payload, fb_payload))

--- a/crates/op-rbuilder/src/flashtestations/builder_tx.rs
+++ b/crates/op-rbuilder/src/flashtestations/builder_tx.rs
@@ -391,7 +391,7 @@ impl BuilderTransactions for FlashtestationsBuilderTx {
                 Err(e) => {
                     warn!(
                         target: "flashtestations",
-                        error = ?e,
+                        error = %e,
                         "failed to add permit block proof transaction"
                     )
                 }

--- a/crates/op-rbuilder/src/flashtestations/service.rs
+++ b/crates/op-rbuilder/src/flashtestations/service.rs
@@ -150,7 +150,7 @@ fn load_or_generate_tee_key(key_path: &str, debug: bool, debug_seed: &str) -> ey
             warn!(
                 target: "flashtestations",
                 key_path = %key_path,
-                error = ?e,
+                error = %e,
                 "Failed to write key to path"
             )
         })
@@ -165,25 +165,25 @@ fn load_tee_key(path: &Path) -> Option<Signer> {
         return None;
     }
 
-    info!(target: "flashtestations", path = ?path, "Loading TEE key");
+    info!(target: "flashtestations", path = %path.display(), "Loading TEE key");
     let key_hex = fs::read_to_string(path)
-        .inspect_err(|e| warn!(target: "flashtestations", error = ?e, "failed to read key file"))
+        .inspect_err(|e| warn!(target: "flashtestations", error = %e, "failed to read key file"))
         .ok()?;
 
     let secret_bytes = B256::try_from(
         hex::decode(key_hex.trim())
             .inspect_err(
-                |e| warn!(target: "flashtestations", error = ?e, "failed to decode hex from file"),
+                |e| warn!(target: "flashtestations", error = %e, "failed to decode hex from file"),
             )
             .ok()?
             .as_slice(),
     )
-    .inspect_err(|e| warn!(target: "flashtestations", error = ?e, "failed to parse key from file"))
+    .inspect_err(|e| warn!(target: "flashtestations", error = %e, "failed to parse key from file"))
     .ok()?;
 
     Signer::try_from_secret(secret_bytes)
         .inspect_err(
-            |e| warn!(target: "flashtestations", error = ?e, "failed to create signer from key"),
+            |e| warn!(target: "flashtestations", error = %e, "failed to create signer from key"),
         )
         .ok()
 }

--- a/crates/op-rbuilder/src/presim.rs
+++ b/crates/op-rbuilder/src/presim.rs
@@ -210,7 +210,7 @@ pub(crate) async fn maintain_pending_simulations<Pool, St>(
                 }
                 Ok(true) => {}
                 Err(e) => {
-                    error!(tx_hash = %tx_hash, error = ?e, "background simulation failed");
+                    error!(tx_hash = %tx_hash, error = %e, "background simulation failed");
                 }
             }
         });

--- a/crates/op-rbuilder/src/primitives/telemetry.rs
+++ b/crates/op-rbuilder/src/primitives/telemetry.rs
@@ -9,6 +9,7 @@ fn default_trace_filter() -> Targets {
         .with_default(LevelFilter::WARN)
         .with_target("op_rbuilder", LevelFilter::INFO)
         .with_target("payload_builder", LevelFilter::DEBUG)
+        .with_target("tx_trace", LevelFilter::DEBUG)
 }
 
 /// Setup telemetry layer with sampling and custom endpoint configuration

--- a/crates/op-rbuilder/src/revert_protection.rs
+++ b/crates/op-rbuilder/src/revert_protection.rs
@@ -90,7 +90,7 @@ where
         let bundle_result = self
             .send_bundle_inner(bundle)
             .await
-            .inspect_err(|err| error!(error = ?err, "eth_sendBundle request failed"));
+            .inspect_err(|err| error!(error = %err, "eth_sendBundle request failed"));
 
         if bundle_result.is_ok() {
             self.metrics.valid_bundles.increment(1);
@@ -208,7 +208,7 @@ where
                         pool.remove_transaction(sim_tx_hash);
                     }
                     Err(e) => {
-                        error!(error = ?e, "pre-simulation task failed");
+                        error!(error = %e, "pre-simulation task failed");
                     }
                 }
                 metrics


### PR DESCRIPTION
## Summary

Follow-up to #470 (reshape log levels). Sweeps the remaining builder / flashtestations files for the same patterns:

- `?` (Debug) → `%` (Display) for errors, tx hashes, addresses, `Bytes`, paths (via `Path::display()`)
- Projected `?header()` struct dumps to `block_hash` + `block_number` fields
- Projected `?builder_tx.signed_tx` to `tx_hash` at trace level

Deliberately left alone: `result = ?result` on rare warn paths (diagnostic value), `?multiaddrs` (Vec), `?elapsed` (Duration), full payload dumps at trace level.