### PR TITLE
fix(continuous): metrics recording

### DIFF
--- a/crates/op-rbuilder/src/builder/continuous/candidate_loop.rs
+++ b/crates/op-rbuilder/src/builder/continuous/candidate_loop.rs
@@ -214,11 +214,9 @@ where
                     tx_tracker: base_tx_tracker.clone(),
                     result: (next_flashblock_state, new_payload, fb_payload),
                     build_duration: empty_build_duration,
-                    // The empty-baseline candidate has no pool fetch and its
-                    // assemble is not separately timed; leave both None so the
-                    // winner-only recording in advance_or_stop_published is a
-                    // no-op when this becomes the published candidate.
+                    // no pool fetch
                     transaction_pool_fetch_duration: None,
+                    // not measured for empty candidate
                     total_block_built_duration: None,
                     limiter_snapshot: ctx.address_limiter().snapshot_pending(),
                     candidates_evaluated,

--- a/crates/op-rbuilder/src/builder/continuous/candidate_loop.rs
+++ b/crates/op-rbuilder/src/builder/continuous/candidate_loop.rs
@@ -214,6 +214,12 @@ where
                     tx_tracker: base_tx_tracker.clone(),
                     result: (next_flashblock_state, new_payload, fb_payload),
                     build_duration: empty_build_duration,
+                    // The empty-baseline candidate has no pool fetch and its
+                    // assemble is not separately timed; leave both None so the
+                    // winner-only recording in advance_or_stop_published is a
+                    // no-op when this becomes the published candidate.
+                    transaction_pool_fetch_duration: None,
+                    total_block_built_duration: None,
                     limiter_snapshot: ctx.address_limiter().snapshot_pending(),
                     candidates_evaluated,
                     candidates_improved: candidates_improved + 1,
@@ -288,12 +294,6 @@ where
                 flashblock_index,
             );
             let transaction_pool_fetch_time = best_txs_start_time.elapsed();
-            ctx.metrics
-                .transaction_pool_fetch_duration
-                .record(transaction_pool_fetch_time);
-            ctx.metrics
-                .transaction_pool_fetch_gauge
-                .set(transaction_pool_fetch_time);
 
             let exec_cancelled = ctx
                 .execute_best_transactions(
@@ -359,12 +359,6 @@ where
                         .map_err(|e| eyre::eyre!("failed to assemble candidate: {e}"))
                 });
             let total_block_built_duration = total_block_built_start.elapsed();
-            ctx.metrics
-                .total_block_built_duration
-                .record(total_block_built_duration);
-            ctx.metrics
-                .total_block_built_gauge
-                .set(total_block_built_duration);
 
             candidates_evaluated += 1;
 
@@ -397,6 +391,8 @@ where
                             fb_state: sim_fb_state,
                             tx_tracker: sim_tx_tracker,
                             build_duration: candidate_build_start.elapsed(),
+                            transaction_pool_fetch_duration: Some(transaction_pool_fetch_time),
+                            total_block_built_duration: Some(total_block_built_duration),
                             result: (next_flashblock_state, new_payload, fb_payload),
                             limiter_snapshot: ctx.address_limiter().snapshot_pending(),
                             candidates_evaluated,

--- a/crates/op-rbuilder/src/builder/continuous/interval.rs
+++ b/crates/op-rbuilder/src/builder/continuous/interval.rs
@@ -85,6 +85,15 @@ where
             }
         }
 
+        // Record the wall time of the final in-flight interval. The trigger arm
+        // records via publish_and_spawn_next (before any branching), so it never
+        // reaches here. Both break arms — payload-cancel and channel-closed —
+        // drop the interval without publishing; recording here ensures the
+        // histogram captures the final (often longest) interval exactly once.
+        self.metrics()
+            .continuous_build_duration
+            .record(interval.build_start.elapsed());
+
         Ok(PayloadBuildStats::new(
             deps.payload_cancel.clone(),
             deps.span.clone(),

--- a/crates/op-rbuilder/src/builder/continuous/interval.rs
+++ b/crates/op-rbuilder/src/builder/continuous/interval.rs
@@ -85,11 +85,7 @@ where
             }
         }
 
