### PR TITLE
fix: avoid double-recording bundle_pre_simulation_duration on revert

### DIFF
--- a/crates/op-rbuilder/src/revert_protection.rs
+++ b/crates/op-rbuilder/src/revert_protection.rs
@@ -202,9 +202,6 @@ where
                     }
                     Ok(false) => {
                         metrics.bundle_pre_simulation_reverts.increment(1);
-                        metrics
-                            .bundle_pre_simulation_duration
-                            .record(sim_start.elapsed());
                         pool.remove_transaction(sim_tx_hash);
                     }
                     Err(e) => {


### PR DESCRIPTION
## 📝 Summary

`bundle_pre_simulation_duration` is being recorded twice in the `Ok(false)` arm (once inline, once in the unconditional record). Removes the inline record so all three arms pass / revert / err are counted once. Introduced in #466.

<!--- A general summary of your changes -->

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
