### PR TITLE
feat(presim): limit max concurrency

### DIFF
--- a/crates/op-rbuilder/src/args/op.rs
+++ b/crates/op-rbuilder/src/args/op.rs
@@ -72,6 +72,14 @@ pub struct OpRbuilderArgs {
     )]
     pub pre_simulate_bundles: bool,
 
+    /// The maximum number of concurrent presim tasks to run.
+    #[arg(
+        long = "builder.presim-max-concurrent",
+        default_value = "4",
+        env = "PRESIM_MAX_CONCURRENT"
+    )]
+    pub presim_max_concurrent: usize,
+
     /// Enables logs to trace transaction lifecycle as it is added to the
     /// mempool and added to a block. Requires `RUST_LOG=tx_trace=debug` in
     /// addition to this flag.

--- a/crates/op-rbuilder/src/args/op.rs
+++ b/crates/op-rbuilder/src/args/op.rs
@@ -15,7 +15,7 @@ use anyhow::{Result, anyhow};
 use clap::Parser;
 use reth_optimism_cli::commands::Commands;
 use reth_optimism_node::args::RollupArgs;
-use std::path::PathBuf;
+use std::{num::NonZeroUsize, path::PathBuf};
 
 /// Parameters for rollup configuration
 #[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
@@ -72,13 +72,10 @@ pub struct OpRbuilderArgs {
     )]
     pub pre_simulate_bundles: bool,
 
-    /// The maximum number of concurrent presim tasks to run.
-    #[arg(
-        long = "builder.presim-max-concurrent",
-        default_value = "4",
-        env = "PRESIM_MAX_CONCURRENT"
-    )]
-    pub presim_max_concurrent: usize,
+    /// The maximum number of concurrent presim tasks to run. If omitted,
+    /// concurrency will be unbounded.
+    #[arg(long = "builder.presim-max-concurrent", env = "PRESIM_MAX_CONCURRENT")]
+    pub presim_max_concurrent: Option<NonZeroUsize>,
 
     /// Enables logs to trace transaction lifecycle as it is added to the
     /// mempool and added to a block. Requires `RUST_LOG=tx_trace=debug` in

--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -325,3 +325,27 @@ impl VersionInfo {
         gauge.set(1);
     }
 }
+
+#[must_use = "dropping the guard decrements the gauge"]
+pub struct GaugeIncrementGuard {
+    gauge: Gauge,
+}
+
+pub trait GaugeExt {
+    fn increment_guard(&self) -> GaugeIncrementGuard;
+}
+
+impl GaugeExt for Gauge {
+    fn increment_guard(&self) -> GaugeIncrementGuard {
+        self.increment(1);
+        GaugeIncrementGuard {
+            gauge: self.clone(),
+        }
+    }
+}
+
+impl Drop for GaugeIncrementGuard {
+    fn drop(&mut self) {
+        self.gauge.decrement(1);
+    }
+}

--- a/crates/op-rbuilder/src/pool/builder.rs
+++ b/crates/op-rbuilder/src/pool/builder.rs
@@ -40,6 +40,7 @@ pub struct FlashpoolBuilder {
 
     enable_revert_protection: bool,
     pre_simulate_bundles: bool,
+    presim_max_concurrent: usize,
     block_time_secs: u64,
 
     backrun_bundle_args: BackrunBundleArgs,
@@ -59,6 +60,7 @@ impl FlashpoolBuilder {
             op_pool_builder,
             enable_revert_protection: builder_args.enable_revert_protection,
             pre_simulate_bundles: builder_args.pre_simulate_bundles,
+            presim_max_concurrent: builder_args.presim_max_concurrent,
             block_time_secs: builder_args.chain_block_time / 1000,
             backrun_bundle_args: builder_args.backrun_bundle.clone(),
         }
@@ -91,6 +93,7 @@ where
             op_pool_builder,
             enable_revert_protection,
             pre_simulate_bundles,
+            presim_max_concurrent,
             block_time_secs,
             backrun_bundle_args,
         } = self;
