### PR TITLE
feat: create reth pool wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3314,6 +3314,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "delegate"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7153,6 +7164,7 @@ dependencies = [
  "criterion",
  "ctor",
  "dashmap",
+ "delegate",
  "derive_more",
  "dirs-next",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ clap = { version = "4.4.3", features = ["derive", "env", "string"] }
 clap_builder = { version = "4.5.19" }
 ctor = "0.4.2"
 dashmap = "6.1"
+delegate = "0.13.5"
 derive_more = { version = "2" }
 dirs-next = "2.0.0"
 dotenvy = "0.15.4"

--- a/crates/op-rbuilder/Cargo.toml
+++ b/crates/op-rbuilder/Cargo.toml
@@ -96,6 +96,7 @@ clap.workspace = true
 clap_builder = { workspace = true }
 ctor = { workspace = true, optional = true }
 dashmap.workspace = true
+delegate.workspace = true
 derive_more.workspace = true
 dirs-next.workspace = true
 either.workspace = true

--- a/crates/op-rbuilder/src/launcher.rs
+++ b/crates/op-rbuilder/src/launcher.rs
@@ -13,9 +13,9 @@ use crate::{
     builder::{BuilderConfig, FlashblocksServiceBuilder},
     metrics::{OpRBuilderMetrics, VERSION, record_flag_gauge_metrics},
     monitor_tx_pool::monitor_tx_pool,
+    pool::FlashpoolBuilder,
     presim::{TopOfBlockSimulator, maintain_pending_simulations, maintain_tip_state},
     revert_protection::{EthApiExtServer, RevertProtectionExt},
-    tx::FBPooledTransaction,
 };
 use moka::future::Cache;
 use reth::builder::{NodeBuilder, WithLaunchContext};
@@ -26,7 +26,7 @@ use reth_optimism_cli::chainspec::OpChainSpecParser;
 use reth_optimism_evm::OpEvmConfig;
 use reth_optimism_node::{
     OpNode,
-    node::{OpAddOns, OpAddOnsBuilder, OpEngineValidatorBuilder, OpPoolBuilder},
+    node::{OpAddOns, OpAddOnsBuilder, OpEngineValidatorBuilder},
 };
 use reth_provider::{CanonStateSubscriptions, ChainSpecProvider};
 use reth_transaction_pool::TransactionPool;
@@ -95,7 +95,7 @@ impl Launcher<OpChainSpecParser, OpRbuilderArgs> for BuilderLauncher {
 
         let da_config = builder_config.da_config.clone();
         let gas_limit_config = builder_config.gas_limit_config.clone();
-        let rollup_args = builder_args.rollup_args;
+        let rollup_args = &builder_args.rollup_args;
         let op_node = OpNode::new(rollup_args.clone());
         let reverted_cache = Cache::builder().max_capacity(100).build();
         let reverted_cache_copy = reverted_cache.clone();
@@ -125,19 +125,7 @@ impl Launcher<OpChainSpecParser, OpRbuilderArgs> for BuilderLauncher {
             .with_components(
                 op_node
                     .components()
-                    .pool(
-                        OpPoolBuilder::<FBPooledTransaction>::default()
-                            .with_enable_tx_conditional(
-                                // Revert protection uses the same internal pool logic as conditional transactions
-                                // to garbage collect transactions out of the bundle range.
-                                rollup_args.enable_tx_conditional
-                                    || builder_args.enable_revert_protection,
-                            )
-                            .with_supervisor(
-                                rollup_args.supervisor_http.clone(),
-                                rollup_args.supervisor_safety_level,
-                            ),
-                    )
+                    .pool(FlashpoolBuilder::new(&builder_args))
                     .payload(FlashblocksServiceBuilder::new(builder_config)),
             )
             .with_add_ons(addons)

--- a/crates/op-rbuilder/src/lib.rs
+++ b/crates/op-rbuilder/src/lib.rs
@@ -8,6 +8,7 @@ pub mod hardforks;
 pub mod launcher;
 pub mod metrics;
 mod monitor_tx_pool;
+pub mod pool;
 pub mod presim;
 pub mod primitives;
 pub mod revert_protection;

--- a/crates/op-rbuilder/src/pool/builder.rs
+++ b/crates/op-rbuilder/src/pool/builder.rs
@@ -1,0 +1,47 @@
+use reth_evm::ConfigureEvm;
+use reth_node_api::{FullNodeTypes, NodeTypes, PrimitivesTy, TxTy};
+use reth_node_builder::{BuilderContext, components::PoolBuilder};
+use reth_optimism_forks::OpHardforks;
+use reth_optimism_node::OpPoolBuilder;
+use reth_optimism_txpool::{OpPooledTx, OpTransactionPool};
+use reth_transaction_pool::{EthPoolTransaction, blobstore::DiskFileBlobStore};
+
+use crate::{args::OpRbuilderArgs, pool::Flashpool, tx::FBPooledTransaction};
+
+pub struct FlashpoolBuilder {
+    op_pool_builder: OpPoolBuilder<FBPooledTransaction>,
+}
+
+impl FlashpoolBuilder {
+    pub fn new(builder_args: &OpRbuilderArgs) -> Self {
+        let rollup_args = &builder_args.rollup_args;
+        let op_pool_builder = OpPoolBuilder::<FBPooledTransaction>::default()
+            .with_enable_tx_conditional(
+                // Revert protection uses the same internal pool logic as conditional transactions
+                // to garbage collect transactions out of the bundle range.
+                rollup_args.enable_tx_conditional || builder_args.enable_revert_protection,
+            );
+
+        Self { op_pool_builder }
+    }
+}
+
+impl<Node, Evm> PoolBuilder<Node, Evm> for FlashpoolBuilder
+where
+    Node: FullNodeTypes<Types: NodeTypes<ChainSpec: OpHardforks>>,
+    FBPooledTransaction: EthPoolTransaction<Consensus = TxTy<Node::Types>> + OpPooledTx,
+    Evm: ConfigureEvm<Primitives = PrimitivesTy<Node::Types>> + Clone + 'static,
+{
+    type Pool =
+        Flashpool<OpTransactionPool<Node::Provider, DiskFileBlobStore, Evm, FBPooledTransaction>>;
+
+    async fn build_pool(
+        self,
+        ctx: &BuilderContext<Node>,
+        evm_config: Evm,
+    ) -> eyre::Result<Self::Pool> {
+        Ok(Flashpool {
+            inner: self.op_pool_builder.build_pool(ctx, evm_config).await?,
+        })
+    }
+}

--- a/crates/op-rbuilder/src/pool/delegate.rs
+++ b/crates/op-rbuilder/src/pool/delegate.rs
@@ -1,0 +1,190 @@
+use std::sync::Arc;
+
+use alloy_eips::{
+    eip4844::{BlobAndProofV1, BlobAndProofV2},
+    eip7594::BlobTransactionSidecarVariant,
+};
+use alloy_primitives::{Address, B256, TxHash, map::AddressSet};
+use delegate::delegate;
+use reth::network::types::HandleMempoolData;
+use reth_primitives_traits::Recovered;
+use reth_transaction_pool::{
+    AddedTransactionOutcome, AllPoolTransactions, AllTransactionsEvents, BestTransactions,
+    BestTransactionsAttributes, BlockInfo, GetPooledTransactionLimit, NewBlobSidecar,
+    NewTransactionEvent, PoolResult, PoolSize, PoolTransaction, PropagatedTransactions,
+    TransactionEvents, TransactionListenerKind, TransactionOrigin, TransactionPool,
+    ValidPoolTransaction, blobstore::BlobStoreError,
+};
+use tokio::sync::mpsc::Receiver;
+
+use crate::{pool::Flashpool, tx::FBPooledTransaction};
+
+impl<P: TransactionPool<Transaction = FBPooledTransaction>> TransactionPool for Flashpool<P> {
+    type Transaction = FBPooledTransaction;
+
+    delegate! {
+        to self.inner {
+            fn pool_size(&self) -> PoolSize;
+            fn block_info(&self) -> BlockInfo;
+            fn add_transaction_and_subscribe(
+                &self,
+                origin: TransactionOrigin,
+                transaction: Self::Transaction,
+            ) -> impl Future<Output = PoolResult<TransactionEvents>> + Send;
+            fn add_transaction(
+                &self,
+                origin: TransactionOrigin,
+                transaction: Self::Transaction,
+            ) -> impl Future<Output = PoolResult<AddedTransactionOutcome>> + Send;
+            fn add_transactions_with_origins(
+                &self,
+                transactions: impl IntoIterator<Item = (TransactionOrigin, Self::Transaction)> + Send,
+            ) -> impl Future<Output = Vec<PoolResult<AddedTransactionOutcome>>> + Send;
+            fn transaction_event_listener(
+                &self,
+                tx_hash: TxHash,
+            ) -> Option<TransactionEvents>;
+            fn all_transactions_event_listener(
+                &self,
+            ) -> AllTransactionsEvents<Self::Transaction>;
+            fn pending_transactions_listener_for(
+                &self,
+                kind: TransactionListenerKind,
+            ) -> Receiver<TxHash>;
+            fn blob_transaction_sidecars_listener(&self) -> Receiver<NewBlobSidecar>;
+            fn new_transactions_listener_for(
+                &self,
+                kind: TransactionListenerKind,
+            ) -> Receiver<NewTransactionEvent<Self::Transaction>>;
+            fn pooled_transaction_hashes(&self) -> Vec<TxHash>;
+            fn pooled_transaction_hashes_max(&self, max: usize) -> Vec<TxHash>;
+            fn pooled_transactions(
+                &self,
+            ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+            fn pooled_transactions_max(
+                &self,
+                max: usize,
+            ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+            fn get_pooled_transaction_elements(
+                &self,
+                tx_hashes: Vec<TxHash>,
+                limit: GetPooledTransactionLimit,
+            ) -> Vec<<Self::Transaction as PoolTransaction>::Pooled>;
+            fn get_pooled_transaction_element(
+                &self,
+                tx_hash: TxHash,
+            ) -> Option<Recovered<<Self::Transaction as PoolTransaction>::Pooled>>;
+            fn best_transactions(
+                &self,
+            ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<Self::Transaction>>>>;
+            fn best_transactions_with_attributes(
+                &self,
+                best_transactions_attributes: BestTransactionsAttributes,
+            ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<Self::Transaction>>>>;
+            fn pending_transactions(
+                &self,
+            ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+            fn pending_transactions_max(
+                &self,
+                max: usize,
+            ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+            fn queued_transactions(
+                &self,
+            ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+            fn pending_and_queued_txn_count(&self) -> (usize, usize);
+            fn all_transactions(&self) -> AllPoolTransactions<Self::Transaction>;
+            fn all_transaction_hashes(&self) -> Vec<TxHash>;
+            fn remove_transactions(
+                &self,
+                hashes: Vec<TxHash>,
+            ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+            fn remove_transactions_and_descendants(
+                &self,
+                hashes: Vec<TxHash>,
+            ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+            fn remove_transactions_by_sender(
+                &self,
+                sender: Address,
+            ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+            fn prune_transactions(
+                &self,
+                hashes: Vec<TxHash>,
+            ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+            fn retain_unknown<A>(&self, announcement: &mut A)
+            where
+                A: HandleMempoolData;
+            fn get(
+                &self,
+                tx_hash: &TxHash,
+            ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>>;
+            fn get_all(
+                &self,
+                txs: Vec<TxHash>,
+            ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+            fn on_propagated(&self, txs: PropagatedTransactions);
+            fn get_transactions_by_sender(
+                &self,
+                sender: Address,
+            ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+            fn get_pending_transactions_with_predicate(
+                &self,
+                predicate: impl FnMut(&ValidPoolTransaction<Self::Transaction>) -> bool,
+            ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+            fn get_pending_transactions_by_sender(
+                &self,
+                sender: Address,
+            ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+            fn get_queued_transactions_by_sender(
+                &self,
+                sender: Address,
+            ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+            fn get_highest_transaction_by_sender(
+                &self,
+                sender: Address,
+            ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>>;
+            fn get_highest_consecutive_transaction_by_sender(
+                &self,
+                sender: Address,
+                on_chain_nonce: u64,
+            ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>>;
+            fn get_transaction_by_sender_and_nonce(
+                &self,
+                sender: Address,
+                nonce: u64,
+            ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>>;
+            fn get_transactions_by_origin(
+                &self,
+                origin: TransactionOrigin,
+            ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+            fn get_pending_transactions_by_origin(
+                &self,
+                origin: TransactionOrigin,
+            ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+            fn unique_senders(&self) -> AddressSet;
+            fn get_blob(
+                &self,
+                tx_hash: TxHash,
+            ) -> Result<Option<Arc<BlobTransactionSidecarVariant>>, BlobStoreError>;
+            fn get_all_blobs(
+                &self,
+                tx_hashes: Vec<TxHash>,
+            ) -> Result<Vec<(TxHash, Arc<BlobTransactionSidecarVariant>)>, BlobStoreError>;
+            fn get_all_blobs_exact(
+                &self,
+                tx_hashes: Vec<TxHash>,
+            ) -> Result<Vec<Arc<BlobTransactionSidecarVariant>>, BlobStoreError>;
+            fn get_blobs_for_versioned_hashes_v1(
+                &self,
+                versioned_hashes: &[B256],
+            ) -> Result<Vec<Option<BlobAndProofV1>>, BlobStoreError>;
+            fn get_blobs_for_versioned_hashes_v2(
+                &self,
+                versioned_hashes: &[B256],
+            ) -> Result<Option<Vec<BlobAndProofV2>>, BlobStoreError>;
+            fn get_blobs_for_versioned_hashes_v3(
+                &self,
+                versioned_hashes: &[B256],
+            ) -> Result<Vec<Option<BlobAndProofV2>>, BlobStoreError>;
+        }
+    }
+}

--- a/crates/op-rbuilder/src/pool/mod.rs
+++ b/crates/op-rbuilder/src/pool/mod.rs
@@ -1,0 +1,13 @@
+mod builder;
+mod delegate;
+
+pub use builder::FlashpoolBuilder;
+
+use reth_transaction_pool::TransactionPool;
+
+use crate::tx::FBPooledTransaction;
+
+#[derive(Debug, Clone)]
+pub struct Flashpool<P: TransactionPool<Transaction = FBPooledTransaction>> {
+    inner: P,
+}

--- a/crates/op-rbuilder/src/tests/framework/instance.rs
+++ b/crates/op-rbuilder/src/tests/framework/instance.rs
@@ -3,6 +3,7 @@ use crate::{
     backrun_bundle::{BackrunBundleApiServer, BackrunBundleRpc},
     builder::{BuilderConfig, FlashblocksServiceBuilder},
     metrics::OpRBuilderMetrics,
+    pool::FlashpoolBuilder,
     presim::{TopOfBlockSimulator, maintain_pending_simulations, maintain_tip_state},
     revert_protection::{EthApiExtServer, RevertProtectionExt},
     tests::{
@@ -42,7 +43,7 @@ use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::OpEvmConfig;
 use reth_optimism_node::{
     OpNode,
-    node::{OpAddOns, OpAddOnsBuilder, OpEngineValidatorBuilder, OpPoolBuilder},
+    node::{OpAddOns, OpAddOnsBuilder, OpEngineValidatorBuilder},
 };
 use reth_optimism_rpc::OpEthApiBuilder;
 use reth_provider::{CanonStateSubscriptions, ChainSpecProvider};
@@ -141,7 +142,7 @@ impl LocalInstance {
             .with_components(
                 op_node
                     .components()
-                    .pool(pool_component(&args))
+                    .pool(FlashpoolBuilder::new(&args))
                     .payload(FlashblocksServiceBuilder::new(builder_config)),
             )
             .with_add_ons(addons)
@@ -389,20 +390,6 @@ fn chain_spec() -> Arc<OpChainSpec> {
 
 fn task_runtime() -> TaskRuntime {
     TaskRuntime::test()
-}
-
-fn pool_component(args: &OpRbuilderArgs) -> OpPoolBuilder<FBPooledTransaction> {
-    let rollup_args = &args.rollup_args;
-    OpPoolBuilder::<FBPooledTransaction>::default()
-        .with_enable_tx_conditional(
-            // Revert protection uses the same internal pool logic as conditional transactions
-            // to garbage collect transactions out of the bundle range.
-            rollup_args.enable_tx_conditional || args.enable_revert_protection,
-        )
-        .with_supervisor(
-            rollup_args.supervisor_http.clone(),
-            rollup_args.supervisor_safety_level,
-        )
 }
 
 async fn spawn_attestation_provider() -> eyre::Result<AttestationServer> {


### PR DESCRIPTION
## Summary
Create a new `Flashpool` to wrap reth's transaction pool.

I do this by creating a `FlashpoolBuilder` to wrap `OpPoolBuilder` and implement `PoolBuilder` by delegating to the inner `OpPoolBuilder`. The `Flashpool` then wraps around the `OpTransactionPool` created by the inner builder.

Implementing `TransactionPool` for `Flashpool` is done through the `delegate` macro for the 50+ methods on that trait. This will allow us to selectively customize individual methods later and access newly added fields on `Flashpool`.

## Motivation
The following features benefit from tighter integration with the pool:
* presim
* backruns
* multi-tx bundles
* reverted tx tracking
* .. and probably more that I can't think of right now

So while this is over-engineering at the present moment, I think this is the least unreasonable way to extend pool functionality.