### PR TITLE
feat: add reverted_tx_count counter metric

### DIFF
--- a/crates/op-rbuilder/src/builder/context.rs
+++ b/crates/op-rbuilder/src/builder/context.rs
@@ -513,6 +513,7 @@ impl OpPayloadJobCtx {
                 num_txs_simulated_fail += 1;
                 reverted_gas_used += gas_used;
                 self.metrics.reverted_tx_gas_used.record(gas_used as f64);
+                self.metrics.reverted_tx_count.increment(1);
                 if is_bundle_tx {
                     num_bundles_reverted += 1;
                 }
@@ -763,6 +764,7 @@ impl OpPayloadJobCtx {
                         num_bundles_reverted += 1;
                         reverted_gas_used += br_gas_used;
                         self.metrics.reverted_tx_gas_used.record(br_gas_used as f64);
+                        self.metrics.reverted_tx_count.increment(1);
                         log_br_txn(TxnExecutionResult::RevertedAndExcluded);
                         continue;
                     }

--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -137,6 +137,8 @@ pub struct OpRBuilderMetrics {
     pub successful_tx_gas_used: Histogram,
     /// Histogram of gas used by reverted transactions
     pub reverted_tx_gas_used: Histogram,
+    /// Cumulative count of reverted transactions observed during payload building.
+    pub reverted_tx_count: Counter,
     /// Gas used by reverted transactions in the latest block
     pub payload_reverted_tx_gas_used: Gauge,
     /// Histogram of tx simulation duration


### PR DESCRIPTION
Replaces the per-tx `skipping reverted transaction` log (already at `trace!`) with an explicit `op_rbuilder_reverted_tx_count` Counter so reverted-tx volume is observable without flooding logs.