### PR TITLE
chore: update rust to version 1.96

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 version = "0.4.6"
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.96"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/flashbots/op-rbuilder"
 repository = "https://github.com/flashbots/op-rbuilder"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 ARG FEATURES
 ARG RBUILDER_BIN="op-rbuilder"
 
-FROM rust:1.94-bookworm AS base
+FROM rust:1.96-bookworm AS base
 ARG TARGETPLATFORM
 
 RUN apt-get update \

--- a/crates/op-rbuilder/src/backrun_bundle/global_pool.rs
+++ b/crates/op-rbuilder/src/backrun_bundle/global_pool.rs
@@ -230,6 +230,7 @@ mod tests {
     use crate::tx_signer::Signer;
     use alloy_primitives::{B256, U256};
     use reth_optimism_primitives::OpTransactionSigned;
+    use std::assert_matches;
 
     fn pool_bundle_count(pool: &BackrunBundlePayloadPool) -> usize {
         pool.per_tx_bundle_counts().sum()
@@ -441,9 +442,9 @@ mod tests {
         assert!(gp.cancel_bundle(uuid, bundle_replacement_nonce + 3, 25));
         assert!(!gp.cancel_bundle(uuid, bundle_replacement_nonce + 2, 30));
         assert!(!gp.cancel_bundle(uuid, bundle_replacement_nonce + 3, 30));
-        assert!(matches!(
+        assert_matches!(
             gp.inner.replacements.get(&uuid).as_deref(),
             Some(&UuidEntry::Cancellation { nonce, max_block: 25 }) if nonce == bundle_replacement_nonce + 3
-        ));
+        );
     }
 }

--- a/crates/op-rbuilder/src/limiter/mod.rs
+++ b/crates/op-rbuilder/src/limiter/mod.rs
@@ -225,6 +225,7 @@ impl Drop for AddressLimiterGuard {
 mod tests {
     use super::*;
     use alloy_primitives::Address;
+    use std::assert_matches;
 
     fn create_test_config(max_gas: u64, refill_rate: u64, cleanup_interval: u64) -> GasLimiterArgs {
         GasLimiterArgs {
@@ -349,7 +350,7 @@ mod tests {
         limiter.refill_buckets(1);
 
         let err = guard.commit().expect_err("must reject stale commit");
-        assert!(matches!(err, CommitError::StaleEpoch { .. }));
+        assert_matches!(err, CommitError::StaleEpoch { .. });
     }
 
     #[test]

--- a/crates/op-rbuilder/src/primitives/bundle.rs
+++ b/crates/op-rbuilder/src/primitives/bundle.rs
@@ -145,6 +145,7 @@ pub enum BundleConditionalError {
     FlashblockMinGreaterThanMax { min: u64, max: u64 },
 }
 
+#[derive(Debug)]
 pub struct BundleConditional {
     pub transaction_conditional: TransactionConditional,
     pub min_flashblock_number: Option<u64>,
@@ -242,6 +243,7 @@ pub struct BundleResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
 
     #[test]
     fn test_bundle_conditional_no_bounds() {
@@ -292,13 +294,13 @@ mod tests {
         let last_block = 1000;
         let result = bundle.conditional(last_block);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(BundleConditionalError::MinGreaterThanMax {
                 min: 1010,
                 max: 1005
             })
-        ));
+        );
     }
 
     #[test]
@@ -311,13 +313,13 @@ mod tests {
         let last_block = 1000;
         let result = bundle.conditional(last_block);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(BundleConditionalError::MaxBlockInPast {
                 max: 999,
                 current: 1000
             })
-        ));
+        );
     }
 
     #[test]
@@ -330,14 +332,14 @@ mod tests {
         let last_block = 1000;
         let result = bundle.conditional(last_block);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(BundleConditionalError::MaxBlockTooHigh {
                 max: 1020,
                 current: 1000,
                 max_allowed: 1010
             })
-        ));
+        );
     }
 
     #[test]
@@ -350,13 +352,13 @@ mod tests {
         let last_block = 1000;
         let result = bundle.conditional(last_block);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(BundleConditionalError::MinTooHighForDefaultRange {
                 min: 1015,
                 max_allowed: 1010
             })
-        ));
+        );
     }
 
     #[test]
@@ -421,10 +423,10 @@ mod tests {
         let last_block = 1000;
         let result = bundle.conditional(last_block);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(BundleConditionalError::FlashblockMinGreaterThanMax { min: 105, max: 100 })
-        ));
+        );
     }
 
     #[test]

--- a/crates/op-rbuilder/src/primitives/reth/execution.rs
+++ b/crates/op-rbuilder/src/primitives/reth/execution.rs
@@ -232,6 +232,7 @@ fn build_receipt<E: Evm>(
 #[cfg(test)]
 mod tests {
     use super::{ExecutionInfo, TxnExecutionResult};
+    use std::assert_matches;
 
     #[test]
     fn tx_limit_rejects_when_uncompressed_size_exceeds_limit() {
@@ -242,12 +243,12 @@ mod tests {
 
         let result = info.is_tx_over_limits(0, 30_000_000, None, None, 21_000, None, 50, Some(149));
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(TxnExecutionResult::BlockUncompressedSizeExceeded(
                 100, 50, 149
             ))
-        ));
+        );
     }
 
     #[test]

--- a/crates/tdx-quote-provider/Dockerfile
+++ b/crates/tdx-quote-provider/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.94 AS builder
+FROM rust:1.96 AS builder
 
 WORKDIR /app
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.94.0"
+channel = "1.96.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
use new stabilized api as well:
- https://doc.rust-lang.org/stable/std/macro.assert_matches.html