### PR TITLE
fix flashblock uncompressed limit check and presim error handling

### DIFF
--- a/crates/op-rbuilder/src/builder/payload_handler.rs
+++ b/crates/op-rbuilder/src/builder/payload_handler.rs
@@ -423,7 +423,7 @@ fn execute_transactions(
         }
 
         let tx_uncompressed_size = tx_recovered.encode_2718_len() as u64;
-        let _new_cumulative_uncompressed = info
+        let new_cumulative_uncompressed = info
             .cumulative_uncompressed_bytes
             .checked_add(tx_uncompressed_size)
             .ok_or_else(|| {
@@ -432,7 +432,7 @@ fn execute_transactions(
                 )
             })?;
         if let Some(limit) = max_uncompressed_block_size
-            && info.cumulative_uncompressed_bytes > limit
+            && new_cumulative_uncompressed > limit
         {
             bail!("flashblock exceeded max uncompressed block size when executing transactions");
         }

--- a/crates/op-rbuilder/src/pool/overrides.rs
+++ b/crates/op-rbuilder/src/pool/overrides.rs
@@ -57,9 +57,6 @@ impl<
                     Ok(false) => {}
                     Err(e) => {
                         error!(tx_hash = %tx_hash, error = %e, "pre-simulation task failed");
-                        let _ = inner_pool
-                            .add_transaction(origin, transaction.into_transaction())
-                            .await;
                     }
                 }
                 metrics.presim_duration.record(sim_start.elapsed());


### PR DESCRIPTION
hey team, mooncitydev here. was reading through the flashblock sync path and the revert-protected pool flow and found two things that looked wrong.

first, `execute_transactions` in `payload_handler.rs` (the path that re-executes flashblocks received over p2p) was checking `max_uncompressed_block_size` against `info.cumulative_uncompressed_bytes` *before* counting the tx being validated. it already computed `checked_add(tx_uncompressed_size)` into `_new_cumulative_uncompressed` but never used it. gas limit in the same loop does it the right way (`new_cumulative_gas > gas_limit`). so you could accept an external flashblock that blows past the uncompressed cap as long as the previous total was still under. main builder path uses `cumulative + tx_size > limit` in `ExecutionInfo::validate_tx`, this sync path just didn't.

second, in `pool/overrides.rs`, when presim returns `Err` for a revert-protected tx, we logged and still called `inner_pool.add_transaction`. `Ok(false)` correctly skips the tx; `Err` was effectively fail-open. if the simulator rpc is flaky you could end up with txs in the pool that would have been dropped on a clean `Ok(false)`. now presim errors leave the tx out (same as a simulated revert).

## test plan
- [x] ci on flashbots/op-rbuilder
- [x] if you run with `--builder.max-uncompressed-block-size`, try syncing an external flashblock near the size cap and confirm it rejects when the last tx would push over
- [ ] revert-protected submit with presim temporarily broken should not land the tx in the pool