### PR TITLE
refactor: remove backrun pool from config type

### DIFF
--- a/crates/op-rbuilder/src/builder/context.rs
+++ b/crates/op-rbuilder/src/builder/context.rs
@@ -28,7 +28,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, trace};
 
 use crate::{
-    backrun_bundle::{BackrunBundleArgs, BackrunBundleGlobalPool, BackrunBundlePayloadPool},
+    backrun_bundle::{BackrunBundleArgs, BackrunBundlePayloadPool},
     builder::builder_tx::BuilderTxEnv,
     evm::OpBlockEvmFactory,
     hardforks::ActiveHardforks,
@@ -64,8 +64,6 @@ pub struct OpPayloadBuilderCtx {
     /// Per-address rate limiting based on gas and/or compute time. This is an
     /// optional feature.
     pub address_limiter: AddressLimiter,
-    /// Global pool of backrun bundles (per-block views are derived in the per-job ctx).
-    pub backrun_bundle_pool: BackrunBundleGlobalPool,
     /// Backrun bundle configuration.
     pub backrun_bundle_args: BackrunBundleArgs,
     /// Skip reverted txs in subsequent flashblocks
@@ -94,7 +92,7 @@ pub struct OpPayloadJobCtx {
     /// Marker to check whether the job has been cancelled.
     pub cancel: CancellationToken,
     /// Per-block view into the global backrun bundle pool.
-    pub backrun_pool: BackrunBundlePayloadPool,
+    pub backrun_pool: Option<BackrunBundlePayloadPool>,
 }
 
 impl Deref for OpPayloadJobCtx {
@@ -563,10 +561,10 @@ impl OpPayloadJobCtx {
                     0,
                 );
 
-            if can_backrun {
+            if can_backrun && let Some(ref backrun_pool) = self.backrun_pool {
                 let backrun_start_time = Instant::now();
                 let gas_left = block_gas_limit.saturating_sub(info.cumulative_gas_used);
-                let backruns = self.backrun_pool.get_backruns(
+                let backruns = backrun_pool.get_backruns(
                     &target_hash,
                     |addr| evm.db_mut().basic(addr).ok().flatten(),
                     base_fee,

--- a/crates/op-rbuilder/src/builder/mod.rs
+++ b/crates/op-rbuilder/src/builder/mod.rs
@@ -3,7 +3,7 @@ use reth_optimism_payload_builder::config::{OpDAConfig, OpGasLimitConfig};
 
 use crate::{
     args::OpRbuilderArgs,
-    backrun_bundle::{BackrunBundleArgs, BackrunBundleGlobalPool},
+    backrun_bundle::BackrunBundleArgs,
     flashtestations::args::FlashtestationsArgs,
     limiter::args::{ComputeLimiterArgs, GasLimiterArgs},
     tx_signer::Signer,
@@ -94,9 +94,6 @@ pub struct BuilderConfig {
     /// Address compute limiter stuff
     pub compute_limiter_config: ComputeLimiterArgs,
 
-    /// Global pool for backrun bundles
-    pub backrun_bundle_pool: BackrunBundleGlobalPool,
-
     /// Backrun bundle configuration
     pub backrun_bundle_args: BackrunBundleArgs,
 
@@ -125,7 +122,6 @@ impl Default for BuilderConfig {
             max_uncompressed_block_size: None,
             gas_limiter_config: GasLimiterArgs::default(),
             compute_limiter_config: ComputeLimiterArgs::default(),
-            backrun_bundle_pool: BackrunBundleGlobalPool::new(false),
             backrun_bundle_args: BackrunBundleArgs::default(),
             flashblocks_config: FlashblocksConfig::default(),
             exclude_reverts_between_flashblocks: false,
@@ -153,9 +149,6 @@ impl TryFrom<OpRbuilderArgs> for BuilderConfig {
             max_uncompressed_block_size: args.max_uncompressed_block_size,
             gas_limiter_config: args.gas_limiter.clone(),
             compute_limiter_config: args.compute_limiter.clone(),
-            backrun_bundle_pool: BackrunBundleGlobalPool::new(
-                args.backrun_bundle.enforce_strict_priority_fee_ordering,
-            ),
             backrun_bundle_args: args.backrun_bundle,
             flashblocks_config,
             exclude_reverts_between_flashblocks: args.exclude_reverts_between_flashblocks,

--- a/crates/op-rbuilder/src/builder/payload.rs
+++ b/crates/op-rbuilder/src/builder/payload.rs
@@ -315,7 +315,6 @@ where
             max_gas_per_txn: config.max_gas_per_txn,
             max_uncompressed_block_size: config.max_uncompressed_block_size,
             address_limiter,
-            backrun_bundle_pool: config.backrun_bundle_pool.clone(),
             backrun_bundle_args: config.backrun_bundle_args.clone(),
             exclude_reverts_between_flashblocks: config.exclude_reverts_between_flashblocks,
             enable_tx_tracking_debug_logs: config.enable_tx_tracking_debug_logs,
@@ -400,9 +399,10 @@ where
         )
         .wrap_err("failed to create next evm env")?;
 
-        let backrun_pool = builder_ctx
-            .backrun_bundle_pool
-            .block_pool(config.parent_header.number + 1);
+        let backrun_pool = self
+            .pool
+            .backrun_bundle_pool()
+            .map(|pool| pool.block_pool(config.parent_header.number + 1));
 
         Ok(OpPayloadJobCtx {
             builder_ctx: Arc::clone(builder_ctx),

--- a/crates/op-rbuilder/src/launcher.rs
+++ b/crates/op-rbuilder/src/launcher.rs
@@ -4,17 +4,14 @@ use tracing::info;
 
 use crate::{
     args::*,
-    backrun_bundle::{
-        BackrunBundleApiServer, BackrunBundleRpc, maintain_backrun_bundle_pool_future,
-    },
+    backrun_bundle::{BackrunBundleApiServer, BackrunBundleRpc},
     builder::{BuilderConfig, FlashblocksServiceBuilder},
     metrics::{VERSION, record_flag_gauge_metrics},
     monitor_tx_pool::monitor_tx_pool,
-    pool::FlashpoolBuilder,
+    pool::{FlashpoolBuilder, FlashpoolExt},
     revert_protection::{EthApiExtServer, RevertProtectionExt},
 };
 use reth::builder::{NodeBuilder, WithLaunchContext};
-use reth_chain_state::CanonStateSubscriptions;
 use reth_cli_commands::launcher::Launcher;
 use reth_db::mdbx::DatabaseEnv;
 use reth_optimism_chainspec::OpChainSpec;
@@ -91,9 +88,6 @@ impl Launcher<OpChainSpecParser, OpRbuilderArgs> for BuilderLauncher {
         let gas_limit_config = builder_config.gas_limit_config.clone();
         let rollup_args = &builder_args.rollup_args;
         let op_node = OpNode::new(rollup_args.clone());
-        let backrun_bundle_enabled = builder_args.backrun_bundle.backruns_enabled;
-        let backrun_bundle_pool = builder_config.backrun_bundle_pool.clone();
-        let backrun_bundle_pool_maintain = backrun_bundle_pool.clone();
 
         let addons: OpAddOns<_, OpEthApiBuilder, OpEngineValidatorBuilder> =
             OpAddOnsBuilder::default()
@@ -125,9 +119,9 @@ impl Launcher<OpChainSpecParser, OpRbuilderArgs> for BuilderLauncher {
                         .add_or_replace_configured(revert_protection_ext.into_rpc())?;
                 }
 
-                if builder_args.backrun_bundle.backruns_enabled {
+                if let Some(backrun_bundle_pool) = ctx.pool().backrun_bundle_pool() {
                     let backrun_rpc = BackrunBundleRpc::new(
-                        backrun_bundle_pool.clone(),
+                        backrun_bundle_pool,
                         ctx.provider().clone(),
                         builder_args
                             .backrun_bundle
@@ -147,17 +141,6 @@ impl Launcher<OpChainSpecParser, OpRbuilderArgs> for BuilderLauncher {
                     let task =
                         monitor_tx_pool(listener, builder_args.enable_tx_tracking_debug_logs);
                     ctx.task_executor.spawn_critical_task("txlogging", task);
-                }
-
-                if backrun_bundle_enabled {
-                    let chain_events = ctx.provider.canonical_state_stream();
-                    let task_executor = ctx.task_executor.clone();
-                    ctx.task_executor
-                        .spawn_task(maintain_backrun_bundle_pool_future(
-                            backrun_bundle_pool_maintain,
-                            chain_events,
-                            task_executor,
-                        ));
                 }
 
                 Ok(())

--- a/crates/op-rbuilder/src/pool/builder.rs
+++ b/crates/op-rbuilder/src/pool/builder.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use alloy_primitives::TxHash;
-use futures::{FutureExt, StreamExt};
+use futures::{FutureExt, Stream, StreamExt};
 use moka::sync::Cache;
 use reth_chain_state::CanonStateSubscriptions;
 use reth_evm::ConfigureEvm;
@@ -13,7 +13,9 @@ use reth_optimism_forks::OpHardforks;
 use reth_optimism_node::OpPoolBuilder;
 use reth_optimism_txpool::{OpPooledTx, OpTransactionPool, OpTransactionValidator};
 use reth_primitives_traits::{Block, NodePrimitives};
-use reth_provider::{BlockReaderIdExt, ChainSpecProvider, NodePrimitivesProvider};
+use reth_provider::{
+    BlockReaderIdExt, CanonStateNotification, ChainSpecProvider, NodePrimitivesProvider,
+};
 use reth_tasks::TaskExecutor;
 use reth_transaction_pool::{
     AllTransactionsEvents, EthPoolTransaction, FullTransactionEvent, TransactionPool,
@@ -22,6 +24,9 @@ use reth_transaction_pool::{
 
 use crate::{
     args::OpRbuilderArgs,
+    backrun_bundle::{
+        BackrunBundleArgs, BackrunBundleGlobalPool, maintain_backrun_bundle_pool_future,
+    },
     pool::{
         Flashpool,
         metrics::PoolMetrics,
@@ -36,6 +41,8 @@ pub struct FlashpoolBuilder {
     enable_revert_protection: bool,
     pre_simulate_bundles: bool,
     block_time_secs: u64,
+
+    backrun_bundle_args: BackrunBundleArgs,
 }
 
 impl FlashpoolBuilder {
@@ -51,9 +58,9 @@ impl FlashpoolBuilder {
         Self {
             op_pool_builder,
             enable_revert_protection: builder_args.enable_revert_protection,
-
             pre_simulate_bundles: builder_args.pre_simulate_bundles,
             block_time_secs: builder_args.chain_block_time / 1000,
+            backrun_bundle_args: builder_args.backrun_bundle.clone(),
         }
     }
 }
@@ -85,6 +92,7 @@ where
             enable_revert_protection,
             pre_simulate_bundles,
             block_time_secs,
+            backrun_bundle_args,
         } = self;
 
         let inner_pool = op_pool_builder.build_pool(ctx, evm_config).await?;
@@ -130,10 +138,17 @@ where
             None
         };
 
+        let backrun_bundle_pool = setup_backruns(
+            backrun_bundle_args,
+            ctx.provider().canonical_state_stream(),
+            ctx.task_executor(),
+        );
+
         Ok(Flashpool {
             inner: inner_pool,
             validator,
             simulator,
+            backrun_bundle_pool,
             task_executor: ctx.task_executor().clone(),
             reverted_cache,
             metrics,
@@ -164,4 +179,30 @@ fn setup_revert_protection(
     });
 
     reverted_cache
+}
+
+fn setup_backruns<N, St>(
+    backrun_bundle_args: BackrunBundleArgs,
+    events: St,
+    task_executor: &TaskExecutor,
+) -> Option<BackrunBundleGlobalPool>
+where
+    N: NodePrimitives,
+    St: Stream<Item = CanonStateNotification<N>> + Send + Unpin + 'static,
+{
+    if !backrun_bundle_args.backruns_enabled {
+        return None;
+    }
+
+    let backrun_bundle_pool =
+        BackrunBundleGlobalPool::new(backrun_bundle_args.enforce_strict_priority_fee_ordering);
+
+    let task_executor_clone = task_executor.clone();
+    task_executor.spawn_task(maintain_backrun_bundle_pool_future(
+        backrun_bundle_pool.clone(),
+        events,
+        task_executor_clone,
+    ));
+
+    Some(backrun_bundle_pool)
 }

--- a/crates/op-rbuilder/src/pool/mod.rs
+++ b/crates/op-rbuilder/src/pool/mod.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use reth_tasks::TaskExecutor;
 
 use crate::{
+    backrun_bundle::BackrunBundleGlobalPool,
     pool::{metrics::PoolMetrics, presim::TopOfBlockSimulator},
     tx::FBPooledTransaction,
 };
@@ -29,6 +30,9 @@ pub struct Flashpool<P, V> {
     /// Optional pre-simulator: when present, revert-protected txs are simulated
     /// before being added to the pool; those that would revert are rejected.
     simulator: Option<Arc<TopOfBlockSimulator>>,
+
+    /// Global pool for backrun bundles
+    backrun_bundle_pool: Option<BackrunBundleGlobalPool>,
 
     /// Task executor for spawning presim tasks
     task_executor: TaskExecutor,
@@ -46,6 +50,8 @@ pub trait FlashpoolExt {
     /// Checks if a transaction is reverted by checking if the given transaction
     /// hash is present in the reverted cache.
     fn is_tx_reverted(&self, hash: TxHash) -> bool;
+
+    fn backrun_bundle_pool(&self) -> Option<BackrunBundleGlobalPool>;
 }
 
 impl<P: TransactionPool<Transaction = FBPooledTransaction>, V> FlashpoolExt for Flashpool<P, V> {
@@ -53,5 +59,9 @@ impl<P: TransactionPool<Transaction = FBPooledTransaction>, V> FlashpoolExt for 
         self.reverted_cache
             .as_ref()
             .is_some_and(|cache| cache.get(&hash).is_some())
+    }
+
+    fn backrun_bundle_pool(&self) -> Option<BackrunBundleGlobalPool> {
+        self.backrun_bundle_pool.clone()
     }
 }

--- a/crates/op-rbuilder/src/tests/framework/instance.rs
+++ b/crates/op-rbuilder/src/tests/framework/instance.rs
@@ -2,7 +2,7 @@ use crate::{
     args::OpRbuilderArgs,
     backrun_bundle::{BackrunBundleApiServer, BackrunBundleRpc},
     builder::{BuilderConfig, FlashblocksServiceBuilder},
-    pool::FlashpoolBuilder,
+    pool::{FlashpoolBuilder, FlashpoolExt},
     revert_protection::{EthApiExtServer, RevertProtectionExt},
     tests::{
         EngineApi, Ipc, TEE_DEBUG_ADDRESS, TransactionPoolObserver, builder_signer, create_test_db,
@@ -109,7 +109,6 @@ impl LocalInstance {
             .expect("Failed to convert rollup args to builder config");
         let da_config = builder_config.da_config.clone();
         let gas_limit_config = builder_config.gas_limit_config.clone();
-        let backrun_bundle_pool = builder_config.backrun_bundle_pool.clone();
         let addons: OpAddOns<_, OpEthApiBuilder, OpEngineValidatorBuilder> =
             OpAddOnsBuilder::default()
                 .with_sequencer(args.rollup_args.sequencer.clone())
@@ -142,10 +141,9 @@ impl LocalInstance {
                         .add_or_replace_configured(revert_protection_ext.into_rpc())?;
                 }
 
-                if args.backrun_bundle.backruns_enabled {
-                    tracing::info!("Backrun bundle RPC enabled");
+                if let Some(backrun_bundle_pool) = ctx.pool().backrun_bundle_pool() {
                     let backrun_rpc = BackrunBundleRpc::new(
-                        backrun_bundle_pool.clone(),
+                        backrun_bundle_pool,
                         ctx.provider().clone(),
                         args.backrun_bundle.enforce_strict_priority_fee_ordering,
                     );

--- a/crates/op-rbuilder/src/traits.rs
+++ b/crates/op-rbuilder/src/traits.rs
@@ -7,7 +7,7 @@ use reth_payload_util::PayloadTransactions;
 use reth_provider::{BlockReaderIdExt, ChainSpecProvider, StateProviderFactory};
 use reth_transaction_pool::TransactionPool;
 
-use crate::tx::FBPooledTransaction;
+use crate::{pool::FlashpoolExt, tx::FBPooledTransaction};
 
 pub trait NodeBounds:
     FullNodeTypes<
@@ -45,10 +45,13 @@ impl<T> NodeComponents for T where
 {
 }
 
-pub trait PoolBounds: TransactionPool<Transaction = FBPooledTransaction> + Unpin + 'static {}
+pub trait PoolBounds:
+    TransactionPool<Transaction = FBPooledTransaction> + FlashpoolExt + Unpin + 'static
+{
+}
 
 impl<T> PoolBounds for T where
-    T: TransactionPool<Transaction = FBPooledTransaction> + Unpin + 'static
+    T: TransactionPool<Transaction = FBPooledTransaction> + FlashpoolExt + Unpin + 'static
 {
 }
 


### PR DESCRIPTION
Backrun pool moved into our own pool, further work will have to be done to limit the api surface exposed instead of just having a method to return the backrun pool