### PR TITLE
refactor: extract receipt and hardforks code

### DIFF
--- a/crates/op-rbuilder/src/builder/builder_tx.rs
+++ b/crates/op-rbuilder/src/builder/builder_tx.rs
@@ -1,19 +1,19 @@
-use alloy_consensus::{Eip658Value, TxEip1559};
+use alloy_consensus::TxEip1559;
 use alloy_eips::{Encodable2718, eip7623::TOTAL_COST_FLOOR_PER_TOKEN};
 use alloy_evm::{Database, rpc::TryIntoTxEnv};
-use alloy_op_evm::{OpEvm, block::receipt_builder::OpReceiptBuilder};
+use alloy_op_evm::OpEvm;
 use alloy_primitives::{Address, B256, BlockHash, Bytes, TxKind, U256, map::HashSet};
 use alloy_sol_types::{ContractError, Revert, SolCall, SolError, SolInterface};
 use core::fmt::Debug;
-use op_alloy_consensus::{OpDepositReceipt, OpTxType, OpTypedTransaction};
+use op_alloy_consensus::OpTypedTransaction;
 use op_alloy_rpc_types::OpTransactionRequest;
 use op_revm::{OpHaltReason, OpTransactionError};
 use reth_evm::{
-    ConfigureEvm, Evm, EvmError, InvalidTxError, eth::receipt_builder::ReceiptBuilderCtx,
+    Evm, EvmError, InvalidTxError, eth::receipt_builder::ReceiptBuilderCtx,
     precompiles::PrecompilesMap,
 };
 use reth_node_api::PayloadBuilderError;
-use reth_optimism_primitives::{OpReceipt, OpTransactionSigned};
+use reth_optimism_primitives::OpTransactionSigned;
 use reth_primitives_traits::Recovered;
 use reth_provider::{ProviderError, StateProvider};
 use reth_revm::{State, database::StateProviderDatabase};
@@ -26,8 +26,8 @@ use revm::{
 use tracing::{error, trace, warn};
 
 use crate::{
-    evm::OpBlockEvmFactory, hardforks::ActiveHardforks, primitives::reth::ExecutionInfo,
-    tx_signer::Signer,
+    builder::receipt::build_receipt, evm::OpBlockEvmFactory, hardforks::ActiveHardforks,
+    primitives::reth::ExecutionInfo, tx_signer::Signer,
 };
 
 #[derive(Debug, Default)]
@@ -150,33 +150,6 @@ pub struct BuilderTxEnv<'a> {
 impl BuilderTxEnv<'_> {
     pub fn chain_id(&self) -> u64 {
         self.hardforks.chain_id()
-    }
-
-    pub fn build_receipt<E: Evm>(
-        &self,
-        ctx: ReceiptBuilderCtx<'_, OpTxType, E>,
-        deposit_nonce: Option<u64>,
-    ) -> OpReceipt {
-        let receipt_builder = self
-            .evm_factory
-            .evm_config()
-            .block_executor_factory()
-            .receipt_builder();
-        match receipt_builder.build_receipt(ctx) {
-            Ok(receipt) => receipt,
-            Err(ctx) => {
-                let receipt = alloy_consensus::Receipt {
-                    status: Eip658Value::Eip658(ctx.result.is_success()),
-                    cumulative_gas_used: ctx.cumulative_gas_used,
-                    logs: ctx.result.into_logs(),
-                };
-                receipt_builder.build_deposit_receipt(OpDepositReceipt {
-                    inner: receipt,
-                    deposit_nonce,
-                    deposit_receipt_version: self.hardforks.is_canyon_active().then_some(1),
-                })
-            }
-        }
     }
 }
 
