### PR TITLE
refactor(builder): split payload builder context into static and per-job

### DIFF
--- a/crates/op-rbuilder/src/builder/builder_tx.rs
+++ b/crates/op-rbuilder/src/builder/builder_tx.rs
@@ -26,7 +26,7 @@ use revm::{
 use tracing::{error, trace, warn};
 
 use crate::{
-    builder::context::OpPayloadBuilderCtx, primitives::reth::ExecutionInfo, tx_signer::Signer,
+    builder::context::OpPayloadJobCtx, primitives::reth::ExecutionInfo, tx_signer::Signer,
 };
 
 #[derive(Debug, Default)]
@@ -142,7 +142,7 @@ pub trait BuilderTransactions {
         &self,
         state_provider: impl StateProvider + Clone,
         info: &mut ExecutionInfo,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         db: &mut State<impl Database + DatabaseRef>,
         top_of_block: bool,
         is_first_flashblock: bool,
@@ -154,7 +154,7 @@ pub trait BuilderTransactions {
         &self,
         state_provider: impl StateProvider + Clone,
         info: &mut ExecutionInfo,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         db: &State<impl Database>,
         top_of_block: bool,
         is_first_flashblock: bool,
@@ -177,7 +177,7 @@ pub trait BuilderTransactions {
         &self,
         state_provider: impl StateProvider + Clone,
         info: &mut ExecutionInfo,
-        builder_ctx: &OpPayloadBuilderCtx,
+        builder_ctx: &OpPayloadJobCtx,
         db: &mut State<impl Database>,
         top_of_block: bool,
         is_first_flashblock: bool,
@@ -321,7 +321,7 @@ pub trait BuilderTransactions {
         from: Signer,
         gas_used: u64,
         calldata: Bytes,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         db: impl DatabaseRef,
     ) -> Result<Recovered<OpTransactionSigned>, BuilderTransactionError> {
         let nonce = get_nonce(db, from.address)?;
@@ -342,7 +342,7 @@ pub trait BuilderTransactions {
     fn commit_txs(
         &self,
         signed_txs: Vec<Recovered<OpTransactionSigned>>,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         db: &mut State<impl Database>,
     ) -> Result<(), BuilderTransactionError> {
         let mut evm = ctx.evm_factory.evm(&mut *db);
@@ -441,7 +441,7 @@ impl BuilderTxBase {
 
     pub(super) fn simulate_builder_tx(
         &self,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         db: impl DatabaseRef,
     ) -> Result<Option<BuilderTransactionCtx>, BuilderTransactionError> {
         match self.signer {
@@ -486,7 +486,7 @@ impl BuilderTxBase {
 
     fn signed_builder_tx(
         &self,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         db: impl DatabaseRef,
         signer: Signer,
         gas_used: u64,

--- a/crates/op-rbuilder/src/builder/context.rs
+++ b/crates/op-rbuilder/src/builder/context.rs
@@ -13,7 +13,7 @@ use reth_evm::{
 };
 use reth_node_api::PayloadBuilderError;
 use reth_optimism_chainspec::OpChainSpec;
-use reth_optimism_evm::OpNextBlockEnvAttributes;
+use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_node::OpPayloadBuilderAttributes;
 use reth_optimism_payload_builder::{
@@ -32,12 +32,12 @@ use reth_transaction_pool::{BestTransactionsAttributes, PoolTransaction};
 use revm::{
     Database as _, DatabaseCommit, context::result::ResultAndState, interpreter::as_u64_saturated,
 };
-use std::{sync::Arc, time::Instant};
+use std::{ops::Deref, sync::Arc, time::Instant};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, trace};
 
 use crate::{
-    backrun_bundle::BackrunBundlesPayloadCtx,
+    backrun_bundle::{BackrunBundleArgs, BackrunBundleGlobalPool, BackrunBundlePayloadPool},
     evm::OpBlockEvmFactory,
     gas_limiter::AddressGasLimiter,
     metrics::OpRBuilderMetrics,
@@ -45,22 +45,23 @@ use crate::{
     traits::PayloadTxsBounds,
 };
 
-/// Container type that holds all necessities to build a new payload.
+/// Configuration that is constant for the entire builder lifetime and shared
+/// across every payload job via [`Arc`].
+///
+/// Every field here is either set once at builder construction (CLI args /
+/// `BuilderConfig`) or is itself an `Arc`/handle whose backing data lives
+/// outside the per-job context (e.g. metrics registry, global backrun pool,
+/// per-address gas limiter buckets).
+#[derive(Debug)]
 pub struct OpPayloadBuilderCtx {
-    /// Factory for creating EVM instances (bundles evm_config + evm_env).
-    pub evm_factory: OpBlockEvmFactory,
+    /// EVM configuration used to build a per-job [`OpBlockEvmFactory`].
+    pub evm_config: OpEvmConfig,
     /// The DA config for the payload builder
     pub da_config: OpDAConfig,
-    // Gas limit configuration for the payload builder
+    /// Gas limit configuration for the payload builder
     pub gas_limit_config: OpGasLimitConfig,
     /// The chainspec
     pub chain_spec: Arc<OpChainSpec>,
-    /// How to build the payload.
-    pub config: PayloadConfig<OpPayloadBuilderAttributes<OpTransactionSigned>>,
-    /// Block env attributes for the current block.
-    pub block_env_attributes: OpNextBlockEnvAttributes,
-    /// Marker to check whether the job has been cancelled.
-    pub cancel: CancellationToken,
     /// The metrics for the builder
     pub metrics: Arc<OpRBuilderMetrics>,
     /// Max gas that can be used by a transaction.
@@ -69,8 +70,10 @@ pub struct OpPayloadBuilderCtx {
     pub max_uncompressed_block_size: Option<u64>,
     /// Rate limiting based on gas. This is an optional feature.
     pub address_gas_limiter: AddressGasLimiter,
-    /// Backrun bundles context.
-    pub backrun_ctx: BackrunBundlesPayloadCtx,
+    /// Global pool of backrun bundles (per-block views are derived in the per-job ctx).
+    pub backrun_bundle_pool: BackrunBundleGlobalPool,
+    /// Backrun bundle configuration.
+    pub backrun_bundle_args: BackrunBundleArgs,
     /// Skip reverted txs in subsequent flashblocks
     pub exclude_reverts_between_flashblocks: bool,
     /// Enable tx tracking logs
@@ -81,7 +84,32 @@ pub struct OpPayloadBuilderCtx {
     pub enable_incremental_state_root: bool,
 }
 
-impl OpPayloadBuilderCtx {
+/// Container type that holds all necessities to build a new payload.
+/// This struct is constructed once per payload job.
+pub struct OpPayloadJobCtx {
+    /// Builder-lifetime configuration shared with all other in-flight jobs.
+    pub builder_ctx: Arc<OpPayloadBuilderCtx>,
+    /// Factory for creating EVM instances (bundles evm_config + evm_env).
+    pub evm_factory: OpBlockEvmFactory,
+    /// How to build the payload.
+    pub config: PayloadConfig<OpPayloadBuilderAttributes<OpTransactionSigned>>,
+    /// Block env attributes for the current block.
+    pub block_env_attributes: OpNextBlockEnvAttributes,
+    /// Marker to check whether the job has been cancelled.
+    pub cancel: CancellationToken,
+    /// Per-block view into the global backrun bundle pool.
+    pub backrun_pool: BackrunBundlePayloadPool,
+}
+
+impl Deref for OpPayloadJobCtx {
+    type Target = OpPayloadBuilderCtx;
+
+    fn deref(&self) -> &Self::Target {
+        &self.builder_ctx
+    }
+}
+
+impl OpPayloadJobCtx {
     pub(super) fn with_cancel(self, cancel: CancellationToken) -> Self {
         Self { cancel, ..self }
     }
@@ -681,9 +709,9 @@ impl OpPayloadBuilderCtx {
                 );
             }
 
-            let can_backrun = self.backrun_ctx.args.backruns_enabled
+            let can_backrun = self.backrun_bundle_args.backruns_enabled
                 && tx_succeeded
-                && !self.backrun_ctx.args.is_limit_reached(
+                && !self.backrun_bundle_args.is_limit_reached(
                     num_backruns_considered,
                     num_backruns_successful,
                     0,
@@ -693,13 +721,12 @@ impl OpPayloadBuilderCtx {
             if can_backrun {
                 let backrun_start_time = Instant::now();
                 let gas_left = block_gas_limit.saturating_sub(info.cumulative_gas_used);
-                let backruns = self.backrun_ctx.pool.get_backruns(
+                let backruns = self.backrun_pool.get_backruns(
                     &target_hash,
                     |addr| evm.db_mut().basic(addr).ok().flatten(),
                     base_fee,
                     gas_left,
-                    self.backrun_ctx
-                        .args
+                    self.backrun_bundle_args
                         .max_considered_backruns_per_transaction,
                     miner_fee,
                 );
@@ -707,7 +734,7 @@ impl OpPayloadBuilderCtx {
                 let mut tx_backruns_landed = 0;
 
                 for (tx_backruns_considered, bundle) in backruns.into_iter().enumerate() {
-                    if self.backrun_ctx.args.is_limit_reached(
+                    if self.backrun_bundle_args.is_limit_reached(
                         num_backruns_considered,
                         num_backruns_successful,
                         tx_backruns_considered,
@@ -776,7 +803,10 @@ impl OpPayloadBuilderCtx {
                         continue;
                     };
 
-                    if self.backrun_ctx.args.enforce_strict_priority_fee_ordering {
+                    if self
+                        .backrun_bundle_args
+                        .enforce_strict_priority_fee_ordering
+                    {
                         if backrun_priority_fee != miner_fee {
                             log_br_txn(TxnExecutionResult::BackrunPriorityFeeInvalid);
                             continue;
@@ -872,7 +902,10 @@ impl OpPayloadBuilderCtx {
                         continue;
                     }
 
-                    if self.backrun_ctx.args.enforce_strict_priority_fee_ordering {
+                    if self
+                        .backrun_bundle_args
+                        .enforce_strict_priority_fee_ordering
+                    {
                         let stated = bundle.coinbase_profit.unwrap_or_default();
                         let coinbase_balance_after = br_state
                             .get(&coinbase)

--- a/crates/op-rbuilder/src/builder/flashblocks_builder_tx.rs
+++ b/crates/op-rbuilder/src/builder/flashblocks_builder_tx.rs
@@ -15,8 +15,7 @@ use tracing::warn;
 use crate::{
     builder::{
         BuilderTransactionCtx, BuilderTransactionError, BuilderTransactions,
-        SimulationSuccessResult, builder_tx::BuilderTxBase, context::OpPayloadBuilderCtx,
-        get_nonce,
+        SimulationSuccessResult, builder_tx::BuilderTxBase, context::OpPayloadJobCtx, get_nonce,
     },
     flashtestations::builder_tx::FlashtestationsBuilderTx,
     primitives::reth::ExecutionInfo,
@@ -76,7 +75,7 @@ impl BuilderTransactions for FlashblocksBuilderTx {
         &self,
         state_provider: impl StateProvider + Clone,
         info: &mut ExecutionInfo,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         db: &mut State<impl Database + DatabaseRef>,
         top_of_block: bool,
         is_first_flashblock: bool,
@@ -154,7 +153,7 @@ impl FlashblocksNumberBuilderTx {
 
     fn signed_increment_flashblocks_tx(
         &self,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<BuilderTransactionCtx, BuilderTransactionError> {
         let calldata = IFlashblockNumber::incrementFlashblockNumberCall {};
@@ -165,7 +164,7 @@ impl FlashblocksNumberBuilderTx {
         &self,
         flashtestations_signer: &Signer,
         current_flashblock_number: U256,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<Signature, BuilderTransactionError> {
         let struct_hash_calldata = IFlashblockNumber::computeStructHashCall {
@@ -184,7 +183,7 @@ impl FlashblocksNumberBuilderTx {
     fn signed_increment_flashblocks_permit_tx(
         &self,
         flashtestations_signer: &Signer,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<BuilderTransactionCtx, BuilderTransactionError> {
         let current_flashblock_calldata = IFlashblockNumber::flashblockNumberCall {};
@@ -202,7 +201,7 @@ impl FlashblocksNumberBuilderTx {
     fn increment_flashblocks_tx<T: SolCall + Clone>(
         &self,
         calldata: T,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<BuilderTransactionCtx, BuilderTransactionError> {
         let SimulationSuccessResult { gas_used, .. } = self.simulate_flashblocks_call(
@@ -232,7 +231,7 @@ impl FlashblocksNumberBuilderTx {
     fn simulate_flashblocks_readonly_call<T: SolCall>(
         &self,
         calldata: T,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<SimulationSuccessResult<T>, BuilderTransactionError> {
         self.simulate_flashblocks_call(calldata, vec![], ctx, evm)
@@ -242,7 +241,7 @@ impl FlashblocksNumberBuilderTx {
         &self,
         calldata: T,
         expected_logs: Vec<B256>,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<SimulationSuccessResult<T>, BuilderTransactionError> {
         let tx_req = OpTransactionRequest::default()
@@ -265,7 +264,7 @@ impl BuilderTransactions for FlashblocksNumberBuilderTx {
         &self,
         state_provider: impl StateProvider + Clone,
         info: &mut ExecutionInfo,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         db: &mut State<impl Database + DatabaseRef>,
         top_of_block: bool,
         is_first_flashblock: bool,

--- a/crates/op-rbuilder/src/builder/mod.rs
+++ b/crates/op-rbuilder/src/builder/mod.rs
@@ -30,7 +30,7 @@ pub use builder_tx::{
     SimulationSuccessResult, get_balance, get_nonce,
 };
 pub use config::FlashblocksConfig;
-pub use context::OpPayloadBuilderCtx;
+pub use context::OpPayloadJobCtx;
 pub use service::FlashblocksServiceBuilder;
 pub use state_root::StateRootCalculator;
 

--- a/crates/op-rbuilder/src/builder/payload.rs
+++ b/crates/op-rbuilder/src/builder/payload.rs
@@ -1,11 +1,10 @@
 use super::{state_root::StateRootCalculator, wspub::WebSocketPublisher};
 use crate::{
-    backrun_bundle::BackrunBundlesPayloadCtx,
     builder::{
         BuilderConfig,
         best_txs::{FlashblockPoolTxCursor, FlashblockTxCache},
         builder_tx::{BuilderTransactions, reserve_builder_tx_budget},
-        context::OpPayloadBuilderCtx,
+        context::{OpPayloadBuilderCtx, OpPayloadJobCtx},
         generator::{BuildArguments, PayloadBuilder},
         timing::{FlashblockScheduler, compute_slot_offset_ms},
     },
@@ -117,7 +116,7 @@ pub(super) struct FlashblocksState {
 }
 
 struct FallbackBuildOutput<Cache, Transition> {
-    ctx: OpPayloadBuilderCtx,
+    ctx: OpPayloadJobCtx,
     info: ExecutionInfo,
     payload: OpBuiltPayload,
     fb_payload: OpFlashblockPayload,
@@ -127,7 +126,7 @@ struct FallbackBuildOutput<Cache, Transition> {
 }
 
 struct FlashblockBuildOutput<Cache, Transition> {
-    ctx: OpPayloadBuilderCtx,
+    ctx: OpPayloadJobCtx,
     build_result: eyre::Result<Option<(FlashblocksState, OpBuiltPayload)>>,
     cache: Cache,
     transition: Transition,
@@ -277,8 +276,8 @@ pub(super) struct OpPayloadBuilder<Pool, Client, BuilderTx> {
 
 #[derive(Debug)]
 pub(super) struct OpPayloadBuilderInner<Pool, Client, BuilderTx> {
-    /// The type responsible for creating the evm.
-    evm_config: OpEvmConfig,
+    /// Builder context
+    builder_ctx: Arc<OpPayloadBuilderCtx>,
     /// The transaction pool
     pool: Pool,
     /// Node client
@@ -294,12 +293,8 @@ pub(super) struct OpPayloadBuilderInner<Pool, Client, BuilderTx> {
     ws_pub: WebSocketPublisher,
     /// System configuration for the builder
     config: BuilderConfig,
-    /// The metrics for the builder
-    metrics: Arc<OpRBuilderMetrics>,
     /// The end of builder transaction type
     builder_tx: BuilderTx,
-    /// Rate limiting based on gas. This is an optional feature.
-    address_gas_limiter: AddressGasLimiter,
     /// Tokio task metrics for monitoring spawned tasks
     task_metrics: Arc<FlashblocksTaskMetrics>,
     /// Task executor used to offload blocking work.
@@ -322,7 +317,10 @@ impl<Pool, Client, BuilderTx> Clone for OpPayloadBuilder<Pool, Client, BuilderTx
     }
 }
 
-impl<Pool, Client, BuilderTx> OpPayloadBuilder<Pool, Client, BuilderTx> {
+impl<Pool, Client, BuilderTx> OpPayloadBuilder<Pool, Client, BuilderTx>
+where
+    Client: ClientBounds,
+{
     #[expect(clippy::too_many_arguments)]
     pub(super) fn new(
         evm_config: OpEvmConfig,
@@ -338,18 +336,32 @@ impl<Pool, Client, BuilderTx> OpPayloadBuilder<Pool, Client, BuilderTx> {
         executor: Runtime,
     ) -> Self {
         let address_gas_limiter = AddressGasLimiter::new(config.gas_limiter_config.clone());
+        let builder_ctx = Arc::new(OpPayloadBuilderCtx {
+            evm_config,
+            da_config: config.da_config.clone(),
+            gas_limit_config: config.gas_limit_config.clone(),
+            chain_spec: client.chain_spec(),
+            metrics,
+            max_gas_per_txn: config.max_gas_per_txn,
+            max_uncompressed_block_size: config.max_uncompressed_block_size,
+            address_gas_limiter,
+            backrun_bundle_pool: config.backrun_bundle_pool.clone(),
+            backrun_bundle_args: config.backrun_bundle_args.clone(),
+            exclude_reverts_between_flashblocks: config.exclude_reverts_between_flashblocks,
+            enable_tx_tracking_debug_logs: config.enable_tx_tracking_debug_logs,
+            disable_state_root: config.flashblocks_config.disable_state_root,
+            enable_incremental_state_root: config.flashblocks_config.enable_incremental_state_root,
+        });
         Self {
             inner: Arc::new(OpPayloadBuilderInner {
-                evm_config,
+                builder_ctx,
                 pool,
                 client,
                 built_fb_payload_tx,
                 built_payload_tx,
                 ws_pub,
                 config,
-                metrics,
                 builder_tx,
-                address_gas_limiter,
                 task_metrics,
                 executor,
             }),
@@ -369,19 +381,33 @@ where
             OpPayloadBuilderAttributes<op_alloy_consensus::OpTxEnvelope>,
         >,
         cancel: CancellationToken,
-    ) -> eyre::Result<OpPayloadBuilderCtx> {
-        let chain_spec = self.client.chain_spec();
+    ) -> eyre::Result<OpPayloadJobCtx> {
+        let builder_ctx = &self.builder_ctx;
         let timestamp = config.attributes.timestamp();
 
-        let extra_data = if chain_spec.is_jovian_active_at_timestamp(timestamp) {
+        let extra_data = if builder_ctx
+            .chain_spec
+            .is_jovian_active_at_timestamp(timestamp)
+        {
             config
                 .attributes
-                .get_jovian_extra_data(chain_spec.base_fee_params_at_timestamp(timestamp))
+                .get_jovian_extra_data(
+                    builder_ctx
+                        .chain_spec
+                        .base_fee_params_at_timestamp(timestamp),
+                )
                 .wrap_err("failed to get holocene extra data for flashblocks payload builder")?
-        } else if chain_spec.is_holocene_active_at_timestamp(timestamp) {
+        } else if builder_ctx
+            .chain_spec
+            .is_holocene_active_at_timestamp(timestamp)
+        {
             config
                 .attributes
-                .get_holocene_extra_data(chain_spec.base_fee_params_at_timestamp(timestamp))
+                .get_holocene_extra_data(
+                    builder_ctx
+                        .chain_spec
+                        .base_fee_params_at_timestamp(timestamp),
+                )
                 .wrap_err("failed to get holocene extra data for flashblocks payload builder")?
         } else {
             Default::default()
@@ -403,40 +429,23 @@ where
         };
 
         let evm_factory = OpBlockEvmFactory::for_next_block(
-            self.evm_config.clone(),
+            builder_ctx.evm_config.clone(),
             &config.parent_header,
             &block_env_attributes,
         )
         .wrap_err("failed to create next evm env")?;
 
-        let backrun_ctx = BackrunBundlesPayloadCtx {
-            pool: self
-                .config
-                .backrun_bundle_pool
-                .block_pool(config.parent_header.number + 1),
-            args: self.config.backrun_bundle_args.clone(),
-        };
+        let backrun_pool = builder_ctx
+            .backrun_bundle_pool
+            .block_pool(config.parent_header.number + 1);
 
-        Ok(OpPayloadBuilderCtx {
+        Ok(OpPayloadJobCtx {
+            builder_ctx: Arc::clone(builder_ctx),
             evm_factory,
-            chain_spec,
             config,
             block_env_attributes,
             cancel,
-            da_config: self.config.da_config.clone(),
-            gas_limit_config: self.config.gas_limit_config.clone(),
-            metrics: self.metrics.clone(),
-            max_gas_per_txn: self.config.max_gas_per_txn,
-            max_uncompressed_block_size: self.config.max_uncompressed_block_size,
-            address_gas_limiter: self.address_gas_limiter.clone(),
-            backrun_ctx,
-            exclude_reverts_between_flashblocks: self.config.exclude_reverts_between_flashblocks,
-            enable_tx_tracking_debug_logs: self.config.enable_tx_tracking_debug_logs,
-            disable_state_root: self.config.flashblocks_config.disable_state_root,
-            enable_incremental_state_root: self
-                .config
-                .flashblocks_config
-                .enable_incremental_state_root,
+            backrun_pool,
         })
     }
 
@@ -480,7 +489,9 @@ where
             ctx.enable_incremental_state_root,
         );
 
-        self.address_gas_limiter.refresh(ctx.block_number());
+        self.builder_ctx
+            .address_gas_limiter
+            .refresh(ctx.block_number());
 
         // Phase 1: Build the fallback block.
         let fallback_span = if span.is_none() {
@@ -673,7 +684,7 @@ where
                 // ensures cancellation is checked before trigger.
                 biased;
                 _ = payload_cancel.cancelled() => {
-                    Self::record_cancellation_reason(&self.metrics, &payload_cancel, &span);
+                    Self::record_cancellation_reason(&self.builder_ctx.metrics, &payload_cancel, &span);
                     self.record_flashblocks_metrics(&ctx, &fb_state, &info, target_flashblocks, &span);
                     return Ok(());
                 }
@@ -681,7 +692,7 @@ where
                     Some(t) => t,
                     None => {
                         // Channel closed — scheduler exhausted or canceled
-                        Self::record_cancellation_reason(&self.metrics, &payload_cancel, &span);
+                        Self::record_cancellation_reason(&self.builder_ctx.metrics, &payload_cancel, &span);
                         self.record_flashblocks_metrics(&ctx, &fb_state, &info, target_flashblocks, &span);
                         return Ok(());
                     }
@@ -720,9 +731,9 @@ where
                 _ = payload_cancel.cancelled() => {
                     if payload_cancel.is_resolved() {
                         // Suppressed flashblock: we received getResolve during flashblock building
-                        self.metrics.flashblock_publish_suppressed_total.increment(1);
+                        self.builder_ctx.metrics.flashblock_publish_suppressed_total.increment(1);
                     }
-                    Self::record_cancellation_reason(&self.metrics, &payload_cancel, &span);
+                    Self::record_cancellation_reason(&self.builder_ctx.metrics, &payload_cancel, &span);
                     return Ok(());
                 }
                 result = self.executor.run_blocking_task({
@@ -806,7 +817,7 @@ where
                 if payload_cancel.is_resolved() {
                     ctx.metrics.flashblock_publish_suppressed_total.increment(1);
                 }
-                Self::record_cancellation_reason(&self.metrics, &payload_cancel, &span);
+                Self::record_cancellation_reason(&self.builder_ctx.metrics, &payload_cancel, &span);
                 self.record_flashblocks_metrics(&ctx, &fb_state, &info, target_flashblocks, &span);
                 return Ok(());
             }
@@ -817,7 +828,11 @@ where
                     next_flashblock_state
                 }
                 Ok(None) => {
-                    Self::record_cancellation_reason(&self.metrics, &payload_cancel, &span);
+                    Self::record_cancellation_reason(
+                        &self.builder_ctx.metrics,
+                        &payload_cancel,
+                        &span,
+                    );
                     self.record_flashblocks_metrics(
                         &ctx,
                         &fb_state,
@@ -849,7 +864,7 @@ where
     /// Execute the pre-steps and seal an early fallback block
     fn build_fallback_block(
         &self,
-        ctx: OpPayloadBuilderCtx,
+        ctx: OpPayloadJobCtx,
         mut fb_state: FlashblocksState,
         mut cached_reads: CachedReads,
     ) -> eyre::Result<FallbackBuildOutput<CacheState, Option<TransitionState>>> {
@@ -916,7 +931,7 @@ where
         P: StateRootProvider + HashedPostStateProvider + StorageRootProvider,
     >(
         &self,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         fb_state: &mut FlashblocksState,
         info: &mut ExecutionInfo,
         state: &mut State<DB>,
@@ -1156,7 +1171,7 @@ where
     /// Do some logging and metric recording when we stop building flashblocks
     fn record_flashblocks_metrics(
         &self,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         fb_state: &FlashblocksState,
         info: &ExecutionInfo,
         flashblocks_per_block: u64,
@@ -1232,7 +1247,7 @@ where
 
 fn execute_pre_steps<DB>(
     state: &mut State<DB>,
-    ctx: &OpPayloadBuilderCtx,
+    ctx: &OpPayloadJobCtx,
 ) -> Result<ExecutionInfo, PayloadBuilderError>
 where
     DB: Database<Error = ProviderError> + std::fmt::Debug,
@@ -1253,7 +1268,7 @@ where
 #[tracing::instrument(level = "info", name = "seal_block", skip_all)]
 pub(super) fn build_block<DB, P>(
     state: &mut State<DB>,
-    ctx: &OpPayloadBuilderCtx,
+    ctx: &OpPayloadJobCtx,
     mut fb_state: Option<&mut FlashblocksState>,
     info: &mut ExecutionInfo,
     calculate_state_root: bool,

--- a/crates/op-rbuilder/src/builder/syncer_ctx.rs
+++ b/crates/op-rbuilder/src/builder/syncer_ctx.rs
@@ -1,45 +1,21 @@
 use crate::{
-    backrun_bundle::{BackrunBundleArgs, BackrunBundleGlobalPool, BackrunBundlesPayloadCtx},
-    builder::{BuilderConfig, OpPayloadBuilderCtx},
+    builder::{BuilderConfig, OpPayloadJobCtx, context::OpPayloadBuilderCtx},
     evm::OpBlockEvmFactory,
     gas_limiter::{AddressGasLimiter, args::GasLimiterArgs},
     metrics::OpRBuilderMetrics,
     traits::ClientBounds,
 };
 use reth_basic_payload_builder::PayloadConfig;
-use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
 use reth_optimism_forks::OpHardforks;
-use reth_optimism_payload_builder::{
-    OpPayloadBuilderAttributes,
-    config::{OpDAConfig, OpGasLimitConfig},
-};
+use reth_optimism_payload_builder::{OpPayloadBuilderAttributes, config::OpGasLimitConfig};
 use reth_optimism_primitives::OpTransactionSigned;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, Clone)]
 pub(super) struct OpPayloadSyncerCtx {
-    /// The type that knows how to perform system calls and configure the evm.
-    evm_config: OpEvmConfig,
-    /// The DA config for the payload builder
-    da_config: OpDAConfig,
-    /// The chainspec
-    chain_spec: Arc<OpChainSpec>,
-    /// Max gas that can be used by a transaction.
-    max_gas_per_txn: Option<u64>,
-    /// Maximum cumulative uncompressed (EIP-2718 encoded) block size in bytes.
-    max_uncompressed_block_size: Option<u64>,
-    /// The metrics for the builder
-    metrics: Arc<OpRBuilderMetrics>,
-    /// Global backrun bundle pool
-    backrun_bundle_pool: BackrunBundleGlobalPool,
-    /// Backrun bundle configuration
-    backrun_bundle_args: BackrunBundleArgs,
-    /// Skip reverted txs in subsequent flashblocks
-    exclude_reverts_between_flashblocks: bool,
-    /// Enable transaction tracking logs
-    enable_tx_tracking_debug_logs: bool,
+    builder_ctx: Arc<OpPayloadBuilderCtx>,
 }
 
 impl OpPayloadSyncerCtx {
@@ -53,44 +29,53 @@ impl OpPayloadSyncerCtx {
         Client: ClientBounds,
     {
         let chain_spec = client.chain_spec();
-        Ok(Self {
+        let builder_ctx = Arc::new(OpPayloadBuilderCtx {
             evm_config,
-            da_config: builder_config.da_config.clone(),
+            da_config: builder_config.da_config,
+            gas_limit_config: OpGasLimitConfig::default(),
             chain_spec,
+            metrics,
             max_gas_per_txn: builder_config.max_gas_per_txn,
             max_uncompressed_block_size: builder_config.max_uncompressed_block_size,
-            metrics,
-            backrun_bundle_pool: builder_config.backrun_bundle_pool.clone(),
-            backrun_bundle_args: builder_config.backrun_bundle_args.clone(),
+            address_gas_limiter: AddressGasLimiter::new(GasLimiterArgs::default()),
+            backrun_bundle_pool: builder_config.backrun_bundle_pool,
+            backrun_bundle_args: builder_config.backrun_bundle_args,
             exclude_reverts_between_flashblocks: builder_config.exclude_reverts_between_flashblocks,
             enable_tx_tracking_debug_logs: builder_config.enable_tx_tracking_debug_logs,
-        })
+            disable_state_root: false,
+            enable_incremental_state_root: false,
+        });
+        Ok(Self { builder_ctx })
     }
 
     pub(super) fn evm_config(&self) -> &OpEvmConfig {
-        &self.evm_config
+        &self.builder_ctx.evm_config
     }
 
     pub(super) fn max_gas_per_txn(&self) -> Option<u64> {
-        self.max_gas_per_txn
+        self.builder_ctx.max_gas_per_txn
     }
 
     pub(super) fn max_uncompressed_block_size(&self) -> Option<u64> {
-        self.max_uncompressed_block_size
+        self.builder_ctx.max_uncompressed_block_size
     }
 
     pub(super) fn enable_tx_tracking_debug_logs(&self) -> bool {
-        self.enable_tx_tracking_debug_logs
+        self.builder_ctx.enable_tx_tracking_debug_logs
     }
 
     /// Returns true if regolith is active for the payload.
     pub(super) fn is_regolith_active(&self, timestamp: u64) -> bool {
-        self.chain_spec.is_regolith_active_at_timestamp(timestamp)
+        self.builder_ctx
+            .chain_spec
+            .is_regolith_active_at_timestamp(timestamp)
     }
 
     /// Returns true if canyon is active for the payload.
     pub(super) fn is_canyon_active(&self, timestamp: u64) -> bool {
-        self.chain_spec.is_canyon_active_at_timestamp(timestamp)
+        self.builder_ctx
+            .chain_spec
+            .is_canyon_active_at_timestamp(timestamp)
     }
 
     pub(super) fn into_op_payload_builder_ctx(
@@ -99,30 +84,18 @@ impl OpPayloadSyncerCtx {
         evm_factory: OpBlockEvmFactory,
         block_env_attributes: OpNextBlockEnvAttributes,
         cancel: CancellationToken,
-    ) -> OpPayloadBuilderCtx {
-        let backrun_ctx = BackrunBundlesPayloadCtx {
-            pool: self
-                .backrun_bundle_pool
-                .block_pool(payload_config.parent_header.number + 1),
-            args: self.backrun_bundle_args,
-        };
-        OpPayloadBuilderCtx {
+    ) -> OpPayloadJobCtx {
+        let backrun_pool = self
+            .builder_ctx
+            .backrun_bundle_pool
+            .block_pool(payload_config.parent_header.number + 1);
+        OpPayloadJobCtx {
+            builder_ctx: self.builder_ctx,
             evm_factory,
-            da_config: self.da_config,
-            gas_limit_config: OpGasLimitConfig::default(),
-            chain_spec: self.chain_spec,
             config: payload_config,
             block_env_attributes,
             cancel,
-            metrics: self.metrics,
-            max_gas_per_txn: self.max_gas_per_txn,
-            max_uncompressed_block_size: self.max_uncompressed_block_size,
-            address_gas_limiter: AddressGasLimiter::new(GasLimiterArgs::default()),
-            backrun_ctx,
-            exclude_reverts_between_flashblocks: self.exclude_reverts_between_flashblocks,
-            enable_tx_tracking_debug_logs: self.enable_tx_tracking_debug_logs,
-            disable_state_root: false,
-            enable_incremental_state_root: false,
+            backrun_pool,
         }
     }
 }

--- a/crates/op-rbuilder/src/flashtestations/builder_tx.rs
+++ b/crates/op-rbuilder/src/flashtestations/builder_tx.rs
@@ -16,7 +16,7 @@ use tracing::{debug, info, warn};
 
 use crate::{
     builder::{
-        BuilderTransactionCtx, BuilderTransactionError, BuilderTransactions, OpPayloadBuilderCtx,
+        BuilderTransactionCtx, BuilderTransactionError, BuilderTransactions, OpPayloadJobCtx,
         SimulationSuccessResult, get_nonce,
     },
     flashtestations::{
@@ -117,7 +117,7 @@ impl FlashtestationsBuilderTx {
     fn set_registered(
         &self,
         state_provider: impl StateProvider + Clone,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
     ) -> Result<(), BuilderTransactionError> {
         let mut simulation_state = State::builder()
             .with_database(StateProviderDatabase::new(state_provider))
@@ -143,7 +143,7 @@ impl FlashtestationsBuilderTx {
     fn get_permit_nonce(
         &self,
         contract_address: Address,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<U256, BuilderTransactionError> {
         let calldata = IERC20Permit::noncesCall {
@@ -157,7 +157,7 @@ impl FlashtestationsBuilderTx {
     fn registration_permit_signature(
         &self,
         permit_nonce: U256,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<Signature, BuilderTransactionError> {
         let struct_hash_calldata = IFlashtestationRegistry::computeStructHashCall {
@@ -186,7 +186,7 @@ impl FlashtestationsBuilderTx {
 
     fn signed_registration_permit_tx(
         &self,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         evm: &mut OpEvm<&mut State<impl Database + DatabaseRef>, NoOpInspector, PrecompilesMap>,
     ) -> Result<BuilderTransactionCtx, BuilderTransactionError> {
         let permit_nonce = self.get_permit_nonce(self.registry_address, ctx, evm)?;
@@ -233,7 +233,7 @@ impl FlashtestationsBuilderTx {
         &self,
         permit_nonce: U256,
         block_content_hash: B256,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<Signature, BuilderTransactionError> {
         let struct_hash_calldata = IBlockBuilderPolicy::computeStructHashCall {
@@ -262,7 +262,7 @@ impl FlashtestationsBuilderTx {
     fn signed_block_proof_permit_tx(
         &self,
         transactions: &[OpTransactionSigned],
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<BuilderTransactionCtx, BuilderTransactionError> {
         let permit_nonce = self.get_permit_nonce(self.builder_policy_address, ctx, evm)?;
@@ -309,7 +309,7 @@ impl FlashtestationsBuilderTx {
         &self,
         contract_address: Address,
         calldata: T,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<SimulationSuccessResult<T>, BuilderTransactionError> {
         self.flashtestations_call(contract_address, calldata, vec![], ctx, evm)
@@ -320,7 +320,7 @@ impl FlashtestationsBuilderTx {
         contract_address: Address,
         calldata: T,
         expected_topics: Vec<B256>,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<SimulationSuccessResult<T>, BuilderTransactionError> {
         let tx_req = OpTransactionRequest::default()
@@ -355,7 +355,7 @@ impl BuilderTransactions for FlashtestationsBuilderTx {
         &self,
         state_provider: impl StateProvider + Clone,
         info: &mut ExecutionInfo,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &OpPayloadJobCtx,
         db: &mut State<impl Database + DatabaseRef>,
         _top_of_block: bool,
         _is_first_flashblock: bool,


### PR DESCRIPTION
## Summary
- Split `OpPayloadBuilderCtx` into a builder-lifetime `OpPayloadBuilderCtx` (shared via `Arc`) and a per-job `OpPayloadJobCtx`. Previously every FCU cloned ~14 static fields into a fresh per-job struct.
- `OpPayloadJobCtx` derefs to `OpPayloadBuilderCtx`, so existing field access (`ctx.chain_spec`, `ctx.metrics`, etc.) keeps working unchanged.
- `OpPayloadSyncerCtx` is reduced to a thin wrapper around the same shared `Arc`, so syncer and builder paths share one source of truth for static config.

## Test plan
- [x] `cargo check -p op-rbuilder --lib` clean
- [x] `cargo test -p op-rbuilder --lib builder::` 37/37 pass