### PR TITLE
feat(presim): constrain number of sim tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7264,6 +7264,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tokio-metrics",
+ "tokio-stream",
  "tokio-tungstenite 0.26.2",
  "tokio-util",
  "tower",

--- a/crates/op-rbuilder/Cargo.toml
+++ b/crates/op-rbuilder/Cargo.toml
@@ -127,6 +127,7 @@ testcontainers = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio.workspace = true
 tokio-metrics.workspace = true
+tokio-stream.workspace = true
 tokio-tungstenite.workspace = true
 tokio-util.workspace = true
 tower.workspace = true

--- a/crates/op-rbuilder/src/args/op.rs
+++ b/crates/op-rbuilder/src/args/op.rs
@@ -70,6 +70,14 @@ pub struct OpRbuilderArgs {
     )]
     pub pre_simulate_bundles: bool,
 
+    /// Maximum number of concurrent pre-simulation tasks. If not set,
+    /// concurrency is unbounded.
+    #[arg(
+        long = "builder.presim-max-concurrency",
+        env = "PRESIM_MAX_CONCURRENCY"
+    )]
+    pub presim_max_concurrency: Option<usize>,
+
     /// Enables logs to trace transaction lifecycle as it is added to the
     /// mempool and added to a block. Requires `RUST_LOG=tx_trace=debug` in
     /// addition to this flag.

--- a/crates/op-rbuilder/src/launcher.rs
+++ b/crates/op-rbuilder/src/launcher.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use eyre::Result;
 use futures::FutureExt;
 use reth_optimism_rpc::OpEthApiBuilder;
