### PR TITLE
sanity(payload-builder): atomic cancel + flashblock publish

### DIFF
--- a/crates/op-rbuilder/src/builder/cancellation.rs
+++ b/crates/op-rbuilder/src/builder/cancellation.rs
@@ -1,3 +1,4 @@
+use parking_lot::{Mutex, MutexGuard};
 use std::sync::{Arc, OnceLock};
 use tokio_util::sync::CancellationToken;
 
@@ -21,6 +22,7 @@ pub(crate) enum CancellationReason {
 pub(crate) struct PayloadJobCancellation {
     token: CancellationToken,
     reason: Arc<OnceLock<CancellationReason>>,
+    publish_lock: Arc<Mutex<()>>,
 }
 
 impl PayloadJobCancellation {
@@ -29,14 +31,22 @@ impl PayloadJobCancellation {
         Self {
             token: CancellationToken::new(),
             reason: Arc::new(OnceLock::new()),
+            publish_lock: Arc::new(Mutex::new(())),
         }
     }
 
     fn cancel_with(&self, reason: CancellationReason) {
+        // Wait for any in-flight flashblock publish to complete
+        let _publish_guard = self.publish_lock.lock();
         // OnceLock ensures that the first writer wins. If already set, the
         // original reason is preserved.
         let _ = self.reason.set(reason);
         self.token.cancel();
+    }
+
+    /// Acquire the publish lock.
+    pub(crate) fn lock_publish(&self) -> MutexGuard<'_, ()> {
+        self.publish_lock.lock()
     }
 
     /// Cancel with `NewFcu` reason.
@@ -176,5 +186,30 @@ mod tests {
         cancel.cancel_resolved();
         cancel.cancel_new_fcu();
         assert_eq!(cancel.reason(), Some(CancellationReason::Resolved));
+    }
+
+    #[test]
+    fn test_cancel_blocked_by_publish_lock() {
+        let cancel = PayloadJobCancellation::new();
+        let guard = cancel.lock_publish();
+
+        let cancel_for_thread = cancel.clone();
+        let handle = std::thread::spawn(move || {
+            cancel_for_thread.cancel_resolved();
+        });
+
+        // Give the cancel thread a chance to attempt the flip.
+        std::thread::sleep(Duration::from_millis(20));
+
+        // Guard is still held -> cancel must not have taken effect.
+        assert!(!cancel.token().is_cancelled());
+        assert_eq!(cancel.reason(), None);
+
+        drop(guard);
+        handle.join().unwrap();
+
+        // After lock release, cancel completes.
+        assert!(cancel.token().is_cancelled());
+        assert!(cancel.is_resolved());
     }
 }

--- a/crates/op-rbuilder/src/builder/payload.rs
+++ b/crates/op-rbuilder/src/builder/payload.rs
@@ -709,7 +709,7 @@ where
                 result = self.executor.run_blocking_task({
                     let builder = self.clone();
                     let ctx = ctx;
-                    let block_cancel = payload_cancel.token();
+                    let payload_cancel = payload_cancel.clone();
                     let info = info;
                     let cache = cache;
                     let transition = transition;
@@ -741,7 +741,7 @@ where
                             &mut state,
                             &state_provider,
                             &mut best_txs,
-                            &block_cancel,
+                            &payload_cancel,
                             &mut state_root_calc,
                         );
 
@@ -919,7 +919,7 @@ where
         state: &mut State<DB>,
         state_provider: impl reth::providers::StateProvider + Clone,
         best_txs: &mut NextFlashblockPoolTxCursor<'a, Pool>,
-        block_cancel: &CancellationToken,
+        payload_cancel: &super::cancellation::PayloadJobCancellation,
         state_root_calc: &mut StateRootCalculator,
     ) -> eyre::Result<Option<(FlashblocksState, OpBuiltPayload)>> {
         let flashblock_index = fb_state.flashblock_index();
@@ -1012,7 +1012,7 @@ where
         }
 
         // Block cancelled (new FCU, getPayload resolved, or deadline). Skip publishing.
-        if block_cancel.is_cancelled() {
+        if payload_cancel.token().is_cancelled() {
             return Ok(None);
         }
 
@@ -1067,15 +1067,28 @@ where
                 fb_payload.index = flashblock_index;
                 fb_payload.base = None;
 
-                // Block canceled (new FCU, getPayload resolved, or deadline).
-                // Don't publish to ensures every published flashblock is a subset of the resolved payload.
-                if block_cancel.is_cancelled() {
-                    return Ok(None);
-                }
-                let flashblock_byte_size = self
-                    .ws_pub
-                    .publish(&fb_payload)
-                    .wrap_err("failed to publish flashblock via websocket")?;
+                // Atomically: check cancel, then ws-publish + channel sends
+                let flashblock_byte_size = {
+                    let _publish_guard = payload_cancel.lock_publish();
+                    if payload_cancel.token().is_cancelled() {
+                        return Ok(None);
+                    }
+                    let flashblock_byte_size = self
+                        .ws_pub
+                        .publish(&fb_payload)
+                        .wrap_err("failed to publish flashblock via websocket")?;
+                    self.built_fb_payload_tx
+                        .try_send(new_payload.clone())
+                        .wrap_err("failed to send built payload to handler")?;
+                    if let Err(e) = self.built_payload_tx.try_send(new_payload.clone()) {
+                        warn!(
+                            target: "payload_builder",
+                            error = %e,
+                            "Failed to send updated payload"
+                        );
+                    }
+                    flashblock_byte_size
+                };
 
                 // Record slot-relative publish timing (ms since slot start)
                 let slot_offset_ms =
@@ -1092,16 +1105,6 @@ where
                         total_txs = info.executed_transactions.len(),
                         slot_offset_ms,
                         stage = "fb_published"
-                    );
-                }
-                self.built_fb_payload_tx
-                    .try_send(new_payload.clone())
-                    .wrap_err("failed to send built payload to handler")?;
-                if let Err(e) = self.built_payload_tx.try_send(new_payload.clone()) {
-                    warn!(
-                        target: "payload_builder",
-                        error = %e,
-                        "Failed to send updated payload"
                     );
                 }
                 // Record flashblock build duration


### PR DESCRIPTION
Wraps per-flashblock publish side effects (`ws_pub.publish`, `built_fb_payload_tx.try_send`, `built_payload_tx.try_send`) and payload cancellation token in a shared `publish_lock`. 
This is preventive against a suspected race between cancel check and publish where a "cancelled" flashblock could still be emitted, inserting an orphan sibling into the engine tree via `Events::BuiltPayload`.