### PR TITLE
Release v0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6335,7 +6335,7 @@ dependencies = [
 
 [[package]]
 name = "macros"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7153,7 +7153,7 @@ dependencies = [
 
 [[package]]
 name = "op-rbuilder"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -7448,7 +7448,7 @@ dependencies = [
 
 [[package]]
 name = "p2p"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "derive_more",
  "eyre",
@@ -13198,7 +13198,7 @@ dependencies = [
 
 [[package]]
 name = "tdx-quote-provider"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT OR Apache-2.0"

--- a/crates/op-rbuilder/CHANGELOG.md
+++ b/crates/op-rbuilder/CHANGELOG.md
@@ -1,6 +1,37 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.4.3] - 2026-04-27
+
+### Bug Fixes
+
+- Use cumulative prefix sets for incremental trie state root ([#445](https://github.com/flashbots/op-rbuilder/pull/445))
+- Only simulate bundles with revert protection in presim ([#472](https://github.com/flashbots/op-rbuilder/pull/472))
+- Avoid double-recording bundle_pre_simulation_duration on revert ([#474](https://github.com/flashbots/op-rbuilder/pull/474))
+- Remove Box::leak in TEE metrics recording ([#469](https://github.com/flashbots/op-rbuilder/pull/469))
+- Point to op-reth fork for payload id mismatch ([#473](https://github.com/flashbots/op-rbuilder/pull/473))
+
+### Features
+
+- Async payload builder ([#438](https://github.com/flashbots/op-rbuilder/pull/438))
+- Top-of-block pre-simulation to filter reverting tx spam ([#466](https://github.com/flashbots/op-rbuilder/pull/466))
+- Add flashblock publish timing metric ([#464](https://github.com/flashbots/op-rbuilder/pull/464))
+- Reshape log levels ([#470](https://github.com/flashbots/op-rbuilder/pull/470))
+
+### Refactor
+
+- Extract `reserve_builder_tx_budget` helper ([#476](https://github.com/flashbots/op-rbuilder/pull/476))
+- Extract `FlashblocksState::next_after_seal` ([#477](https://github.com/flashbots/op-rbuilder/pull/477))
+- Move state root flags from FlashblocksState to OpPayloadBuilderCtx ([#478](https://github.com/flashbots/op-rbuilder/pull/478))
+- Generator: drop dead config and tidy module ([#479](https://github.com/flashbots/op-rbuilder/pull/479))
+- Generator: behaviour fixes for new_payload_job and best_payload ([#480](https://github.com/flashbots/op-rbuilder/pull/480))
+
+### Chore
+
+- Remove unused `interop` feature ([#475](https://github.com/flashbots/op-rbuilder/pull/475))
+- Follow-up log reshape across builder/flashtestations ([#471](https://github.com/flashbots/op-rbuilder/pull/471))
+- Rename `reverted_hashes` to `allowed_revert_hashes` for clarity ([#468](https://github.com/flashbots/op-rbuilder/pull/468))
+
 ## [0.4.2] - 2026-04-13
 
 ### Features


### PR DESCRIPTION
## Summary

- Bump workspace version to `0.4.3`
- Update CHANGELOG with 17 PRs since v0.4.2

## Highlights

- **Async payload builder** (#438)
- **Top-of-block pre-simulation** to filter reverting tx spam (#466)
- **Incremental trie state root fix** for reverted storage slots (#445)
- **Payload ID mismatch fix** for op-reth 2.0 (#473)
- Several generator/payload refactors (#476–#480)

See [CHANGELOG](crates/op-rbuilder/CHANGELOG.md) for the full list.

## Checklist

* [x] Version bumped in `Cargo.toml`
* [x] `Cargo.lock` updated
* [x] CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)