-        // Record the wall time of the final in-flight interval. The trigger arm
-        // records via publish_and_spawn_next (before any branching), so it never
-        // reaches here. Both break arms — payload-cancel and channel-closed —
-        // drop the interval without publishing; recording here ensures the
-        // histogram captures the final (often longest) interval exactly once.
+        // Record the wall time of the final in-flight interval.
         self.metrics()
             .continuous_build_duration
             .record(interval.build_start.elapsed());

--- a/crates/op-rbuilder/src/builder/continuous/publish.rs
+++ b/crates/op-rbuilder/src/builder/continuous/publish.rs
@@ -398,6 +398,8 @@ where
             tx_tracker,
             limiter_snapshot,
             build_duration,
+            transaction_pool_fetch_duration,
+            total_block_built_duration,
             state_root_calc,
             ..
         } = candidate;
@@ -446,6 +448,21 @@ where
             .metrics
             .flashblock_build_duration
             .record(build_duration);
+        // Record pool-fetch and assemble durations for the published winner only,
+        // keeping histogram cadence comparable with the non-continuous path which
+        // samples once per flashblock. None for the empty-baseline candidate.
+        if let Some(d) = transaction_pool_fetch_duration {
+            base_state
+                .ctx
+                .metrics
+                .transaction_pool_fetch_duration
+                .record(d);
+            base_state.ctx.metrics.transaction_pool_fetch_gauge.set(d);
+        }
+        if let Some(d) = total_block_built_duration {
+            base_state.ctx.metrics.total_block_built_duration.record(d);
+            base_state.ctx.metrics.total_block_built_gauge.set(d);
+        }
 
         fb_span.record(
             "tx_count",

--- a/crates/op-rbuilder/src/builder/continuous/publish.rs
+++ b/crates/op-rbuilder/src/builder/continuous/publish.rs
@@ -103,14 +103,15 @@ where
 {
     /// Publish a candidate flashblock immediately. The context is only used for
     /// publish timing metadata, so this can run before awaiting the build task.
-    /// Returns the serialized byte size.
+    /// Returns `(byte_size, slot_offset_ms)` so the caller can include
+    /// slot_offset_ms in the fb_published tx_trace log.
     fn publish_candidate(
         &self,
         candidate: &BestCandidate,
         best_payload_tx: &watch::Sender<Option<OpBuiltPayload>>,
         fb_span: &tracing::Span,
         ctx: &OpPayloadJobCtx,
-    ) -> Result<usize, PayloadBuilderError> {
+    ) -> Result<(usize, f64), PayloadBuilderError> {
         let _publish_span = if fb_span.is_none() {
             tracing::Span::none()
         } else {
@@ -128,7 +129,7 @@ where
         let slot_offset_ms =
             compute_slot_offset_ms(ctx.attributes().timestamp(), self.config().block_time);
         record_flashblock_publish_timing(candidate.fb_state.flashblock_index(), slot_offset_ms);
-        Ok(flashblock_byte_size)
+        Ok((flashblock_byte_size, slot_offset_ms))
     }
 
     pub(super) async fn publish_and_spawn_next(
@@ -288,7 +289,7 @@ where
     ) -> Result<ControlFlow<PayloadBuildStats, FlashblockInterval>, PayloadBuilderError> {
         match outcome {
             TriggerOutcome::PublishAndAdvance | TriggerOutcome::PublishAndStop => {
-                let byte_size = self.publish_candidate(
+                let (byte_size, slot_offset_ms) = self.publish_candidate(
                     &candidate,
                     deps.best_payload_tx,
                     fb_span,
@@ -307,6 +308,7 @@ where
                     candidate_ctx,
                     candidate,
                     byte_size,
+                    slot_offset_ms,
                     candidates_evaluated,
                     candidates_improved,
                     new_fb_cancel,
@@ -382,6 +384,7 @@ where
         ctx: OpPayloadJobCtx,
         candidate: BestCandidate,
         byte_size: usize,
+        slot_offset_ms: f64,
         candidates_evaluated: u64,
         candidates_improved: u64,
         new_fb_cancel: FlashblockJobCancellation,
@@ -426,6 +429,7 @@ where
                 flashblock_index = base_state.fb_state.flashblock_index(),
                 byte_size,
                 total_txs = base_state.info.executed_transactions.len(),
+                slot_offset_ms,
                 stage = "fb_published"
             );
         }
@@ -440,17 +444,16 @@ where
             .metrics
             .flashblock_num_tx_histogram
             .record(base_state.info.executed_transactions.len() as f64);
-        // Record only the winning candidate's single-build time, so this stays
-        // comparable with the non-continuous path. The full trigger-to-trigger
-        // interval is in `continuous_build_duration`.
+        // Record only the winning candidate's single-build time.
+        // The full trigger-to-trigger interval is in `continuous_build_duration`.
         base_state
             .ctx
             .metrics
             .flashblock_build_duration
             .record(build_duration);
-        // Record pool-fetch and assemble durations for the published winner only,
-        // keeping histogram cadence comparable with the non-continuous path which
-        // samples once per flashblock. None for the empty-baseline candidate.
+
+        // Record pool-fetch and assemble durations for published winner only.
+        // None for empty-baseline candidate.
         if let Some(d) = transaction_pool_fetch_duration {
             base_state
                 .ctx

--- a/crates/op-rbuilder/src/builder/continuous/types.rs
+++ b/crates/op-rbuilder/src/builder/continuous/types.rs
@@ -79,6 +79,16 @@ pub(super) struct BestCandidate {
     pub(super) limiter_snapshot: AddressLimiterDeltas,
     /// Wall time spent building this single candidate.
     pub(super) build_duration: Duration,
+    /// Wall time to fetch the transaction pool iterator for this candidate.
+    /// `None` for the empty-baseline candidate, which has no pool fetch.
+    /// Recorded on `transaction_pool_fetch_duration` only for the published
+    /// winner, keeping cadence comparable with the non-continuous path.
+    pub(super) transaction_pool_fetch_duration: Option<Duration>,
+    /// Wall time for the assemble (state-root + seal) step of this candidate.
+    /// `None` for the empty-baseline candidate (its assemble is not separately
+    /// timed to avoid contorting the empty path).
+    /// Recorded on `total_block_built_duration` only for the published winner.
+    pub(super) total_block_built_duration: Option<Duration>,
     /// Number of candidates evaluated when this candidate became best.
     pub(super) candidates_evaluated: u64,
     /// Number of times the interval best improved including this candidate.

--- a/crates/op-rbuilder/src/builder/continuous/types.rs
+++ b/crates/op-rbuilder/src/builder/continuous/types.rs
@@ -80,14 +80,12 @@ pub(super) struct BestCandidate {
     /// Wall time spent building this single candidate.
     pub(super) build_duration: Duration,
     /// Wall time to fetch the transaction pool iterator for this candidate.
-    /// `None` for the empty-baseline candidate, which has no pool fetch.
-    /// Recorded on `transaction_pool_fetch_duration` only for the published
-    /// winner, keeping cadence comparable with the non-continuous path.
+    /// `None` for the empty-baseline candidate (no pool fetch).
+    /// Recorded only for published winner.
     pub(super) transaction_pool_fetch_duration: Option<Duration>,
     /// Wall time for the assemble (state-root + seal) step of this candidate.
-    /// `None` for the empty-baseline candidate (its assemble is not separately
-    /// timed to avoid contorting the empty path).
-    /// Recorded on `total_block_built_duration` only for the published winner.
+    /// `None` for the empty-baseline candidate.
+    /// Recorded only for published winner.
     pub(super) total_block_built_duration: Option<Duration>,
     /// Number of candidates evaluated when this candidate became best.
     pub(super) candidates_evaluated: u64,


### PR DESCRIPTION
- pool_fetch / total_block_built were recorded on every candidate iteration. Now carried on BestCandidate and recorded for only for the published winner. It should match more metrics of the non continuous path.

- continuous_build_duration was never recorded for intervals ended by payload-cancel / channel-close. But we always have a final (often long) interval in every block, that is now recorded.

- missing slot_offset_ms added in fb_published tx_trace log.