+use tokio::sync::mpsc;
 use tracing::info;
 
 use crate::{
@@ -13,6 +14,7 @@ use crate::{
     builder::{BuilderConfig, FlashblocksServiceBuilder},
     metrics::{OpRBuilderMetrics, VERSION, record_flag_gauge_metrics},
     monitor_tx_pool::monitor_tx_pool,
+    pool::run_pool_insertion_task,
     presim::{TopOfBlockSimulator, maintain_pending_simulations, maintain_tip_state},
     revert_protection::{EthApiExtServer, RevertProtectionExt},
     tx::FBPooledTransaction,
@@ -30,6 +32,7 @@ use reth_optimism_node::{
 };
 use reth_provider::{CanonStateSubscriptions, ChainSpecProvider};
 use reth_transaction_pool::TransactionPool;
+
 pub fn launch() -> Result<()> {
     let cli = Cli::parsed();
 
@@ -104,6 +107,8 @@ impl Launcher<OpChainSpecParser, OpRbuilderArgs> for BuilderLauncher {
         let backrun_bundle_pool = builder_config.backrun_bundle_pool.clone();
         let backrun_bundle_pool_maintain = backrun_bundle_pool.clone();
 
+        let (pool_tx, pool_rx) = mpsc::unbounded_channel();
+
         let simulator = if builder_args.pre_simulate_bundles {
             Some(Arc::new(TopOfBlockSimulator::new()))
         } else {
@@ -145,14 +150,12 @@ impl Launcher<OpChainSpecParser, OpRbuilderArgs> for BuilderLauncher {
                 if builder_args.enable_revert_protection {
                     info!("Revert protection enabled");
 
-                    let pool = ctx.pool().clone();
                     let provider = ctx.provider().clone();
                     let revert_protection_ext = RevertProtectionExt::new(
-                        pool,
                         provider,
                         ctx.registry.eth_api().clone(),
                         reverted_cache,
-                        simulator_for_rpc,
+                        pool_tx,
                     );
 
                     ctx.modules
@@ -175,6 +178,20 @@ impl Launcher<OpChainSpecParser, OpRbuilderArgs> for BuilderLauncher {
             })
             .on_node_started(move |ctx| {
                 VERSION.register_version_metrics();
+
+                let metrics = Arc::new(OpRBuilderMetrics::default());
+
+                ctx.task_executor.spawn_critical_task(
+                    "bundleInsertion",
+                    run_pool_insertion_task(
+                        ctx.task_executor.clone(),
+                        ctx.pool.clone(),
+                        pool_rx,
+                        simulator_for_rpc,
+                        metrics.clone(),
+                    ),
+                );
+
                 if builder_args.log_pool_transactions {
                     info!("Logging pool transactions");
                     let listener = ctx.pool.all_transactions_event_listener();
@@ -198,7 +215,6 @@ impl Launcher<OpChainSpecParser, OpRbuilderArgs> for BuilderLauncher {
                 }
 
                 if let Some(simulator) = simulator_for_maintenance {
-                    let metrics = Arc::new(OpRBuilderMetrics::default());
                     let chain_events = ctx.provider.canonical_state_stream();
                     let evm_config = OpEvmConfig::optimism(ctx.provider.chain_spec());
                     ctx.task_executor.spawn_task(
@@ -216,6 +232,7 @@ impl Launcher<OpChainSpecParser, OpRbuilderArgs> for BuilderLauncher {
                     let pending_events = ctx.pool.all_transactions_event_listener();
                     ctx.task_executor.spawn_task(
                         maintain_pending_simulations(
+                            ctx.task_executor.clone(),
                             simulator,
                             ctx.pool.clone(),
                             metrics,

--- a/crates/op-rbuilder/src/launcher.rs
+++ b/crates/op-rbuilder/src/launcher.rs
@@ -189,6 +189,7 @@ impl Launcher<OpChainSpecParser, OpRbuilderArgs> for BuilderLauncher {
                         pool_rx,
                         simulator_for_rpc,
                         metrics.clone(),
+                        builder_args.presim_max_concurrency,
                     ),
                 );
 

--- a/crates/op-rbuilder/src/lib.rs
+++ b/crates/op-rbuilder/src/lib.rs
@@ -7,6 +7,7 @@ pub mod gas_limiter;
 pub mod launcher;
 pub mod metrics;
 mod monitor_tx_pool;
+pub mod pool;
 pub mod presim;
 pub mod primitives;
 pub mod revert_protection;

--- a/crates/op-rbuilder/src/pool.rs
+++ b/crates/op-rbuilder/src/pool.rs
@@ -1,0 +1,73 @@
+use std::{sync::Arc, time::Instant};
+
+use reth_tasks::Runtime;
+use reth_transaction_pool::{
+    PoolTransaction, TransactionOrigin, TransactionPool, error::PoolError,
+};
+use tokio::sync::{mpsc, oneshot};
+use tracing::error;
+
+use crate::{metrics::OpRBuilderMetrics, presim::TopOfBlockSimulator, tx::FBPooledTransaction};
+
+#[derive(derive_more::Constructor)]
+pub(super) struct AddBundleRequest {
+    tx: FBPooledTransaction,
+    respond_to: oneshot::Sender<Option<PoolError>>,
+}
+
+pub(super) async fn run_pool_insertion_task(
+    runtime: Runtime,
+    // TODO: Remove 'static bound
+    pool: impl TransactionPool<Transaction = FBPooledTransaction> + 'static,
+    mut rx: mpsc::UnboundedReceiver<AddBundleRequest>,
+    simulator: Option<Arc<TopOfBlockSimulator>>,
+    metrics: Arc<OpRBuilderMetrics>,
+) {
+    while let Some(req) = rx.recv().await {
+        let AddBundleRequest { tx, respond_to } = req;
+
+        if let Err(e) = pool
+            .add_transaction(TransactionOrigin::Local, tx.clone())
+            .await
+        {
+            let _ = respond_to.send(Some(e));
+            continue;
+        } else {
+            let _ = respond_to.send(None);
+        }
+
+        // Pre-simulate the transaction against current head state if:
+        // - pre-simulation is enabled (simulator is Some)
+        // - the tx has opted into revert protection
+        if tx.revert_protected()
+            && let Some(simulator) = &simulator
+        {
+            let pool = pool.clone();
+            let metrics = metrics.clone();
+            let simulator = simulator.clone();
+            runtime.spawn_task({
+                let runtime = runtime.clone();
+                async move {
+                    let sim_start = Instant::now();
+                    let sim_tx = tx.into_consensus();
+                    let sim_tx_hash = *sim_tx.hash();
+                    match simulator.clone().simulate_tx(&runtime, sim_tx).await {
+                        Ok(true) => {
+                            metrics.bundle_pre_simulation_passes.increment(1);
+                        }
+                        Ok(false) => {
+                            metrics.bundle_pre_simulation_reverts.increment(1);
+                            pool.remove_transaction(sim_tx_hash);
+                        }
+                        Err(e) => {
+                            error!(error = %e, "pre-simulation task failed");
+                        }
+                    }
+                    metrics
+                        .bundle_pre_simulation_duration
+                        .record(sim_start.elapsed());
+                }
+            });
+        }
+    }
+}

--- a/crates/op-rbuilder/src/pool.rs
+++ b/crates/op-rbuilder/src/pool.rs
@@ -1,10 +1,12 @@
 use std::{sync::Arc, time::Instant};
 
+use futures::StreamExt;
 use reth_tasks::Runtime;
 use reth_transaction_pool::{
     PoolTransaction, TransactionOrigin, TransactionPool, error::PoolError,
 };
 use tokio::sync::{mpsc, oneshot};
+use tokio_stream::wrappers::ReceiverStream;
 use tracing::error;
 
 use crate::{metrics::OpRBuilderMetrics, presim::TopOfBlockSimulator, tx::FBPooledTransaction};
@@ -22,7 +24,19 @@ pub(super) async fn run_pool_insertion_task(
     mut rx: mpsc::UnboundedReceiver<AddBundleRequest>,
     simulator: Option<Arc<TopOfBlockSimulator>>,
     metrics: Arc<OpRBuilderMetrics>,
+    max_concurrency: Option<usize>,
 ) {
+    let bounded_sender = max_concurrency.map(|max| {
+        let (sender, receiver) = mpsc::channel(max);
+        runtime.spawn_task(async move {
+            let _ = ReceiverStream::new(receiver)
+                .buffer_unordered(max)
+                .for_each(|_| async {})
+                .await;
+        });
+        sender
+    });
+
     while let Some(req) = rx.recv().await {
         let AddBundleRequest { tx, respond_to } = req;
 
@@ -45,7 +59,7 @@ pub(super) async fn run_pool_insertion_task(
             let pool = pool.clone();
             let metrics = metrics.clone();
             let simulator = simulator.clone();
-            runtime.spawn_task({
+            let fut = {
                 let runtime = runtime.clone();
                 async move {
                     let sim_start = Instant::now();
@@ -67,7 +81,14 @@ pub(super) async fn run_pool_insertion_task(
                         .bundle_pre_simulation_duration
                         .record(sim_start.elapsed());
                 }
-            });
+            };
+
+            match &bounded_sender {
+                Some(sender) => sender.send(fut).await.unwrap(),
+                None => {
+                    runtime.spawn_task(fut);
+                }
+            }
         }
     }
 }

--- a/crates/op-rbuilder/src/presim.rs
+++ b/crates/op-rbuilder/src/presim.rs
@@ -15,6 +15,7 @@ use reth_optimism_primitives::OpTransactionSigned;
 use reth_primitives_traits::{Block, NodePrimitives, Recovered, RecoveredBlock};
 use reth_provider::{BlockReaderIdExt, ChainSpecProvider, StateProvider, StateProviderFactory};
 use reth_revm::{State, database::StateProviderDatabase};
+use reth_tasks::Runtime;
 use reth_transaction_pool::{FullTransactionEvent, PoolTransaction, TransactionPool};
 use revm::{context::result::ResultAndState, context_interface::result::InvalidTransaction};
 use tracing::{debug, error, warn};
@@ -41,9 +42,11 @@ impl TopOfBlockSimulator {
 
     pub(crate) async fn simulate_tx(
         self: Arc<Self>,
+        runtime: &Runtime,
         tx: Recovered<OpTransactionSigned>,
     ) -> eyre::Result<bool> {
-        tokio::task::spawn_blocking(move || self.simulate_tx_sync(tx))
+        runtime
+            .spawn_blocking(move || self.simulate_tx_sync(tx))
             .await
             .wrap_err("simulate tx task panicked")
     }
@@ -178,6 +181,7 @@ pub(crate) async fn maintain_tip_state<N, St, Provider>(
 }
 
 pub(crate) async fn maintain_pending_simulations<Pool, St>(
+    runtime: Runtime,
     simulator: Arc<TopOfBlockSimulator>,
     pool: Pool,
     metrics: Arc<OpRBuilderMetrics>,
@@ -206,17 +210,20 @@ pub(crate) async fn maintain_pending_simulations<Pool, St>(
         let pool = pool.clone();
         let metrics = metrics.clone();
 
-        tokio::spawn(async move {
-            let consensus_tx = tx.transaction.clone_into_consensus();
-            match simulator.simulate_tx(consensus_tx).await {
-                Ok(false) => {
-                    debug!(tx_hash = %tx_hash, "evicting reverting tx from pool");
-                    pool.remove_transactions(vec![tx_hash]);
-                    metrics.presim_pending_evictions.increment(1);
-                }
-                Ok(true) => {}
-                Err(e) => {
-                    error!(tx_hash = %tx_hash, error = %e, "background simulation failed");
+        runtime.spawn_task({
+            let runtime = runtime.clone();
+            async move {
+                let consensus_tx = tx.transaction.clone_into_consensus();
+                match simulator.simulate_tx(&runtime, consensus_tx).await {
+                    Ok(false) => {
+                        debug!(tx_hash = %tx_hash, "evicting reverting tx from pool");
+                        pool.remove_transactions(vec![tx_hash]);
+                        metrics.presim_pending_evictions.increment(1);
+                    }
+                    Ok(true) => {}
+                    Err(e) => {
+                        error!(tx_hash = %tx_hash, error = %e, "background simulation failed");
+                    }
                 }
             }
         });

--- a/crates/op-rbuilder/src/revert_protection.rs
+++ b/crates/op-rbuilder/src/revert_protection.rs
@@ -2,11 +2,10 @@ use std::{sync::Arc, time::Instant};
 
 use crate::{
     metrics::OpRBuilderMetrics,
-    presim::TopOfBlockSimulator,
+    pool::AddBundleRequest,
     primitives::bundle::{Bundle, BundleResult},
     tx::{FBPooledTransaction, MaybeFlashblockFilter},
 };
-use alloy_consensus::Header;
 use alloy_json_rpc::RpcObject;
 use alloy_primitives::B256;
 use jsonrpsee::{
@@ -14,15 +13,13 @@ use jsonrpsee::{
     proc_macros::rpc,
 };
 use moka::future::Cache;
-use op_alloy_consensus::OpTxEnvelope;
 use reth::rpc::api::eth::{RpcReceipt, helpers::FullEthApi};
-use reth_optimism_chainspec::OpChainSpec;
-use reth_optimism_primitives::OpTransactionSigned;
 use reth_optimism_txpool::{OpPooledTransaction, conditional::MaybeConditionalTransaction};
 use reth_primitives_traits::Recovered;
-use reth_provider::{BlockReaderIdExt, ChainSpecProvider, StateProviderFactory};
+use reth_provider::BlockNumReader;
 use reth_rpc_eth_types::{EthApiError, utils::recover_raw_transaction};
-use reth_transaction_pool::{PoolTransaction, TransactionOrigin, TransactionPool};
+use reth_transaction_pool::PoolTransaction;
+use tokio::sync::{mpsc, oneshot};
 use tracing::error;
 
 // Namespace overrides for revert protection support
@@ -36,51 +33,40 @@ pub trait EthApiExt<R: RpcObject> {
     async fn transaction_receipt(&self, hash: B256) -> RpcResult<Option<R>>;
 }
 
-pub struct RevertProtectionExt<Pool, Provider, Eth> {
-    pool: Pool,
+pub struct RevertProtectionExt<Provider, Eth> {
     provider: Provider,
     eth_api: Eth,
     metrics: Arc<OpRBuilderMetrics>,
     reverted_cache: Cache<B256, ()>,
-    simulator: Option<Arc<TopOfBlockSimulator>>,
+    pool_tx: mpsc::UnboundedSender<AddBundleRequest>,
 }
 
-impl<Pool, Provider, Eth> RevertProtectionExt<Pool, Provider, Eth>
+impl<Provider, Eth> RevertProtectionExt<Provider, Eth>
 where
-    Pool: Clone,
     Provider: Clone,
     Eth: Clone,
 {
     pub(crate) fn new(
-        pool: Pool,
         provider: Provider,
         eth_api: Eth,
         reverted_cache: Cache<B256, ()>,
-        simulator: Option<Arc<TopOfBlockSimulator>>,
+        pool_tx: mpsc::UnboundedSender<AddBundleRequest>,
     ) -> Self {
         Self {
-            pool,
             provider,
             eth_api,
             metrics: Arc::new(OpRBuilderMetrics::default()),
             reverted_cache,
-            simulator,
+            pool_tx,
         }
     }
 }
 
 #[async_trait]
-impl<Pool, Provider, Eth> EthApiExtServer<RpcReceipt<Eth::NetworkTypes>>
-    for RevertProtectionExt<Pool, Provider, Eth>
+impl<Provider, Eth> EthApiExtServer<RpcReceipt<Eth::NetworkTypes>>
+    for RevertProtectionExt<Provider, Eth>
 where
-    Pool: TransactionPool<Transaction = FBPooledTransaction> + Clone + 'static,
-    Provider: StateProviderFactory
-        + BlockReaderIdExt<Header = Header>
-        + ChainSpecProvider<ChainSpec = OpChainSpec>
-        + Send
-        + Sync
-        + Clone
-        + 'static,
+    Provider: BlockNumReader + Send + Sync + Clone + 'static,
     Eth: FullEthApi + Send + Sync + Clone + 'static,
 {
     async fn send_bundle(&self, bundle: Bundle) -> RpcResult<BundleResult> {
@@ -123,16 +109,9 @@ where
     }
 }
 
-impl<Pool, Provider, Eth> RevertProtectionExt<Pool, Provider, Eth>
+impl<Provider, Eth> RevertProtectionExt<Provider, Eth>
 where
-    Pool: TransactionPool<Transaction = FBPooledTransaction> + Clone + 'static,
-    Provider: StateProviderFactory
-        + BlockReaderIdExt<Header = Header>
-        + ChainSpecProvider<ChainSpec = OpChainSpec>
-        + Send
-        + Sync
-        + Clone
-        + 'static,
+    Provider: BlockNumReader + Send + Sync + Clone + 'static,
     Eth: FullEthApi + Send + Sync + Clone + 'static,
 {
     async fn send_bundle_inner(&self, bundle: Bundle) -> RpcResult<BundleResult> {
@@ -167,55 +146,23 @@ where
 
         let pool_transaction =
             FBPooledTransaction::from(OpPooledTransaction::from_pooled(recovered.clone()))
-                .with_allowed_revert_hashes(bundle.reverting_tx_hashes.clone().unwrap_or_default())
+                .with_allowed_revert_hashes(bundle.reverting_tx_hashes.unwrap_or_default())
                 .with_min_flashblock_number(conditional.min_flashblock_number)
                 .with_max_flashblock_number(conditional.max_flashblock_number)
                 .with_conditional(conditional.transaction_conditional);
 
-        let outcome = self
-            .pool
-            .add_transaction(TransactionOrigin::Local, pool_transaction)
-            .await
-            .map_err(EthApiError::from)?;
+        let (tx, rx) = oneshot::channel();
+        let req = AddBundleRequest::new(pool_transaction, tx);
+        self.pool_tx
+            .send(req)
+            .map_err(|_| EthApiError::InternalEthError)?;
 
-        // Pre-simulate the transaction against current head state if:
-        // - pre-simulation is enabled (simulator is Some)
-        // - the tx is allowed to revert
-        if bundle
-            .reverting_tx_hashes
-            .as_ref()
-            .is_some_and(|hashes| !hashes.is_empty())
-            && let Some(simulator) = &self.simulator
-        {
-            let pool = self.pool.clone();
-            let metrics = self.metrics.clone();
-            let simulator = simulator.clone();
-            tokio::task::spawn(async move {
-                let sim_start = Instant::now();
-                let sim_tx: Recovered<OpTransactionSigned> = recovered
-                    .clone()
-                    .map(|tx| OpTransactionSigned::from(OpTxEnvelope::from(tx)));
-                let sim_tx_hash = *sim_tx.hash();
-                match simulator.clone().simulate_tx(sim_tx).await {
-                    Ok(true) => {
-                        metrics.bundle_pre_simulation_passes.increment(1);
-                    }
-                    Ok(false) => {
-                        metrics.bundle_pre_simulation_reverts.increment(1);
-                        pool.remove_transaction(sim_tx_hash);
-                    }
-                    Err(e) => {
-                        error!(error = %e, "pre-simulation task failed");
-                    }
-                }
-                metrics
-                    .bundle_pre_simulation_duration
-                    .record(sim_start.elapsed());
-            });
+        if let Some(e) = rx.await.map_err(|_| EthApiError::InternalEthError)? {
+            return Err(EthApiError::from(e).into());
         }
 
         let result = BundleResult {
-            bundle_hash: outcome.hash,
+            bundle_hash: *recovered.hash(),
         };
         Ok(result)
     }

--- a/crates/op-rbuilder/src/tests/framework/instance.rs
+++ b/crates/op-rbuilder/src/tests/framework/instance.rs
@@ -200,6 +200,7 @@ impl LocalInstance {
                         pool_rx,
                         simulator_for_rpc,
                         metrics.clone(),
+                        None,
                     ),
                 );
 

--- a/crates/op-rbuilder/src/tests/framework/instance.rs
+++ b/crates/op-rbuilder/src/tests/framework/instance.rs
@@ -3,6 +3,7 @@ use crate::{
     backrun_bundle::{BackrunBundleApiServer, BackrunBundleRpc},
     builder::{BuilderConfig, FlashblocksServiceBuilder},
     metrics::OpRBuilderMetrics,
+    pool::run_pool_insertion_task,
     presim::{TopOfBlockSimulator, maintain_pending_simulations, maintain_tip_state},
     revert_protection::{EthApiExtServer, RevertProtectionExt},
     tests::{
@@ -52,7 +53,11 @@ use std::{
     sync::{Arc, LazyLock},
     time::Instant,
 };
-use tokio::{net::TcpListener, sync::oneshot, task::JoinHandle};
+use tokio::{
+    net::TcpListener,
+    sync::{mpsc, oneshot},
+    task::JoinHandle,
+};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tokio_util::sync::CancellationToken;
 
@@ -126,6 +131,8 @@ impl LocalInstance {
         let simulator_for_rpc = simulator.clone();
         let simulator_for_maintenance = simulator.clone();
 
+        let (pool_tx, pool_rx) = mpsc::unbounded_channel();
+
         let addons: OpAddOns<_, OpEthApiBuilder, OpEngineValidatorBuilder> =
             OpAddOnsBuilder::default()
                 .with_sequencer(args.rollup_args.sequencer.clone())
@@ -149,14 +156,12 @@ impl LocalInstance {
                 if args.enable_revert_protection {
                     tracing::info!("Revert protection enabled");
 
-                    let pool = ctx.pool().clone();
                     let provider = ctx.provider().clone();
                     let revert_protection_ext = RevertProtectionExt::new(
-                        pool,
                         provider,
                         ctx.registry.eth_api().clone(),
                         reverted_cache,
-                        simulator_for_rpc,
+                        pool_tx,
                     );
 
                     ctx.modules
@@ -185,8 +190,20 @@ impl LocalInstance {
                     .send(ctx.pool.all_transactions_event_listener())
                     .expect("Failed to send txpool ready signal");
 
+                let metrics = Arc::new(OpRBuilderMetrics::default());
+
+                ctx.task_executor.spawn_critical_task(
+                    "bundleInsertion",
+                    run_pool_insertion_task(
+                        ctx.task_executor.clone(),
+                        ctx.pool.clone(),
+                        pool_rx,
+                        simulator_for_rpc,
+                        metrics.clone(),
+                    ),
+                );
+
                 if let Some(simulator) = simulator_for_maintenance {
-                    let metrics = Arc::new(OpRBuilderMetrics::default());
                     let chain_events = ctx.provider.canonical_state_stream();
                     let evm_config = OpEvmConfig::optimism(ctx.provider.chain_spec());
                     ctx.task_executor.spawn_task(
@@ -204,6 +221,7 @@ impl LocalInstance {
                     let pending_events = ctx.pool.all_transactions_event_listener();
                     ctx.task_executor.spawn_task(
                         maintain_pending_simulations(
+                            ctx.task_executor.clone(),
                             simulator,
                             ctx.pool.clone(),
                             metrics,

--- a/crates/op-rbuilder/src/tests/revert.rs
+++ b/crates/op-rbuilder/src/tests/revert.rs
@@ -460,7 +460,6 @@ async fn presim_rejects_reverting_bundle(rbuilder: LocalInstance) -> eyre::Resul
     let bundle = driver
         .create_transaction()
         .random_reverting_transaction()
-        .with_reverted_hash()
         .with_bundle(BundleOpts::default())
         .send()
         .await?;


### PR DESCRIPTION
1st commit: refactoring pool insertion to happen after sending on a channel. This will make it easier later on to put the presim at the right spot (before bundles get into the reth pool).

2nd commit: Added a flag to constrain the number of simultaneously running presim tasks