### PR TITLE
refactor: move state root computation into its module

### DIFF
--- a/crates/op-rbuilder/benches/bench_flashblocks_state_root.rs
+++ b/crates/op-rbuilder/benches/bench_flashblocks_state_root.rs
@@ -194,8 +194,8 @@ fn bench_without_cache(
         let fb_start = Instant::now();
         let provider = provider_factory.database_provider_ro().unwrap();
         let latest = LatestStateProvider::new(provider);
-        let output = StateRootCalculator::new(false)
-            .compute(&latest, hashed_state.clone())
+        let output = StateRootCalculator::new(true, false)
+            .compute_from_hashed(&latest, hashed_state.clone())
             .unwrap();
         individual_times.push(fb_start.elapsed().as_micros());
         black_box(output.state_root);
@@ -212,7 +212,7 @@ fn bench_with_cache(
     flashblock_changes: &[HashedPostState],
 ) -> (u128, Vec<u128>) {
     let mut individual_times = Vec::new();
-    let mut calc = StateRootCalculator::new(true);
+    let mut calc = StateRootCalculator::new(true, true);
     let total_start = Instant::now();
 
     for hashed_state in flashblock_changes {
@@ -220,7 +220,9 @@ fn bench_with_cache(
         let provider = provider_factory.database_provider_ro().unwrap();
         let latest = LatestStateProvider::new(provider);
 
-        let output = calc.compute(&latest, hashed_state.clone()).unwrap();
+        let output = calc
+            .compute_from_hashed(&latest, hashed_state.clone())
+            .unwrap();
 
         individual_times.push(fb_start.elapsed().as_micros());
         black_box(output.state_root);

--- a/crates/op-rbuilder/src/builder/assembly.rs
+++ b/crates/op-rbuilder/src/builder/assembly.rs
@@ -29,13 +29,12 @@ use reth_revm::{
     State,
     db::{BundleState, states::bundle_state::BundleRetention},
 };
-use reth_trie::{HashedPostState, updates::TrieUpdates};
 use revm::{Database, interpreter::as_u64_saturated};
 use std::{collections::BTreeMap, time::Instant};
 use tracing::{debug, info, warn};
 
 use crate::{
-    builder::{StateRootCalculator, payload::FlashblocksState},
+    builder::{StateRootCalculator, payload::FlashblocksState, state_root::StateRootOutput},
     evm::OpBlockEvmFactory,
     hardforks::ActiveHardforks,
     metrics::OpRBuilderMetrics,
@@ -297,10 +296,10 @@ impl BlockAssemblyInput {
     pub(super) fn assemble<DB, P>(
         self,
         state: &mut State<DB>,
-        mut fb_state: Option<&mut FlashblocksState>,
+        fb_state: Option<&mut FlashblocksState>,
         info: &mut ExecutionInfo,
+        state_root_calc: &mut StateRootCalculator,
         metrics: Arc<OpRBuilderMetrics>,
-        calculate_state_root: bool,
         enable_tx_tracking_debug_logs: bool,
     ) -> Result<(OpBuiltPayload, OpFlashblockPayload), PayloadBuilderError>
     where
@@ -317,53 +316,29 @@ impl BlockAssemblyInput {
 
         self.check_block_number()?;
 
-        // TODO: maybe recreate state with bundle in here
-        let state_root_start_time = Instant::now();
-        let mut state_root = B256::ZERO;
-        let mut hashed_state = HashedPostState::default();
-        let mut trie_updates_to_cache: Option<Arc<TrieUpdates>> = None;
-
         let flashblock_index_for_trace = fb_state
             .as_deref()
             .map(|s| s.flashblock_index())
             .unwrap_or(0);
 
-        if calculate_state_root {
-            let state_provider = state.database.as_ref();
-            let flashblock_index = fb_state
-                .as_deref()
-                .map(|s| s.flashblock_index())
-                .unwrap_or(0);
-
-            hashed_state = state_provider.hashed_post_state(&state.bundle_state);
-
-            let mut default_calc = StateRootCalculator::default();
-            let calc = match fb_state.as_deref_mut() {
-                Some(s) => &mut s.state_root_calculator_mut(),
-                None => &mut default_calc,
-            };
-
-            debug!(
-                target: "payload_builder",
-                flashblock_index,
-                incremental = calc.has_cached_trie(),
-                "Computing state root"
-            );
-
-            let output = calc
-                .compute(state_provider, hashed_state.clone())
-                .inspect_err(|err| {
-                    warn!(
-                        target: "payload_builder",
-                        parent_header = %self.parent_header.hash(),
-                        %err,
-                        "failed to calculate state root for payload"
-                    );
-                })
-                .map_err(PayloadBuilderError::other)?;
-            state_root = output.state_root;
-            trie_updates_to_cache = Some(output.trie_updates);
-
+        // Calculate the state root (returns defaults when disabled)
+        let state_root_start_time = Instant::now();
+        let StateRootOutput {
+            state_root,
+            hashed_state,
+            trie_updates,
+        } = state_root_calc
+            .compute(state.database.as_ref(), &state.bundle_state)
+            .inspect_err(|err| {
+                warn!(
+                    target: "payload_builder",
+                    parent_header = %self.parent_header.hash(),
+                    %err,
+                    "failed to calculate state root for payload"
+                );
+            })
+            .map_err(PayloadBuilderError::other)?;
+        if state_root_calc.is_enabled() {
             let state_root_calculation_time = state_root_start_time.elapsed();
             metrics
                 .state_root_calculation_duration
@@ -374,7 +349,7 @@ impl BlockAssemblyInput {
 
             debug!(
                 target: "payload_builder",
-                flashblock_index,
+                flashblock_index = flashblock_index_for_trace,
                 state_root = %state_root,
                 duration_ms = state_root_calculation_time.as_millis(),
                 "State root calculation completed"
@@ -386,7 +361,7 @@ impl BlockAssemblyInput {
                     block_number = self.block_number,
                     flashblock_index = flashblock_index_for_trace,
                     duration_ms = state_root_calculation_time.as_millis() as u64,
-                    incremental = calc.has_cached_trie(),
+                    incremental = state_root_calc.has_cached_trie(),
                     cumulative_gas = info.cumulative_gas_used,
                     num_txs = info.executed_transactions.len(),
                     stage = "state_root_computed"
@@ -465,9 +440,7 @@ impl BlockAssemblyInput {
         let executed = BuiltPayloadExecutedBlock {
             recovered_block: Arc::new(recovered_block),
             execution_output: Arc::new(execution_output),
-            trie_updates: either::Either::Left(
-                trie_updates_to_cache.unwrap_or_else(|| Arc::new(TrieUpdates::default())),
-            ),
+            trie_updates: either::Either::Left(trie_updates),
             hashed_state: either::Either::Left(Arc::new(hashed_state)),
         };
         debug!(

--- a/crates/op-rbuilder/src/builder/payload.rs
+++ b/crates/op-rbuilder/src/builder/payload.rs
@@ -80,9 +80,6 @@ pub(super) struct FlashblocksState {
     /// Index into ExecutionInfo tracking the last consumed flashblock
     /// Used for slicing transactions/receipts per flashblock
     last_flashblock_tx_index: usize,
-    /// State root calculator. Manages cached trie updates and cumulative prefix
-    /// sets across flashblocks when incremental mode is enabled.
-    state_root_calculator: StateRootCalculator,
 }
 
 struct FallbackBuildOutput<Cache, Transition> {
@@ -93,6 +90,7 @@ struct FallbackBuildOutput<Cache, Transition> {
     cache: Cache,
     transition: Transition,
     fb_state: FlashblocksState,
+    state_root_calc: StateRootCalculator,
 }
 
 struct FlashblockBuildOutput<Cache, Transition> {
@@ -103,13 +101,13 @@ struct FlashblockBuildOutput<Cache, Transition> {
     tx_tracker: FlashblockTxTracker,
     info: ExecutionInfo,
     fb_state: FlashblocksState,
+    state_root_calc: StateRootCalculator,
 }
 
 impl FlashblocksState {
-    fn new(target_flashblock_count: u64, enable_incremental_state_root: bool) -> Self {
+    fn new(target_flashblock_count: u64) -> Self {
         Self {
             target_flashblock_count,
-            state_root_calculator: StateRootCalculator::new(enable_incremental_state_root),
             ..Default::default()
         }
     }
@@ -131,7 +129,6 @@ impl FlashblocksState {
             da_per_batch: self.da_per_batch,
             da_footprint_per_batch: self.da_footprint_per_batch,
             last_flashblock_tx_index: self.last_flashblock_tx_index,
-            state_root_calculator: self.state_root_calculator.clone(),
         }
     }
 
@@ -222,10 +219,6 @@ impl FlashblocksState {
 
     pub(super) fn set_last_flashblock_tx_index(&mut self, index: usize) {
         self.last_flashblock_tx_index = index;
-    }
-
-    pub(super) fn state_root_calculator_mut(&mut self) -> &mut StateRootCalculator {
-        &mut self.state_root_calculator
     }
 
     /// Extracts new transactions since the last flashblock
@@ -459,7 +452,10 @@ where
             self.config
                 .flashblocks_config
                 .flashblocks_per_block(self.config.block_time),
-            ctx.enable_incremental_state_root,
+        );
+        let mut state_root_calc = StateRootCalculator::new(
+            !ctx.builder_ctx.disable_state_root || ctx.attributes().no_tx_pool,
+            ctx.builder_ctx.enable_incremental_state_root,
         );
 
         self.builder_ctx.address_limiter.refresh(ctx.block_number());
@@ -478,12 +474,13 @@ where
             mut cache,
             mut transition,
             fb_state: returned_fb_state,
+            state_root_calc: returned_state_root_calc,
         } = tracing::Instrument::instrument(
             self.executor.run_blocking_task({
                 let builder = self.clone();
                 move || {
                     builder
-                        .build_fallback_block(ctx, fb_state, cached_reads)
+                        .build_fallback_block(ctx, fb_state, cached_reads, state_root_calc)
                         .map_err(|e| PayloadBuilderError::Other(e.into()))
                 }
             }),
@@ -491,6 +488,7 @@ where
         )
         .await?;
         fb_state = returned_fb_state;
+        state_root_calc = returned_state_root_calc;
 
         self.built_fb_payload_tx
             .try_send(payload.clone())
@@ -717,6 +715,7 @@ where
                     let transition = transition;
                     let mut tx_tracker = tx_tracker;
                     let fb_state = fb_state;
+                    let mut state_root_calc = state_root_calc;
                     let fb_span = fb_span.clone();
                     move || {
                         // Enter the flashblock span so child spans are properly parented
@@ -743,6 +742,7 @@ where
                             &state_provider,
                             &mut best_txs,
                             &block_cancel,
+                            &mut state_root_calc,
                         );
 
                         let cache = std::mem::take(&mut state.cache);
@@ -756,6 +756,7 @@ where
                             tx_tracker,
                             info,
                             fb_state,
+                            state_root_calc,
                         })
                     }
                 }) => result?,
@@ -769,10 +770,12 @@ where
                 tx_tracker: new_tx_tracker,
                 info: new_info,
                 fb_state: returned_fb_state,
+                state_root_calc: returned_state_root_calc,
             } = build_output;
 
             ctx = returned_ctx;
             fb_state = returned_fb_state;
+            state_root_calc = returned_state_root_calc;
             info = new_info;
             cache = new_cache;
             transition = new_transition;
@@ -839,6 +842,7 @@ where
         ctx: OpPayloadJobCtx,
         mut fb_state: FlashblocksState,
         mut cached_reads: CachedReads,
+        mut state_root_calc: StateRootCalculator,
     ) -> eyre::Result<FallbackBuildOutput<CacheState, Option<TransitionState>>> {
         let state_provider = self.client.state_by_block_hash(ctx.parent().hash())?;
         let db = StateProviderDatabase::new(&state_provider);
@@ -882,8 +886,8 @@ where
             &mut state,
             Some(&mut fb_state),
             &mut info,
+            &mut state_root_calc,
             ctx.metrics.clone(),
-            !ctx.disable_state_root || ctx.attributes().no_tx_pool, // need to calculate state root for CL sync
             ctx.enable_tx_tracking_debug_logs,
         )?;
 
@@ -898,6 +902,7 @@ where
             cache,
             transition,
             fb_state,
+            state_root_calc,
         })
     }
 
@@ -915,6 +920,7 @@ where
         state_provider: impl reth::providers::StateProvider + Clone,
         best_txs: &mut NextFlashblockPoolTxCursor<'a, Pool>,
         block_cancel: &CancellationToken,
+        state_root_calc: &mut StateRootCalculator,
     ) -> eyre::Result<Option<(FlashblocksState, OpBuiltPayload)>> {
         let flashblock_index = fb_state.flashblock_index();
         let mut target_gas_for_batch = fb_state.target_gas_for_batch();
@@ -1040,8 +1046,8 @@ where
             state,
             Some(fb_state),
             info,
+            state_root_calc,
             ctx.metrics.clone(),
-            !ctx.disable_state_root || ctx.attributes().no_tx_pool,
             ctx.enable_tx_tracking_debug_logs,
         );
         let total_block_built_duration = total_block_built_duration.elapsed();
@@ -1259,7 +1265,7 @@ mod tests {
         target_da: Option<u64>,
         target_da_footprint: Option<u64>,
     ) -> FlashblocksState {
-        FlashblocksState::new(5, false).with_batch_limits(
+        FlashblocksState::new(5).with_batch_limits(
             gas_per_batch,
             da_per_batch,
             da_footprint_per_batch,
@@ -1328,7 +1334,7 @@ mod tests {
 
     #[test]
     fn test_next_after_seal_preserves_config() {
-        let state = FlashblocksState::new(10, true).with_batch_limits(
+        let state = FlashblocksState::new(10).with_batch_limits(
             50_000,
             Some(500),
             Some(250),

--- a/crates/op-rbuilder/src/builder/payload_handler.rs
+++ b/crates/op-rbuilder/src/builder/payload_handler.rs
@@ -1,7 +1,7 @@
 use crate::{
     builder::{
         assembly::BlockAssemblyInput, p2p::Message, receipt::build_receipt,
-        syncer_config::OpPayloadSyncerConfig,
+        state_root::StateRootCalculator, syncer_config::OpPayloadSyncerConfig,
     },
     evm::OpBlockEvmFactory,
     hardforks::ActiveHardforks,
@@ -335,8 +335,8 @@ where
                 &mut state,
                 None,
                 &mut info,
+                &mut StateRootCalculator::new(true, false),
                 metrics.clone(),
-                true,
                 enable_tx_tracking_debug_logs,
             )
             .wrap_err("failed to build flashblock")?;

--- a/crates/op-rbuilder/src/builder/state_root.rs
+++ b/crates/op-rbuilder/src/builder/state_root.rs
@@ -5,19 +5,26 @@
 //! cached trie for incremental computation.
 
 use alloy_primitives::B256;
-use reth_provider::{ProviderError, StateRootProvider};
+use reth_provider::{HashedPostStateProvider, ProviderError, StateRootProvider};
+use reth_revm::db::BundleState;
 use reth_trie::{HashedPostState, TrieInput, prefix_set::TriePrefixSetsMut, updates::TrieUpdates};
 use std::sync::Arc;
 
 /// Output of [`StateRootCalculator::compute`].
+#[derive(Default)]
 pub struct StateRootOutput {
     /// The computed state root hash.
     pub state_root: B256,
+    /// The hashed post-state used for computation.
+    pub hashed_state: HashedPostState,
     /// Trie updates (shared with the calculator's internal cache).
     pub trie_updates: Arc<TrieUpdates>,
 }
 
 /// Manages state root computation across flashblocks.
+///
+/// When `enabled` is false, [`Self::compute`] short-circuits and returns
+/// `B256::ZERO` with empty state and trie updates.
 ///
 /// When `incremental` is true, caches trie updates and cumulative prefix sets
 /// so that each successive flashblock's state root can be computed
@@ -30,20 +37,26 @@ pub struct StateRootOutput {
 /// cumulative prefix sets from all prior flashblocks so the trie walker
 /// re-visits every previously modified path — preventing stale cached hashes
 /// from reverted storage slots.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct StateRootCalculator {
+    enabled: bool,
     incremental: bool,
     prev_trie_updates: Option<Arc<TrieUpdates>>,
     cumulative_prefix_sets: Option<TriePrefixSetsMut>,
 }
 
 impl StateRootCalculator {
-    pub fn new(incremental: bool) -> Self {
+    pub fn new(enabled: bool, incremental: bool) -> Self {
         Self {
+            enabled,
             incremental,
             prev_trie_updates: None,
             cumulative_prefix_sets: None,
         }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
     }
 
     /// Whether the next [`Self::compute`] call will use cached trie state.
@@ -56,14 +69,31 @@ impl StateRootCalculator {
     /// Updates internal state so the next call can build on this result.
     pub fn compute(
         &mut self,
+        state_provider: &(impl StateRootProvider + HashedPostStateProvider + ?Sized),
+        bundle_state: &BundleState,
+    ) -> Result<StateRootOutput, ProviderError> {
+        if !self.enabled {
+            return Ok(StateRootOutput::default());
+        }
+
+        let hashed_state = state_provider.hashed_post_state(bundle_state);
+        self.compute_from_hashed(state_provider, hashed_state)
+    }
+
+    /// Compute the state root from an already-hashed post-state. Used for tests
+    /// and benchmarks.
+    pub fn compute_from_hashed(
+        &mut self,
         state_provider: &(impl StateRootProvider + ?Sized),
         hashed_state: HashedPostState,
     ) -> Result<StateRootOutput, ProviderError> {
         if !self.incremental {
+            let hashed_state_for_output = hashed_state.clone();
             let (state_root, trie_updates) =
                 state_provider.state_root_with_updates(hashed_state)?;
             return Ok(StateRootOutput {
                 state_root,
+                hashed_state: hashed_state_for_output,
                 trie_updates: Arc::new(trie_updates),
             });
         }
@@ -78,6 +108,7 @@ impl StateRootCalculator {
         }
         let cumulative = prefix_sets.clone();
 
+        let hashed_state_for_output = hashed_state.clone();
         let (state_root, trie_updates) = if let Some(prev_trie) = &self.prev_trie_updates {
             let trie_input = TrieInput::new(prev_trie.as_ref().clone(), hashed_state, prefix_sets);
             state_provider.state_root_from_nodes_with_updates(trie_input)?
@@ -92,6 +123,7 @@ impl StateRootCalculator {
 
         Ok(StateRootOutput {
             state_root,
+            hashed_state: hashed_state_for_output,
             trie_updates,
         })
     }
@@ -170,20 +202,22 @@ mod tests {
         // Full (ground truth): fresh calculator, single call
         let provider = factory.database_provider_ro().unwrap();
         let latest = LatestStateProvider::new(provider);
-        let full = StateRootCalculator::new(false)
-            .compute(&latest, fb2_cumulative_state.clone())
+        let full = StateRootCalculator::new(true, false)
+            .compute_from_hashed(&latest, fb2_cumulative_state.clone())
             .unwrap();
 
         // Incremental: calculator across both flashblocks
-        let mut calc = StateRootCalculator::new(true);
+        let mut calc = StateRootCalculator::new(true, true);
 
         let provider = factory.database_provider_ro().unwrap();
         let latest = LatestStateProvider::new(provider);
-        calc.compute(&latest, fb1_state).unwrap();
+        calc.compute_from_hashed(&latest, fb1_state).unwrap();
 
         let provider = factory.database_provider_ro().unwrap();
         let latest = LatestStateProvider::new(provider);
-        let incremental = calc.compute(&latest, fb2_cumulative_state).unwrap();
+        let incremental = calc
+            .compute_from_hashed(&latest, fb2_cumulative_state)
+            .unwrap();
 
         (full.state_root, incremental.state_root)
     }


### PR DESCRIPTION
## 📝 Summary
* Move more of the state root computation into its module
* Remove the state root calculate from flashblock state since it's not a pure data type

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
