### PR TITLE
fix: add back schedule times to log

### DIFF
--- a/crates/op-rbuilder/src/builder/payload.rs
+++ b/crates/op-rbuilder/src/builder/payload.rs
@@ -592,6 +592,7 @@ where
             target: "payload_builder",
             id = %fb_payload.payload_id,
             target_flashblocks,
+            schedule = ?flashblock_scheduler,
             "Computed flashblock timing schedule"
         );
 


### PR DESCRIPTION
this log is very useful, let's keep it (regression from https://github.com/flashbots/op-rbuilder/pull/470)