### PR TITLE
chore: prepare v0.4.4 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6297,7 +6297,7 @@ dependencies = [
 
 [[package]]
 name = "macros"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7128,7 +7128,7 @@ dependencies = [
 
 [[package]]
 name = "op-rbuilder"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -7424,7 +7424,7 @@ dependencies = [
 
 [[package]]
 name = "p2p"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "derive_more",
  "eyre",
@@ -13096,7 +13096,7 @@ dependencies = [
 
 [[package]]
 name = "tdx-quote-provider"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
  ## Summary

  Prepare the `v0.4.4` release by bumping the workspace version from `0.4.3` to `0.4.4` and updating `Cargo.lock`.

  This branch is rebased on top of `main` and does not include the metrics refactor work.

  ## Release Notes

  `v0.4.4` includes the following changes since `v0.4.3`:

  - fix: add back schedule times to log (#491)
  - refactor(builder): split payload builder context into static and per-job (#489)
  - refactor: rename `FlashblockTxCache` to `FlashblockTxTracker` (#490)
  - chore: downgrade reth to `v1.11.3` (#484)
  - fix: propagate `eth_api` errors instead of panicking (#486)

  ## Changes In This PR

  - bump workspace version to `0.4.4` in `Cargo.toml`
  - update package versions in `Cargo.lock`