@@ -325,15 +298,19 @@ pub trait BuilderTransactions {
             info.cumulative_da_bytes_used += builder_tx.da_size;
             info.cumulative_uncompressed_bytes += tx_uncompressed_size;
 
-            let receipt_builder_ctx = ReceiptBuilderCtx {
+            let receipt_ctx = ReceiptBuilderCtx {
                 tx_type: builder_tx.signed_tx.inner().tx_type(),
                 evm: &evm,
                 result,
                 state: &state,
                 cumulative_gas_used: info.cumulative_gas_used,
             };
-            info.receipts
-                .push(ctx.build_receipt(receipt_builder_ctx, None));
+            info.receipts.push(build_receipt(
+                ctx.evm_factory,
+                ctx.hardforks,
+                receipt_ctx,
+                None,
+            ));
 
             // Commit changes
             evm.db_mut().commit(state);

--- a/crates/op-rbuilder/src/builder/builder_tx.rs
+++ b/crates/op-rbuilder/src/builder/builder_tx.rs
@@ -1,19 +1,19 @@
-use alloy_consensus::TxEip1559;
+use alloy_consensus::{Eip658Value, TxEip1559};
 use alloy_eips::{Encodable2718, eip7623::TOTAL_COST_FLOOR_PER_TOKEN};
 use alloy_evm::{Database, rpc::TryIntoTxEnv};
-use alloy_op_evm::OpEvm;
-use alloy_primitives::{Address, B256, Bytes, TxKind, U256, map::HashSet};
+use alloy_op_evm::{OpEvm, block::receipt_builder::OpReceiptBuilder};
+use alloy_primitives::{Address, B256, BlockHash, Bytes, TxKind, U256, map::HashSet};
 use alloy_sol_types::{ContractError, Revert, SolCall, SolError, SolInterface};
 use core::fmt::Debug;
-use op_alloy_consensus::OpTypedTransaction;
+use op_alloy_consensus::{OpDepositReceipt, OpTxType, OpTypedTransaction};
 use op_alloy_rpc_types::OpTransactionRequest;
 use op_revm::{OpHaltReason, OpTransactionError};
 use reth_evm::{
-    Evm, EvmError, InvalidTxError, eth::receipt_builder::ReceiptBuilderCtx,
+    ConfigureEvm, Evm, EvmError, InvalidTxError, eth::receipt_builder::ReceiptBuilderCtx,
     precompiles::PrecompilesMap,
 };
 use reth_node_api::PayloadBuilderError;
-use reth_optimism_primitives::OpTransactionSigned;
+use reth_optimism_primitives::{OpReceipt, OpTransactionSigned};
 use reth_primitives_traits::Recovered;
 use reth_provider::{ProviderError, StateProvider};
 use reth_revm::{State, database::StateProviderDatabase};
@@ -26,7 +26,8 @@ use revm::{
 use tracing::{error, trace, warn};
 
 use crate::{
-    builder::context::OpPayloadJobCtx, primitives::reth::ExecutionInfo, tx_signer::Signer,
+    evm::OpBlockEvmFactory, hardforks::ActiveHardforks, primitives::reth::ExecutionInfo,
+    tx_signer::Signer,
 };
 
 #[derive(Debug, Default)]
@@ -134,6 +135,51 @@ impl BuilderTransactionError {
     }
 }
 
+/// Minimal environment needed by [`BuilderTransactions`] so that
+/// builder-transaction code does not depend on the full payload-job context.
+pub struct BuilderTxEnv<'a> {
+    pub evm_factory: &'a OpBlockEvmFactory,
+    pub hardforks: &'a ActiveHardforks,
+    pub base_fee: u64,
+    pub block_number: u64,
+    pub block_gas_limit: u64,
+    pub parent_hash: BlockHash,
+    pub max_uncompressed_block_size: Option<u64>,
+}
+
+impl BuilderTxEnv<'_> {
+    pub fn chain_id(&self) -> u64 {
+        self.hardforks.chain_id()
+    }
+
+    pub fn build_receipt<E: Evm>(
+        &self,
+        ctx: ReceiptBuilderCtx<'_, OpTxType, E>,
+        deposit_nonce: Option<u64>,
+    ) -> OpReceipt {
+        let receipt_builder = self
+            .evm_factory
+            .evm_config()
+            .block_executor_factory()
+            .receipt_builder();
+        match receipt_builder.build_receipt(ctx) {
+            Ok(receipt) => receipt,
+            Err(ctx) => {
+                let receipt = alloy_consensus::Receipt {
+                    status: Eip658Value::Eip658(ctx.result.is_success()),
+                    cumulative_gas_used: ctx.cumulative_gas_used,
+                    logs: ctx.result.into_logs(),
+                };
+                receipt_builder.build_deposit_receipt(OpDepositReceipt {
+                    inner: receipt,
+                    deposit_nonce,
+                    deposit_receipt_version: self.hardforks.is_canyon_active().then_some(1),
+                })
+            }
+        }
+    }
+}
+
 pub trait BuilderTransactions {
     // Simulates and returns the signed builder transactions. The simulation modifies and commit
     // changes to the db so call new_simulation_state to simulate on a new copy of the state
@@ -142,7 +188,7 @@ pub trait BuilderTransactions {
         &self,
         state_provider: impl StateProvider + Clone,
         info: &mut ExecutionInfo,
-        ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
         db: &mut State<impl Database + DatabaseRef>,
         top_of_block: bool,
         is_first_flashblock: bool,
@@ -154,7 +200,7 @@ pub trait BuilderTransactions {
         &self,
         state_provider: impl StateProvider + Clone,
         info: &mut ExecutionInfo,
-        ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
         db: &State<impl Database>,
         top_of_block: bool,
         is_first_flashblock: bool,
@@ -177,7 +223,7 @@ pub trait BuilderTransactions {
         &self,
         state_provider: impl StateProvider + Clone,
         info: &mut ExecutionInfo,
-        builder_ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
         db: &mut State<impl Database>,
         top_of_block: bool,
         is_first_flashblock: bool,
@@ -186,14 +232,14 @@ pub trait BuilderTransactions {
         let builder_txs = self.simulate_builder_txs_with_state_copy(
             state_provider,
             info,
-            builder_ctx,
+            ctx,
             db,
             top_of_block,
             is_first_flashblock,
             is_last_flashblock,
         )?;
 
-        let mut evm = builder_ctx.evm_factory.evm(&mut *db);
+        let mut evm = ctx.evm_factory.evm(&mut *db);
 
         let mut invalid = HashSet::new();
 
@@ -259,7 +305,7 @@ pub trait BuilderTransactions {
             // Skip the builder tx if including it would push the cumulative
             // uncompressed block size over the configured limit. The state
             // changes from the simulation are dropped (we never call commit).
-            if let Some(limit) = builder_ctx.max_uncompressed_block_size
+            if let Some(limit) = ctx.max_uncompressed_block_size
                 && info.cumulative_uncompressed_bytes + tx_uncompressed_size > limit
             {
                 warn!(
@@ -279,14 +325,15 @@ pub trait BuilderTransactions {
             info.cumulative_da_bytes_used += builder_tx.da_size;
             info.cumulative_uncompressed_bytes += tx_uncompressed_size;
 
-            let ctx = ReceiptBuilderCtx {
+            let receipt_builder_ctx = ReceiptBuilderCtx {
                 tx_type: builder_tx.signed_tx.inner().tx_type(),
                 evm: &evm,
                 result,
                 state: &state,
                 cumulative_gas_used: info.cumulative_gas_used,
             };
-            info.receipts.push(builder_ctx.build_receipt(ctx, None));
+            info.receipts
+                .push(ctx.build_receipt(receipt_builder_ctx, None));
 
             // Commit changes
             evm.db_mut().commit(state);
@@ -321,7 +368,7 @@ pub trait BuilderTransactions {
         from: Signer,
         gas_used: u64,
         calldata: Bytes,
-        ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
         db: impl DatabaseRef,
     ) -> Result<Recovered<OpTransactionSigned>, BuilderTransactionError> {
         let nonce = get_nonce(db, from.address)?;
@@ -331,7 +378,7 @@ pub trait BuilderTransactions {
             nonce,
             // Due to EIP-150, 63/64 of available gas is forwarded to external calls so need to add a buffer
             gas_limit: gas_used * 64 / 63,
-            max_fee_per_gas: ctx.base_fee().into(),
+            max_fee_per_gas: ctx.base_fee.into(),
             to: TxKind::Call(to),
             input: calldata,
             ..Default::default()
@@ -342,7 +389,7 @@ pub trait BuilderTransactions {
     fn commit_txs(
         &self,
         signed_txs: Vec<Recovered<OpTransactionSigned>>,
-        ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
         db: &mut State<impl Database>,
     ) -> Result<(), BuilderTransactionError> {
         let mut evm = ctx.evm_factory.evm(&mut *db);
@@ -441,12 +488,12 @@ impl BuilderTxBase {
 
     pub(super) fn simulate_builder_tx(
         &self,
-        ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
         db: impl DatabaseRef,
     ) -> Result<Option<BuilderTransactionCtx>, BuilderTransactionError> {
         match self.signer {
             Some(signer) => {
-                let message: Vec<u8> = format!("Block Number: {}", ctx.block_number()).into_bytes();
+                let message: Vec<u8> = format!("Block Number: {}", ctx.block_number).into_bytes();
                 let gas_used = self.estimate_builder_tx_gas(&message);
                 let signed_tx = self.signed_builder_tx(ctx, db, signer, gas_used, message)?;
                 let da_size = op_alloy_flz::tx_estimated_size_fjord_bytes(
@@ -486,7 +533,7 @@ impl BuilderTxBase {
 
     fn signed_builder_tx(
         &self,
-        ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
         db: impl DatabaseRef,
         signer: Signer,
         gas_used: u64,
@@ -499,7 +546,7 @@ impl BuilderTxBase {
             chain_id: ctx.chain_id(),
             nonce,
             gas_limit: gas_used,
-            max_fee_per_gas: ctx.base_fee().into(),
+            max_fee_per_gas: ctx.base_fee.into(),
             max_priority_fee_per_gas: 0,
             to: TxKind::Call(Address::ZERO),
             // Include the message as part of the transaction data

--- a/crates/op-rbuilder/src/builder/context.rs
+++ b/crates/op-rbuilder/src/builder/context.rs
@@ -1,16 +1,12 @@
-use alloy_consensus::{Eip658Value, Transaction, conditional::BlockConditionalAttributes};
+use alloy_consensus::{Transaction, conditional::BlockConditionalAttributes};
 use alloy_eips::{Encodable2718, Typed2718};
 use alloy_evm::Database;
-use alloy_op_evm::block::receipt_builder::OpReceiptBuilder;
 use alloy_primitives::{B256, BlockHash, Bytes, U256};
 use alloy_rpc_types_eth::Withdrawals;
-use op_alloy_consensus::{OpDepositReceipt, OpTxType};
 use op_revm::L1BlockInfo;
 use reth_basic_payload_builder::PayloadConfig;
 use reth_chainspec::EthChainSpec;
-use reth_evm::{
-    ConfigureEvm, Evm, EvmError, InvalidTxError, eth::receipt_builder::ReceiptBuilderCtx,
-};
+use reth_evm::{Evm, EvmError, InvalidTxError, eth::receipt_builder::ReceiptBuilderCtx};
 use reth_node_api::PayloadBuilderError;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
@@ -20,7 +16,7 @@ use reth_optimism_payload_builder::{
     config::{OpDAConfig, OpGasLimitConfig},
     error::OpPayloadBuilderError,
 };
-use reth_optimism_primitives::{OpReceipt, OpTransactionSigned};
+use reth_optimism_primitives::OpTransactionSigned;
 use reth_optimism_txpool::{
     conditional::MaybeConditionalTransaction, estimated_da_size::DataAvailabilitySized,
 };
@@ -38,7 +34,7 @@ use tracing::{debug, info, trace};
 
 use crate::{
     backrun_bundle::{BackrunBundleArgs, BackrunBundleGlobalPool, BackrunBundlePayloadPool},
-    builder::builder_tx::BuilderTxEnv,
+    builder::{builder_tx::BuilderTxEnv, receipt::build_receipt},
     evm::OpBlockEvmFactory,
     gas_limiter::AddressGasLimiter,
     hardforks::ActiveHardforks,
@@ -246,42 +242,6 @@ impl OpPayloadJobCtx {
         self.attributes().payload_id()
     }
 
-    /// Constructs a receipt for the given transaction.
-    pub fn build_receipt<E: Evm>(
-        &self,
-        ctx: ReceiptBuilderCtx<'_, OpTxType, E>,
-        deposit_nonce: Option<u64>,
-    ) -> OpReceipt {
-        let receipt_builder = self
-            .evm_factory
-            .evm_config()
-            .block_executor_factory()
-            .receipt_builder();
-        match receipt_builder.build_receipt(ctx) {
-            Ok(receipt) => receipt,
-            Err(ctx) => {
-                let receipt = alloy_consensus::Receipt {
-                    // Success flag was added in `EIP-658: Embedding transaction status code
-                    // in receipts`.
-                    status: Eip658Value::Eip658(ctx.result.is_success()),
-                    cumulative_gas_used: ctx.cumulative_gas_used,
-                    logs: ctx.result.into_logs(),
-                };
-
-                receipt_builder.build_deposit_receipt(OpDepositReceipt {
-                    inner: receipt,
-                    deposit_nonce,
-                    // The deposit receipt version was introduced in Canyon to indicate an
-                    // update to how receipt hashes should be computed
-                    // when set. The state transition process ensures
-                    // this is only set for post-Canyon deposit
-                    // transactions.
-                    deposit_receipt_version: self.hardforks.is_canyon_active().then_some(1),
-                })
-            }
-        }
-    }
-
     /// Executes all sequencer transactions that are included in the payload attributes.
     pub(super) fn execute_sequencer_transactions(
         &self,
@@ -357,7 +317,7 @@ impl OpPayloadJobCtx {
             }
             info.cumulative_uncompressed_bytes += sequencer_tx.encode_2718_len() as u64;
 
-            let ctx = ReceiptBuilderCtx {
+            let receipt_ctx = ReceiptBuilderCtx {
                 tx_type: sequencer_tx.tx_type(),
                 evm: &evm,
                 result,
@@ -365,7 +325,12 @@ impl OpPayloadJobCtx {
                 cumulative_gas_used: info.cumulative_gas_used,
             };
 
-            info.receipts.push(self.build_receipt(ctx, depositor_nonce));
+            info.receipts.push(build_receipt(
+                &self.evm_factory,
+                &self.hardforks,
+                receipt_ctx,
+                depositor_nonce,
+            ));
 
             // commit changes
             evm.db_mut().commit(state);
@@ -650,14 +615,19 @@ impl OpPayloadJobCtx {
             let tx_succeeded = result.is_success();
 
             // Push transaction changeset and calculate header bloom filter for receipt.
-            let ctx = ReceiptBuilderCtx {
+            let receipt_ctx = ReceiptBuilderCtx {
                 tx_type: tx.tx_type(),
                 evm: &evm,
                 result,
                 state: &state,
                 cumulative_gas_used: info.cumulative_gas_used,
             };
-            info.receipts.push(self.build_receipt(ctx, None));
+            info.receipts.push(build_receipt(
+                &self.evm_factory,
+                &self.hardforks,
+                receipt_ctx,
+                None,
+            ));
 
             // commit changes
             evm.db_mut().commit(state);
@@ -904,14 +874,19 @@ impl OpPayloadJobCtx {
                     info.cumulative_da_bytes_used += br_tx_da_size;
                     info.cumulative_uncompressed_bytes += br_tx_uncompressed_size;
 
-                    let br_ctx = ReceiptBuilderCtx {
+                    let receipt_ctx = ReceiptBuilderCtx {
                         tx_type: bundle.backrun_tx.tx_type(),
                         evm: &evm,
                         result: br_result,
                         state: &br_state,
                         cumulative_gas_used: info.cumulative_gas_used,
                     };
-                    info.receipts.push(self.build_receipt(br_ctx, None));
+                    info.receipts.push(build_receipt(
+                        &self.evm_factory,
+                        &self.hardforks,
+                        receipt_ctx,
+                        None,
+                    ));
                     evm.db_mut().commit(br_state);
 
                     info.total_fees += U256::from(backrun_priority_fee) * U256::from(br_gas_used);

--- a/crates/op-rbuilder/src/builder/context.rs
+++ b/crates/op-rbuilder/src/builder/context.rs
@@ -7,7 +7,7 @@ use alloy_rpc_types_eth::Withdrawals;
 use op_alloy_consensus::{OpDepositReceipt, OpTxType};
 use op_revm::L1BlockInfo;
 use reth_basic_payload_builder::PayloadConfig;
-use reth_chainspec::{EthChainSpec, EthereumHardforks};
+use reth_chainspec::EthChainSpec;
 use reth_evm::{
     ConfigureEvm, Evm, EvmError, InvalidTxError, eth::receipt_builder::ReceiptBuilderCtx,
 };
@@ -38,8 +38,10 @@ use tracing::{debug, info, trace};
 
 use crate::{
     backrun_bundle::{BackrunBundleArgs, BackrunBundleGlobalPool, BackrunBundlePayloadPool},
+    builder::builder_tx::BuilderTxEnv,
     evm::OpBlockEvmFactory,
     gas_limiter::AddressGasLimiter,
+    hardforks::ActiveHardforks,
     metrics::OpRBuilderMetrics,
     primitives::reth::{ExecutionInfo, TxnExecutionResult},
     traits::PayloadTxsBounds,
@@ -95,6 +97,8 @@ pub struct OpPayloadJobCtx {
     pub config: PayloadConfig<OpPayloadBuilderAttributes<OpTransactionSigned>>,
     /// Block env attributes for the current block.
     pub block_env_attributes: OpNextBlockEnvAttributes,
+    /// Hardfork activation state for this block's timestamp.
+    pub hardforks: ActiveHardforks,
     /// Marker to check whether the job has been cancelled.
     pub cancel: CancellationToken,
     /// Per-block view into the global backrun bundle pool.
@@ -112,6 +116,18 @@ impl Deref for OpPayloadJobCtx {
 impl OpPayloadJobCtx {
     pub(super) fn with_cancel(self, cancel: CancellationToken) -> Self {
         Self { cancel, ..self }
+    }
+
+    pub fn builder_tx_env(&self) -> BuilderTxEnv<'_> {
+        BuilderTxEnv {
+            evm_factory: &self.evm_factory,
+            hardforks: &self.hardforks,
+            base_fee: self.base_fee(),
+            block_number: self.block_number(),
+            block_gas_limit: self.block_gas_limit(),
+            parent_hash: self.parent_hash(),
+            max_uncompressed_block_size: self.max_uncompressed_block_size,
+        }
     }
 
     /// Returns the parent block the payload will be build on.
@@ -136,8 +152,8 @@ impl OpPayloadJobCtx {
 
     /// Returns the withdrawals if shanghai is active.
     pub fn withdrawals(&self) -> Option<&Withdrawals> {
-        self.chain_spec
-            .is_shanghai_active_at_timestamp(self.attributes().timestamp())
+        self.hardforks
+            .is_shanghai_active()
             .then(|| &self.attributes().payload_attributes.withdrawals)
     }
 
@@ -182,13 +198,13 @@ impl OpPayloadJobCtx {
             return blob_fields;
         }
         // Compute from execution info
-        if self.is_jovian_active() {
+        if self.hardforks.is_jovian_active() {
             let scalar = info
                 .da_footprint_scalar
                 .expect("Scalar must be defined for Jovian blocks");
             let result = info.cumulative_da_bytes_used * scalar as u64;
             (Some(0), Some(result))
-        } else if self.is_ecotone_active() {
+        } else if self.hardforks.is_ecotone_active() {
             (Some(0), Some(0))
         } else {
             (None, None)
@@ -199,7 +215,7 @@ impl OpPayloadJobCtx {
     ///
     /// After holocene this extracts the extradata from the payload
     pub fn extra_data(&self) -> Result<Bytes, PayloadBuilderError> {
-        if self.is_jovian_active() {
+        if self.hardforks.is_jovian_active() {
             self.attributes()
                 .get_jovian_extra_data(
                     self.chain_spec.base_fee_params_at_timestamp(
@@ -207,7 +223,7 @@ impl OpPayloadJobCtx {
                     ),
                 )
                 .map_err(PayloadBuilderError::other)
-        } else if self.is_holocene_active() {
+        } else if self.hardforks.is_holocene_active() {
             self.attributes()
                 .get_holocene_extra_data(
                     self.chain_spec.base_fee_params_at_timestamp(
@@ -228,47 +244,6 @@ impl OpPayloadJobCtx {
     /// Returns the unique id for this payload job.
     pub fn payload_id(&self) -> PayloadId {
         self.attributes().payload_id()
-    }
-
-    /// Returns true if regolith is active for the payload.
-    pub fn is_regolith_active(&self) -> bool {
-        self.chain_spec
-            .is_regolith_active_at_timestamp(self.attributes().timestamp())
-    }
-
-    /// Returns true if ecotone is active for the payload.
-    pub fn is_ecotone_active(&self) -> bool {
-        self.chain_spec
-            .is_ecotone_active_at_timestamp(self.attributes().timestamp())
-    }
-
-    /// Returns true if canyon is active for the payload.
-    pub fn is_canyon_active(&self) -> bool {
-        self.chain_spec
-            .is_canyon_active_at_timestamp(self.attributes().timestamp())
-    }
-
-    /// Returns true if holocene is active for the payload.
-    pub fn is_holocene_active(&self) -> bool {
-        self.chain_spec
-            .is_holocene_active_at_timestamp(self.attributes().timestamp())
-    }
-
-    /// Returns true if isthmus is active for the payload.
-    pub fn is_isthmus_active(&self) -> bool {
-        self.chain_spec
-            .is_isthmus_active_at_timestamp(self.attributes().timestamp())
-    }
-
-    /// Returns true if isthmus is active for the payload.
-    pub fn is_jovian_active(&self) -> bool {
-        self.chain_spec
-            .is_jovian_active_at_timestamp(self.attributes().timestamp())
-    }
-
-    /// Returns the chain id
-    pub fn chain_id(&self) -> u64 {
-        self.chain_spec.chain_id()
     }
 
     /// Constructs a receipt for the given transaction.
@@ -301,7 +276,7 @@ impl OpPayloadJobCtx {
                     // when set. The state transition process ensures
                     // this is only set for post-Canyon deposit
                     // transactions.
-                    deposit_receipt_version: self.is_canyon_active().then_some(1),
+                    deposit_receipt_version: self.hardforks.is_canyon_active().then_some(1),
                 })
             }
         }
@@ -340,18 +315,19 @@ impl OpPayloadJobCtx {
             // Note that this *only* needs to be done post-regolith hardfork, as deposit nonces
             // were not introduced in Bedrock. In addition, regular transactions don't have deposit
             // nonces, so we don't need to touch the DB for those.
-            let depositor_nonce = (self.is_regolith_active() && sequencer_tx.is_deposit())
-                .then(|| {
-                    evm.db_mut()
-                        .load_cache_account(sequencer_tx.signer())
-                        .map(|acc| acc.account_info().unwrap_or_default().nonce)
-                })
-                .transpose()
-                .map_err(|_| {
-                    PayloadBuilderError::other(OpPayloadBuilderError::AccountLoadFailed(
-                        sequencer_tx.signer(),
-                    ))
-                })?;
+            let depositor_nonce = (self.hardforks.is_regolith_active()
+                && sequencer_tx.is_deposit())
+            .then(|| {
+                evm.db_mut()
+                    .load_cache_account(sequencer_tx.signer())
+                    .map(|acc| acc.account_info().unwrap_or_default().nonce)
+            })
+            .transpose()
+            .map_err(|_| {
+                PayloadBuilderError::other(OpPayloadBuilderError::AccountLoadFailed(
+                    sequencer_tx.signer(),
+                ))
+            })?;
 
             let ResultAndState { result, state } = match evm.transact(&sequencer_tx) {
                 Ok(res) => res,

--- a/crates/op-rbuilder/src/builder/flashblocks_builder_tx.rs
+++ b/crates/op-rbuilder/src/builder/flashblocks_builder_tx.rs
@@ -15,7 +15,9 @@ use tracing::warn;
 use crate::{
     builder::{
         BuilderTransactionCtx, BuilderTransactionError, BuilderTransactions,
-        SimulationSuccessResult, builder_tx::BuilderTxBase, context::OpPayloadJobCtx, get_nonce,
+        SimulationSuccessResult,
+        builder_tx::{BuilderTxBase, BuilderTxEnv},
+        get_nonce,
     },
     flashtestations::builder_tx::FlashtestationsBuilderTx,
     primitives::reth::ExecutionInfo,
@@ -75,7 +77,7 @@ impl BuilderTransactions for FlashblocksBuilderTx {
         &self,
         state_provider: impl StateProvider + Clone,
         info: &mut ExecutionInfo,
-        ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
         db: &mut State<impl Database + DatabaseRef>,
         top_of_block: bool,
         is_first_flashblock: bool,
@@ -153,7 +155,7 @@ impl FlashblocksNumberBuilderTx {
 
     fn signed_increment_flashblocks_tx(
         &self,
-        ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<BuilderTransactionCtx, BuilderTransactionError> {
         let calldata = IFlashblockNumber::incrementFlashblockNumberCall {};
@@ -164,7 +166,7 @@ impl FlashblocksNumberBuilderTx {
         &self,
         flashtestations_signer: &Signer,
         current_flashblock_number: U256,
-        ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<Signature, BuilderTransactionError> {
         let struct_hash_calldata = IFlashblockNumber::computeStructHashCall {
@@ -183,7 +185,7 @@ impl FlashblocksNumberBuilderTx {
     fn signed_increment_flashblocks_permit_tx(
         &self,
         flashtestations_signer: &Signer,
-        ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<BuilderTransactionCtx, BuilderTransactionError> {
         let current_flashblock_calldata = IFlashblockNumber::flashblockNumberCall {};
@@ -201,7 +203,7 @@ impl FlashblocksNumberBuilderTx {
     fn increment_flashblocks_tx<T: SolCall + Clone>(
         &self,
         calldata: T,
-        ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<BuilderTransactionCtx, BuilderTransactionError> {
         let SimulationSuccessResult { gas_used, .. } = self.simulate_flashblocks_call(
@@ -231,7 +233,7 @@ impl FlashblocksNumberBuilderTx {
     fn simulate_flashblocks_readonly_call<T: SolCall>(
         &self,
         calldata: T,
-        ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<SimulationSuccessResult<T>, BuilderTransactionError> {
         self.simulate_flashblocks_call(calldata, vec![], ctx, evm)
@@ -241,12 +243,12 @@ impl FlashblocksNumberBuilderTx {
         &self,
         calldata: T,
         expected_logs: Vec<B256>,
-        ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<SimulationSuccessResult<T>, BuilderTransactionError> {
         let tx_req = OpTransactionRequest::default()
-            .gas_limit(ctx.block_gas_limit())
-            .max_fee_per_gas(ctx.base_fee().into())
+            .gas_limit(ctx.block_gas_limit)
+            .max_fee_per_gas(ctx.base_fee.into())
             .to(self.flashblock_number_address)
             .from(self.signer.address) // use tee key as signer for simulations
             .nonce(get_nonce(evm.db(), self.signer.address)?)
@@ -264,7 +266,7 @@ impl BuilderTransactions for FlashblocksNumberBuilderTx {
         &self,
         state_provider: impl StateProvider + Clone,
         info: &mut ExecutionInfo,
-        ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
         db: &mut State<impl Database + DatabaseRef>,
         top_of_block: bool,
         is_first_flashblock: bool,

--- a/crates/op-rbuilder/src/builder/mod.rs
+++ b/crates/op-rbuilder/src/builder/mod.rs
@@ -26,8 +26,8 @@ mod timing;
 mod wspub;
 
 pub use builder_tx::{
-    BuilderTransactionCtx, BuilderTransactionError, BuilderTransactions, InvalidContractDataError,
-    SimulationSuccessResult, get_balance, get_nonce,
+    BuilderTransactionCtx, BuilderTransactionError, BuilderTransactions, BuilderTxEnv,
+    InvalidContractDataError, SimulationSuccessResult, get_balance, get_nonce,
 };
 pub use config::FlashblocksConfig;
 pub use context::OpPayloadJobCtx;

--- a/crates/op-rbuilder/src/builder/mod.rs
+++ b/crates/op-rbuilder/src/builder/mod.rs
@@ -19,6 +19,7 @@ mod generator;
 mod p2p;
 mod payload;
 mod payload_handler;
+mod receipt;
 mod service;
 mod state_root;
 mod syncer_ctx;

--- a/crates/op-rbuilder/src/builder/payload.rs
+++ b/crates/op-rbuilder/src/builder/payload.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     evm::OpBlockEvmFactory,
     gas_limiter::AddressGasLimiter,
+    hardforks::ActiveHardforks,
     metrics::{OpRBuilderMetrics, record_flashblock_publish_timing},
     primitives::reth::ExecutionInfo,
     runtime_ext::RuntimeExt,
@@ -375,7 +376,7 @@ where
     Client: ClientBounds + 'static,
     BuilderTx: BuilderTransactions + Send + Sync + 'static,
 {
-    fn get_op_payload_builder_ctx(
+    fn get_op_payload_job_ctx(
         &self,
         config: reth_basic_payload_builder::PayloadConfig<
             OpPayloadBuilderAttributes<op_alloy_consensus::OpTxEnvelope>,
@@ -439,11 +440,14 @@ where
             .backrun_bundle_pool
             .block_pool(config.parent_header.number + 1);
 
+        let hardforks = ActiveHardforks::new(Arc::clone(&builder_ctx.chain_spec), timestamp);
+
         Ok(OpPayloadJobCtx {
             builder_ctx: Arc::clone(builder_ctx),
             evm_factory,
             config,
             block_env_attributes,
+            hardforks,
             cancel,
             backrun_pool,
         })
@@ -478,7 +482,7 @@ where
         );
 
         let ctx = self
-            .get_op_payload_builder_ctx(config.clone(), payload_cancel.token())
+            .get_op_payload_job_ctx(config.clone(), payload_cancel.token())
             .map_err(|e| PayloadBuilderError::Other(e.into()))?;
 
         // Initialize flashblocks state for this block
@@ -657,7 +661,7 @@ where
 
         let fb_cancel = payload_cancel.child_token();
         let mut ctx = self
-            .get_op_payload_builder_ctx(config, fb_cancel.clone())
+            .get_op_payload_job_ctx(config, fb_cancel.clone())
             .map_err(|e| PayloadBuilderError::Other(e.into()))?;
 
         let (tx, mut rx) = mpsc::channel((expected_flashblocks + 1) as usize);
@@ -888,7 +892,7 @@ where
             && let Err(e) = self.builder_tx.add_builder_txs(
                 &state_provider,
                 &mut info,
-                &ctx,
+                &ctx.builder_tx_env(),
                 &mut state,
                 false,
                 fb_state.is_first_flashblock(),
@@ -964,7 +968,7 @@ where
             .add_builder_txs(
                 &state_provider,
                 info,
-                ctx,
+                &ctx.builder_tx_env(),
                 state,
                 true,
                 fb_state.is_first_flashblock(),
@@ -1045,7 +1049,7 @@ where
         if let Err(e) = self.builder_tx.add_builder_txs(
             &state_provider,
             info,
-            ctx,
+            &ctx.builder_tx_env(),
             state,
             false,
             fb_state.is_first_flashblock(),

--- a/crates/op-rbuilder/src/builder/payload_handler.rs
+++ b/crates/op-rbuilder/src/builder/payload_handler.rs
@@ -1,13 +1,15 @@
 use crate::{
-    builder::{p2p::Message, payload::build_block, syncer_ctx::OpPayloadSyncerCtx},
+    builder::{
+        p2p::Message, payload::build_block, receipt::build_receipt, syncer_ctx::OpPayloadSyncerCtx,
+    },
     evm::OpBlockEvmFactory,
+    hardforks::ActiveHardforks,
     primitives::reth::ExecutionInfo,
     traits::ClientBounds,
 };
 use alloy_evm::eth::receipt_builder::ReceiptBuilderCtx;
 use alloy_primitives::B64;
 use eyre::{WrapErr as _, bail};
-use op_alloy_consensus::OpTxType;
 use op_alloy_rpc_types_engine::OpFlashblockPayload;
 use op_revm::L1BlockInfo;
 use reth::revm::{State, database::StateProviderDatabase};
@@ -19,7 +21,6 @@ use reth_optimism_evm::OpNextBlockEnvAttributes;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_node::{OpEngineTypes, OpPayloadBuilderAttributes};
 use reth_optimism_payload_builder::OpBuiltPayload;
-use reth_optimism_primitives::OpReceipt;
 use reth_payload_builder::EthPayloadBuilderAttributes;
 use reth_primitives_traits::SealedHeader;
 use reth_tasks::Runtime;
@@ -318,7 +319,7 @@ where
 
     let enable_tx_tracking_debug_logs = ctx.enable_tx_tracking_debug_logs();
     let builder_ctx =
-        ctx.into_op_payload_builder_ctx(payload_config, evm_factory, block_env_attributes, cancel);
+        ctx.into_op_payload_job_ctx(payload_config, evm_factory, block_env_attributes, cancel);
 
     let (built_payload, fb_payload) = build_block(
         &mut state,
@@ -442,12 +443,12 @@ fn execute_transactions(
             cumulative_gas_used: info.cumulative_gas_used,
         };
 
+        let hardforks = ActiveHardforks::new(chain_spec.clone(), timestamp);
         info.receipts.push(build_receipt(
-            ctx,
             evm_factory,
+            &hardforks,
             receipt_ctx,
             depositor_nonce,
-            timestamp,
         ));
 
         evm.db_mut().commit(state);
@@ -467,47 +468,6 @@ fn execute_transactions(
     info.da_footprint_scalar = da_footprint_gas_scalar;
 
     Ok(())
-}
-
-fn build_receipt<E: alloy_evm::Evm>(
-    ctx: &OpPayloadSyncerCtx,
-    evm_factory: &OpBlockEvmFactory,
-    receipt_ctx: ReceiptBuilderCtx<'_, OpTxType, E>,
-    deposit_nonce: Option<u64>,
-    timestamp: u64,
-) -> OpReceipt {
-    use alloy_consensus::Eip658Value;
-    use alloy_op_evm::block::receipt_builder::OpReceiptBuilder as _;
-    use op_alloy_consensus::OpDepositReceipt;
-    use reth_evm::ConfigureEvm as _;
-
-    let receipt_builder = evm_factory
-        .evm_config()
-        .block_executor_factory()
-        .receipt_builder();
-    match receipt_builder.build_receipt(receipt_ctx) {
-        Ok(receipt) => receipt,
-        Err(receipt_ctx) => {
-            let receipt = alloy_consensus::Receipt {
-                // Success flag was added in `EIP-658: Embedding transaction status code
-                // in receipts`.
-                status: Eip658Value::Eip658(receipt_ctx.result.is_success()),
-                cumulative_gas_used: receipt_ctx.cumulative_gas_used,
-                logs: receipt_ctx.result.into_logs(),
-            };
-
-            receipt_builder.build_deposit_receipt(OpDepositReceipt {
-                inner: receipt,
-                deposit_nonce,
-                // The deposit receipt version was introduced in Canyon to indicate an
-                // update to how receipt hashes should be computed
-                // when set. The state transition process ensures
-                // this is only set for post-Canyon deposit
-                // transactions.
-                deposit_receipt_version: ctx.is_canyon_active(timestamp).then_some(1),
-            })
-        }
-    }
 }
 
 /// Validates the payload header and its relationship with the parent before execution.

--- a/crates/op-rbuilder/src/builder/receipt.rs
+++ b/crates/op-rbuilder/src/builder/receipt.rs
@@ -1,0 +1,41 @@
+use alloy_consensus::Eip658Value;
+use alloy_evm::Evm;
+use alloy_op_evm::block::receipt_builder::OpReceiptBuilder;
+use op_alloy_consensus::{OpDepositReceipt, OpReceipt, OpTxType};
+use reth_evm::{ConfigureEvm, eth::receipt_builder::ReceiptBuilderCtx};
+
+use crate::{evm::OpBlockEvmFactory, hardforks::ActiveHardforks};
+
+pub(super) fn build_receipt<E: Evm>(
+    evm_factory: &OpBlockEvmFactory,
+    hardforks: &ActiveHardforks,
+    receipt_ctx: ReceiptBuilderCtx<'_, OpTxType, E>,
+    deposit_nonce: Option<u64>,
+) -> OpReceipt {
+    let receipt_builder = evm_factory
+        .evm_config()
+        .block_executor_factory()
+        .receipt_builder();
+
+    receipt_builder
+        .build_receipt(receipt_ctx)
+        .unwrap_or_else(|receipt_ctx| {
+            let receipt = alloy_consensus::Receipt {
+                // Success flag was added in `EIP-658: Embedding transaction
+                // status code in receipts`.
+                status: Eip658Value::Eip658(receipt_ctx.result.is_success()),
+                cumulative_gas_used: receipt_ctx.cumulative_gas_used,
+                logs: receipt_ctx.result.into_logs(),
+            };
+
+            receipt_builder.build_deposit_receipt(OpDepositReceipt {
+                inner: receipt,
+                deposit_nonce,
+                // The deposit receipt version was introduced in Canyon to
+                // indicate an update to how receipt hashes should be computed
+                // when set. The state transition process ensures this is only
+                // set for post-Canyon deposit transactions.
+                deposit_receipt_version: hardforks.is_canyon_active().then_some(1),
+            })
+        })
+}

--- a/crates/op-rbuilder/src/builder/syncer_ctx.rs
+++ b/crates/op-rbuilder/src/builder/syncer_ctx.rs
@@ -72,14 +72,7 @@ impl OpPayloadSyncerCtx {
             .is_regolith_active_at_timestamp(timestamp)
     }
 
-    /// Returns true if canyon is active for the payload.
-    pub(super) fn is_canyon_active(&self, timestamp: u64) -> bool {
-        self.builder_ctx
-            .chain_spec
-            .is_canyon_active_at_timestamp(timestamp)
-    }
-
-    pub(super) fn into_op_payload_builder_ctx(
+    pub(super) fn into_op_payload_job_ctx(
         self,
         payload_config: PayloadConfig<OpPayloadBuilderAttributes<OpTransactionSigned>>,
         evm_factory: OpBlockEvmFactory,

--- a/crates/op-rbuilder/src/builder/syncer_ctx.rs
+++ b/crates/op-rbuilder/src/builder/syncer_ctx.rs
@@ -2,6 +2,7 @@ use crate::{
     builder::{BuilderConfig, OpPayloadJobCtx, context::OpPayloadBuilderCtx},
     evm::OpBlockEvmFactory,
     gas_limiter::{AddressGasLimiter, args::GasLimiterArgs},
+    hardforks::ActiveHardforks,
     metrics::OpRBuilderMetrics,
     traits::ClientBounds,
 };
@@ -89,11 +90,17 @@ impl OpPayloadSyncerCtx {
             .builder_ctx
             .backrun_bundle_pool
             .block_pool(payload_config.parent_header.number + 1);
+        let hardforks = ActiveHardforks::new(
+            Arc::clone(&self.builder_ctx.chain_spec),
+            block_env_attributes.timestamp,
+        );
+
         OpPayloadJobCtx {
             builder_ctx: self.builder_ctx,
             evm_factory,
             config: payload_config,
             block_env_attributes,
+            hardforks,
             cancel,
             backrun_pool,
         }

--- a/crates/op-rbuilder/src/flashtestations/builder_tx.rs
+++ b/crates/op-rbuilder/src/flashtestations/builder_tx.rs
@@ -16,7 +16,7 @@ use tracing::{debug, info, warn};
 
 use crate::{
     builder::{
-        BuilderTransactionCtx, BuilderTransactionError, BuilderTransactions, OpPayloadJobCtx,
+        BuilderTransactionCtx, BuilderTransactionError, BuilderTransactions, BuilderTxEnv,
         SimulationSuccessResult, get_nonce,
     },
     flashtestations::{
@@ -117,7 +117,7 @@ impl FlashtestationsBuilderTx {
     fn set_registered(
         &self,
         state_provider: impl StateProvider + Clone,
-        ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
     ) -> Result<(), BuilderTransactionError> {
         let mut simulation_state = State::builder()
             .with_database(StateProviderDatabase::new(state_provider))
@@ -143,7 +143,7 @@ impl FlashtestationsBuilderTx {
     fn get_permit_nonce(
         &self,
         contract_address: Address,
-        ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<U256, BuilderTransactionError> {
         let calldata = IERC20Permit::noncesCall {
@@ -157,14 +157,14 @@ impl FlashtestationsBuilderTx {
     fn registration_permit_signature(
         &self,
         permit_nonce: U256,
-        ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<Signature, BuilderTransactionError> {
         let struct_hash_calldata = IFlashtestationRegistry::computeStructHashCall {
             rawQuote: self.attestation.clone().into(),
             extendedRegistrationData: self.extra_registration_data.clone(),
             nonce: permit_nonce,
-            deadline: U256::from(ctx.timestamp()),
+            deadline: U256::from(ctx.hardforks.timestamp),
         };
         let SimulationSuccessResult { output, .. } = self.flashtestations_contract_read(
             self.registry_address,
@@ -186,7 +186,7 @@ impl FlashtestationsBuilderTx {
 
     fn signed_registration_permit_tx(
         &self,
-        ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
         evm: &mut OpEvm<&mut State<impl Database + DatabaseRef>, NoOpInspector, PrecompilesMap>,
     ) -> Result<BuilderTransactionCtx, BuilderTransactionError> {
         let permit_nonce = self.get_permit_nonce(self.registry_address, ctx, evm)?;
@@ -195,7 +195,7 @@ impl FlashtestationsBuilderTx {
             rawQuote: self.attestation.clone().into(),
             extendedRegistrationData: self.extra_registration_data.clone(),
             nonce: permit_nonce,
-            deadline: U256::from(ctx.timestamp()),
+            deadline: U256::from(ctx.hardforks.timestamp),
             signature: signature.as_bytes().into(),
         };
         let SimulationSuccessResult {
@@ -233,7 +233,7 @@ impl FlashtestationsBuilderTx {
         &self,
         permit_nonce: U256,
         block_content_hash: B256,
-        ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<Signature, BuilderTransactionError> {
         let struct_hash_calldata = IBlockBuilderPolicy::computeStructHashCall {
@@ -262,15 +262,15 @@ impl FlashtestationsBuilderTx {
     fn signed_block_proof_permit_tx(
         &self,
         transactions: &[OpTransactionSigned],
-        ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<BuilderTransactionCtx, BuilderTransactionError> {
         let permit_nonce = self.get_permit_nonce(self.builder_policy_address, ctx, evm)?;
         let block_content_hash = Self::compute_block_content_hash(
             transactions,
-            ctx.parent_hash(),
-            ctx.block_number(),
-            ctx.timestamp(),
+            ctx.parent_hash,
+            ctx.block_number,
+            ctx.hardforks.timestamp,
         );
         let signature =
             self.block_proof_permit_signature(permit_nonce, block_content_hash, ctx, evm)?;
@@ -309,7 +309,7 @@ impl FlashtestationsBuilderTx {
         &self,
         contract_address: Address,
         calldata: T,
-        ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<SimulationSuccessResult<T>, BuilderTransactionError> {
         self.flashtestations_call(contract_address, calldata, vec![], ctx, evm)
@@ -320,12 +320,12 @@ impl FlashtestationsBuilderTx {
         contract_address: Address,
         calldata: T,
         expected_topics: Vec<B256>,
-        ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<SimulationSuccessResult<T>, BuilderTransactionError> {
         let tx_req = OpTransactionRequest::default()
-            .gas_limit(ctx.block_gas_limit())
-            .max_fee_per_gas(ctx.base_fee().into())
+            .gas_limit(ctx.block_gas_limit)
+            .max_fee_per_gas(ctx.base_fee.into())
             .to(contract_address)
             .from(self.builder_signer.address)
             .nonce(get_nonce(evm.db(), self.builder_signer.address)?)
@@ -355,7 +355,7 @@ impl BuilderTransactions for FlashtestationsBuilderTx {
         &self,
         state_provider: impl StateProvider + Clone,
         info: &mut ExecutionInfo,
-        ctx: &OpPayloadJobCtx,
+        ctx: &BuilderTxEnv<'_>,
         db: &mut State<impl Database + DatabaseRef>,
         _top_of_block: bool,
         _is_first_flashblock: bool,

--- a/crates/op-rbuilder/src/hardforks.rs
+++ b/crates/op-rbuilder/src/hardforks.rs
@@ -1,0 +1,63 @@
+use std::sync::Arc;
+
+use reth_chainspec::{EthChainSpec, EthereumHardforks};
+use reth_optimism_chainspec::OpChainSpec;
+use reth_optimism_forks::OpHardforks;
+
+/// Binds an [`OpChainSpec`] with a block timestamp so that hardfork activation
+/// checks become simple zero-argument method calls.
+///
+/// Constructed once per block (the timestamp is fixed for the block's lifetime).
+#[derive(Clone)]
+pub struct ActiveHardforks {
+    chain_spec: Arc<OpChainSpec>,
+    pub timestamp: u64,
+}
+
+impl ActiveHardforks {
+    pub fn new(chain_spec: Arc<OpChainSpec>, timestamp: u64) -> Self {
+        Self {
+            chain_spec,
+            timestamp,
+        }
+    }
+
+    pub fn chain_id(&self) -> u64 {
+        self.chain_spec.chain_id()
+    }
+
+    pub fn is_regolith_active(&self) -> bool {
+        self.chain_spec
+            .is_regolith_active_at_timestamp(self.timestamp)
+    }
+
+    pub fn is_canyon_active(&self) -> bool {
+        self.chain_spec
+            .is_canyon_active_at_timestamp(self.timestamp)
+    }
+
+    pub fn is_ecotone_active(&self) -> bool {
+        self.chain_spec
+            .is_ecotone_active_at_timestamp(self.timestamp)
+    }
+
+    pub fn is_holocene_active(&self) -> bool {
+        self.chain_spec
+            .is_holocene_active_at_timestamp(self.timestamp)
+    }
+
+    pub fn is_isthmus_active(&self) -> bool {
+        self.chain_spec
+            .is_isthmus_active_at_timestamp(self.timestamp)
+    }
+
+    pub fn is_jovian_active(&self) -> bool {
+        self.chain_spec
+            .is_jovian_active_at_timestamp(self.timestamp)
+    }
+
+    pub fn is_shanghai_active(&self) -> bool {
+        self.chain_spec
+            .is_shanghai_active_at_timestamp(self.timestamp)
+    }
+}

--- a/crates/op-rbuilder/src/lib.rs
+++ b/crates/op-rbuilder/src/lib.rs
@@ -4,6 +4,7 @@ pub mod builder;
 pub mod evm;
 pub mod flashtestations;
 pub mod gas_limiter;
+pub mod hardforks;
 pub mod launcher;
 pub mod metrics;
 mod monitor_tx_pool;


### PR DESCRIPTION
Extracted the following:
* `build_receipt` fn
* `ActiveHardforks` type to be created once per payload job
* `BuilderTxEnv` so that builder tx code isn't dependent on `OpPayloadJobCtx`

No change in behavior