@@ -106,7 +109,7 @@ where
         let metrics = Arc::new(PoolMetrics::default());
 
         let simulator = if pre_simulate_bundles {
-            let simulator = Arc::new(TopOfBlockSimulator::new());
+            let simulator = Arc::new(TopOfBlockSimulator::new(presim_max_concurrent));
 
             let chain_events = ctx.provider().canonical_state_stream();
             let op_evm_config = OpEvmConfig::optimism(ctx.provider().chain_spec());

--- a/crates/op-rbuilder/src/pool/builder.rs
+++ b/crates/op-rbuilder/src/pool/builder.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{num::NonZeroUsize, sync::Arc};
 
 use alloy_primitives::TxHash;
 use futures::{FutureExt, Stream, StreamExt};
@@ -40,7 +40,7 @@ pub struct FlashpoolBuilder {
 
     enable_revert_protection: bool,
     pre_simulate_bundles: bool,
-    presim_max_concurrent: usize,
+    presim_max_concurrent: Option<NonZeroUsize>,
     block_time_secs: u64,
 
     backrun_bundle_args: BackrunBundleArgs,

--- a/crates/op-rbuilder/src/pool/builder.rs
+++ b/crates/op-rbuilder/src/pool/builder.rs
@@ -109,7 +109,10 @@ where
         let metrics = Arc::new(PoolMetrics::default());
 
         let simulator = if pre_simulate_bundles {
-            let simulator = Arc::new(TopOfBlockSimulator::new(presim_max_concurrent));
+            let simulator = Arc::new(TopOfBlockSimulator::new(
+                presim_max_concurrent,
+                metrics.clone(),
+            ));
 
             let chain_events = ctx.provider().canonical_state_stream();
             let op_evm_config = OpEvmConfig::optimism(ctx.provider().chain_spec());

--- a/crates/op-rbuilder/src/pool/metrics.rs
+++ b/crates/op-rbuilder/src/pool/metrics.rs
@@ -1,4 +1,4 @@
-use metrics::{Counter, Histogram, counter};
+use metrics::{Counter, Gauge, Histogram, counter};
 use reth_metrics::Metrics;
 
 #[derive(Metrics, Clone)]
@@ -10,6 +10,14 @@ pub(super) struct PoolMetrics {
     pub presim_tip_state_updates: Counter,
     /// Number of pending txs evicted due to failing top of block simulation
     pub presim_pending_evictions: Counter,
+    /// Number of presim tasks waiting for a concurrency permit.
+    pub presim_waiting: Gauge,
+    /// Number of presim tasks currently executing.
+    pub presim_in_flight: Gauge,
+    /// Histogram of time spent waiting for a presim concurrency permit.
+    pub presim_wait_duration: Histogram,
+    /// Configured maximum number of concurrent presim tasks.
+    pub presim_concurrency_limit: Gauge,
 }
 
 pub(super) fn increment_presim_count(sim_result: &eyre::Result<bool>) {

--- a/crates/op-rbuilder/src/pool/presim.rs
+++ b/crates/op-rbuilder/src/pool/presim.rs
@@ -36,6 +36,7 @@ pub(crate) struct TopOfBlockSimulator {
 }
 
 /// Holds a concurrency permit when presim limiting is enabled.
+#[derive(derive_more::IsVariant)]
 enum PresimPermit {
     Limited { _permit: OwnedSemaphorePermit },
     Unlimited,
@@ -290,6 +291,8 @@ pub(crate) async fn maintain_pending_simulations<Pool, St>(
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
     use alloy_consensus::{SignableTransaction, TxEip1559};
     use alloy_evm::EvmEnv;
@@ -475,5 +478,42 @@ mod tests {
 
         // Same nonce=0 tx should still succeed — state wasn't persisted
         assert!(tip_state.run_simulation(simple_transfer(&signer, 0)));
+    }
+
+    #[tokio::test]
+    async fn presim_limits_concurrent_tasks() {
+        let simulator = Arc::new(TopOfBlockSimulator::new(
+            NonZeroUsize::new(2),
+            Arc::new(PoolMetrics::default()),
+        ));
+
+        let first = simulator.acquire_permit().await.unwrap();
+        let _second = simulator.acquire_permit().await.unwrap();
+
+        let blocked = tokio::spawn({
+            let simulator = simulator.clone();
+            async move { simulator.acquire_permit().await.unwrap() }
+        });
+
+        tokio::task::yield_now().await;
+        assert!(
+            !blocked.is_finished(),
+            "third task incorrectly acquired a permit"
+        );
+
+        drop(first);
+
+        let third = tokio::time::timeout(Duration::from_millis(100), blocked)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(third.is_limited())
+    }
+
+    #[tokio::test]
+    async fn presim_unlimited_concurrency() {
+        let simulator = TopOfBlockSimulator::new_for_test();
+
+        assert!(simulator.acquire_permit().await.unwrap().is_unlimited());
     }
 }

--- a/crates/op-rbuilder/src/pool/presim.rs
+++ b/crates/op-rbuilder/src/pool/presim.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Instant};
+use std::{num::NonZeroUsize, sync::Arc, time::Instant};
 
 use alloy_consensus::{BlockHeader, Header};
 use alloy_evm::{Evm, InvalidTxError};
@@ -31,8 +31,14 @@ use crate::{
 /// reverting transactions before they enter the pool.
 pub(crate) struct TopOfBlockSimulator {
     tip_state: RwLock<Arc<Option<TipState>>>,
-    permits: Arc<Semaphore>,
+    permits: Option<Arc<Semaphore>>,
     metrics: Arc<PoolMetrics>,
+}
+
+/// Holds a concurrency permit when presim limiting is enabled.
+enum PresimPermit {
+    Limited { _permit: OwnedSemaphorePermit },
+    Unlimited,
 }
 
 impl std::fmt::Debug for TopOfBlockSimulator {
@@ -48,11 +54,15 @@ pub(crate) struct TipState {
 }
 
 impl TopOfBlockSimulator {
-    pub(crate) fn new(max_concurrent: usize, metrics: Arc<PoolMetrics>) -> Self {
-        metrics.presim_concurrency_limit.set(max_concurrent as f64);
+    pub(crate) fn new(max_concurrent: Option<NonZeroUsize>, metrics: Arc<PoolMetrics>) -> Self {
+        let permits = max_concurrent.map(|limit| {
+            metrics.presim_concurrency_limit.set(limit.get() as f64);
+            Arc::new(Semaphore::new(limit.get()))
+        });
+
         Self {
             tip_state: RwLock::new(Arc::new(None)),
-            permits: Arc::new(Semaphore::new(max_concurrent)),
+            permits,
             metrics,
         }
     }
@@ -61,7 +71,7 @@ impl TopOfBlockSimulator {
     fn new_for_test() -> Self {
         Self {
             tip_state: RwLock::new(Arc::new(None)),
-            permits: Arc::new(Semaphore::new(1)),
+            permits: None,
             metrics: Arc::new(PoolMetrics::default()),
         }
     }
@@ -82,12 +92,15 @@ impl TopOfBlockSimulator {
         .wrap_err("simulate tx task panicked")
     }
 
-    async fn acquire_permit(&self) -> eyre::Result<OwnedSemaphorePermit> {
+    async fn acquire_permit(&self) -> eyre::Result<PresimPermit> {
+        let Some(permits) = self.permits.clone() else {
+            return Ok(PresimPermit::Unlimited);
+        };
+
         let wait_start = Instant::now();
         let _waiting = self.metrics.presim_waiting.increment_guard();
 
-        let permit = self
-            .permits
+        let permit = permits
             .clone()
             .acquire_owned()
             .await
@@ -97,7 +110,7 @@ impl TopOfBlockSimulator {
             .presim_wait_duration
             .record(wait_start.elapsed());
 
-        Ok(permit)
+        Ok(PresimPermit::Limited { _permit: permit })
     }
 
     pub(crate) fn simulate_tx_sync(&self, tx: impl IntoTxEnv<OpTransaction<TxEnv>>) -> bool {

--- a/crates/op-rbuilder/src/pool/presim.rs
+++ b/crates/op-rbuilder/src/pool/presim.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Instant};
 
 use alloy_consensus::{BlockHeader, Header};
 use alloy_evm::{Evm, InvalidTxError};
@@ -20,16 +20,19 @@ use revm::{
     context::{TxEnv, result::ResultAndState},
     context_interface::result::InvalidTransaction,
 };
-use tokio::sync::Semaphore;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tracing::{debug, error, warn};
 
-use crate::{evm::OpBlockEvmFactory, pool::metrics::PoolMetrics, tx::FBPooledTransaction};
+use crate::{
+    evm::OpBlockEvmFactory, metrics::GaugeExt, pool::metrics::PoolMetrics, tx::FBPooledTransaction,
+};
 
 /// Pre-simulates transactions against the current head state to filter out
 /// reverting transactions before they enter the pool.
 pub(crate) struct TopOfBlockSimulator {
     tip_state: RwLock<Arc<Option<TipState>>>,
     permits: Arc<Semaphore>,
+    metrics: Arc<PoolMetrics>,
 }
 
 impl std::fmt::Debug for TopOfBlockSimulator {
@@ -45,10 +48,21 @@ pub(crate) struct TipState {
 }
 
 impl TopOfBlockSimulator {
-    pub(crate) fn new(max_concurrent: usize) -> Self {
+    pub(crate) fn new(max_concurrent: usize, metrics: Arc<PoolMetrics>) -> Self {
+        metrics.presim_concurrency_limit.set(max_concurrent as f64);
         Self {
             tip_state: RwLock::new(Arc::new(None)),
             permits: Arc::new(Semaphore::new(max_concurrent)),
+            metrics,
+        }
+    }
+
+    #[cfg(test)]
+    fn new_for_test() -> Self {
+        Self {
+            tip_state: RwLock::new(Arc::new(None)),
+            permits: Arc::new(Semaphore::new(1)),
+            metrics: Arc::new(PoolMetrics::default()),
         }
     }
 
@@ -56,6 +70,22 @@ impl TopOfBlockSimulator {
         self: Arc<Self>,
         tx: Recovered<OpTransactionSigned>,
     ) -> eyre::Result<bool> {
+        let permit = self.acquire_permit().await?;
+
+        let in_flight = self.metrics.presim_in_flight.increment_guard();
+        tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            let _in_flight = in_flight;
+            self.simulate_tx_sync(tx)
+        })
+        .await
+        .wrap_err("simulate tx task panicked")
+    }
+
+    async fn acquire_permit(&self) -> eyre::Result<OwnedSemaphorePermit> {
+        let wait_start = Instant::now();
+        let _waiting = self.metrics.presim_waiting.increment_guard();
+
         let permit = self
             .permits
             .clone()
@@ -63,12 +93,11 @@ impl TopOfBlockSimulator {
             .await
             .wrap_err("presim semaphore closed")?;
 
-        tokio::task::spawn_blocking(move || {
-            let _permit = permit;
-            self.simulate_tx_sync(tx)
-        })
-        .await
-        .wrap_err("simulate tx task panicked")
+        self.metrics
+            .presim_wait_duration
+            .record(wait_start.elapsed());
+
+        Ok(permit)
     }
 
     pub(crate) fn simulate_tx_sync(&self, tx: impl IntoTxEnv<OpTransaction<TxEnv>>) -> bool {
@@ -401,7 +430,7 @@ mod tests {
 
     #[test]
     fn no_tip_state_passes_through() {
-        let simulator = TopOfBlockSimulator::new(1);
+        let simulator = TopOfBlockSimulator::new_for_test();
         let signer = PrivateKeySigner::random();
         let tx = simple_transfer(&signer, 0);
 
@@ -410,7 +439,7 @@ mod tests {
 
     #[test]
     fn update_tip_makes_simulation_available() {
-        let simulator = TopOfBlockSimulator::new(1);
+        let simulator = TopOfBlockSimulator::new_for_test();
         let signer = PrivateKeySigner::random();
         let provider = funded_provider(signer.address());
 

--- a/crates/op-rbuilder/src/pool/presim.rs
+++ b/crates/op-rbuilder/src/pool/presim.rs
@@ -20,6 +20,7 @@ use revm::{
     context::{TxEnv, result::ResultAndState},
     context_interface::result::InvalidTransaction,
 };
+use tokio::sync::Semaphore;
 use tracing::{debug, error, warn};
 
 use crate::{evm::OpBlockEvmFactory, pool::metrics::PoolMetrics, tx::FBPooledTransaction};
@@ -28,6 +29,7 @@ use crate::{evm::OpBlockEvmFactory, pool::metrics::PoolMetrics, tx::FBPooledTran
 /// reverting transactions before they enter the pool.
 pub(crate) struct TopOfBlockSimulator {
     tip_state: RwLock<Arc<Option<TipState>>>,
+    permits: Arc<Semaphore>,
 }
 
 impl std::fmt::Debug for TopOfBlockSimulator {
@@ -43,9 +45,10 @@ pub(crate) struct TipState {
 }
 
 impl TopOfBlockSimulator {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(max_concurrent: usize) -> Self {
         Self {
             tip_state: RwLock::new(Arc::new(None)),
+            permits: Arc::new(Semaphore::new(max_concurrent)),
         }
     }
 
@@ -53,9 +56,19 @@ impl TopOfBlockSimulator {
         self: Arc<Self>,
         tx: Recovered<OpTransactionSigned>,
     ) -> eyre::Result<bool> {
-        tokio::task::spawn_blocking(move || self.simulate_tx_sync(tx))
+        let permit = self
+            .permits
+            .clone()
+            .acquire_owned()
             .await
-            .wrap_err("simulate tx task panicked")
+            .wrap_err("presim semaphore closed")?;
+
+        tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            self.simulate_tx_sync(tx)
+        })
+        .await
+        .wrap_err("simulate tx task panicked")
     }
 
     pub(crate) fn simulate_tx_sync(&self, tx: impl IntoTxEnv<OpTransaction<TxEnv>>) -> bool {
@@ -388,7 +401,7 @@ mod tests {
 
     #[test]
     fn no_tip_state_passes_through() {
-        let simulator = TopOfBlockSimulator::new();
+        let simulator = TopOfBlockSimulator::new(1);
         let signer = PrivateKeySigner::random();
         let tx = simple_transfer(&signer, 0);
 
@@ -397,7 +410,7 @@ mod tests {
 
     #[test]
     fn update_tip_makes_simulation_available() {
-        let simulator = TopOfBlockSimulator::new();
+        let simulator = TopOfBlockSimulator::new(1);
         let signer = PrivateKeySigner::random();
         let provider = funded_provider(signer.address());
 


### PR DESCRIPTION
## 📝 Summary
Simple presim concurrency limiting using a semaphore. Configurable via the `--builder.presim-max-concurrent` flag.

## 💡 Motivation and Context
We want to limit the max number of presim tasks running so we don't starve the tokio executor.

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
