### PR TITLE
cleanup: drop redundant Box::pin on payload builder spawns

### DIFF
--- a/crates/op-rbuilder/src/builder/generator.rs
+++ b/crates/op-rbuilder/src/builder/generator.rs
@@ -296,7 +296,7 @@ where
         let cached_reads = std::mem::take(&mut self.cached_reads);
         // try_build is not in a blocking task!
         // We have to make sure any blocking work is handled individually within payload builder
-        self.executor.spawn_task(Box::pin(async move {
+        self.executor.spawn_task(async move {
             let args = BuildArguments {
                 cached_reads,
                 config: payload_config,
@@ -307,7 +307,7 @@ where
             if let Err(e) = builder.try_build(args, watch_tx).await {
                 tracing::error!(id = %payload_id, "build task failed: {:?}", e);
             }
-        }));
+        });
     }
 }
 

--- a/crates/op-rbuilder/src/builder/service.rs
+++ b/crates/op-rbuilder/src/builder/service.rs
@@ -167,19 +167,15 @@ impl FlashblocksServiceBuilder {
 
         ctx.task_executor().spawn_critical_task(
             "custom payload builder service",
-            Box::pin(
-                task_metrics
-                    .payload_builder_service
-                    .instrument(payload_service),
-            ),
+            task_metrics
+                .payload_builder_service
+                .instrument(payload_service),
         );
         ctx.task_executor().spawn_critical_task(
             "flashblocks payload handler",
-            Box::pin(
-                task_metrics
-                    .payload_handler
-                    .instrument(payload_handler.run()),
-            ),
+            task_metrics
+                .payload_handler
+                .instrument(payload_handler.run()),
         );
 
         // Spawn the tokio metrics collector (records metrics every second)


### PR DESCRIPTION
tokio already Box::pin internally, so this is just minor cleanup