### PR TITLE
perf(p2p): move execute_flashblock directly on blocking thread

### DIFF
--- a/crates/op-rbuilder/src/builder/payload_handler.rs
+++ b/crates/op-rbuilder/src/builder/payload_handler.rs
@@ -123,15 +123,12 @@ where
 
                             // execute the flashblock on a thread where blocking is acceptable,
                             // as it's potentially a heavy operation
-                            task_executor.spawn_blocking_task(Box::pin(async move {
-                                let res = execute_flashblock(
-                                    payload,
-                                    ctx,
-                                    client,
-                                    cancel,
-                                );
-                                match res {
-                                    Ok((payload, _)) => {
+                            let handle = task_executor.spawn_blocking(move || {
+                                execute_flashblock(payload, ctx, client, cancel)
+                            });
+                            task_executor.spawn_task(async move {
+                                match handle.await {
+                                    Ok(Ok((payload, _))) => {
                                         info!(
                                             target: "payload_builder",
                                             block_hash = %payload.block().hash(),
@@ -146,15 +143,22 @@ where
                                             );
                                         }
                                     }
-                                    Err(e) => {
+                                    Ok(Err(e)) => {
                                         error!(
                                             target: "payload_builder",
                                             error = %e,
                                             "failed to execute external received flashblock"
                                         );
                                     }
+                                    Err(e) => {
+                                        error!(
+                                            target: "payload_builder",
+                                            error = %e,
+                                            "execute_flashblock task join error"
+                                        );
+                                    }
                                 }
-                            }));
+                            });
                         }
                     }
                 }


### PR DESCRIPTION
execute_flashblock is fully sync, avoid wrapping it in a heap-allocated future that is just blocked on anyway