### PR TITLE
chore: remove ci step to install foundry toolchain

### DIFF
--- a/.github/workflows/op_rbuilder_checks.yaml
+++ b/.github/workflows/op_rbuilder_checks.yaml
@@ -47,11 +47,6 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
 
-      - name: Install Foundry toolchain
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
-
       - name: Install native dependencies
         run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev clang libclang-dev llvm build-essential pkg-config libtss2-dev
 


### PR DESCRIPTION
We're not doing anything with foundry (forge, anvil, or cast commands)