### PR TITLE
fix: keep tx in pool when pre-simulation hits a non-transaction error

### DIFF
--- a/crates/op-rbuilder/src/pool/presim.rs
+++ b/crates/op-rbuilder/src/pool/presim.rs
@@ -184,25 +184,44 @@ impl TipState {
         let mut evm = self.evm_factory.evm(&mut state);
 
         match evm.transact(tx) {
+            // The EVM executed the transaction: keep it only if it didn't revert.
             Ok(ResultAndState { result, .. }) => result.is_success(),
             Err(err) => {
-                if err.as_invalid_tx_err().is_some_and(|err| {
-                    err.as_invalid_tx_err().is_some_and(|err| {
-                        matches!(
-                            err,
-                            InvalidTransaction::NonceTooLow { .. }
-                                | InvalidTransaction::NonceTooHigh { .. }
-                        )
-                    })
-                }) {
-                    // Nonce gap — tx may depend on pending state, let the pool handle it
-                    true
-                } else {
-                    false
+                if !err.is_invalid_tx_err() {
+                    // The simulation failed for a reason unrelated to the
+                    // transaction itself (e.g. a state-provider/database read
+                    // error). Make the failure visible; the tx is kept rather
+                    // than evicted (see `keep_tx_on_simulation_error`).
+                    warn!(error = %err, "pre-simulation failed with a non-transaction error; keeping tx");
                 }
+                keep_tx_on_simulation_error(&err)
             }
         }
     }
+}
+
+/// Decide whether a transaction whose pre-simulation returned an error should
+/// remain in the pool.
+///
+/// `Evm::transact` returns an error either because the transaction is invalid
+/// (`EvmError::InvalidTransaction`) or because of an infrastructure failure such
+/// as a state-provider/database read error. Only the former says anything about
+/// the transaction, so we evict *only* on a genuine validity error and otherwise
+/// keep the tx (fail open). A transient state-read failure (e.g. the pinned tip
+/// state being reorged out or pruned) must never silently drop a transaction the
+/// user paid to revert-protect.
+fn keep_tx_on_simulation_error<E: EvmError>(err: &E) -> bool {
+    let Some(invalid_tx) = err.as_invalid_tx_err() else {
+        // Not a transaction-validity error: keep the tx.
+        return true;
+    };
+    // A nonce gap usually means the tx depends on not-yet-applied pending state,
+    // so let the pool resolve ordering. Any other validity error means the tx
+    // can never be included, so drop it.
+    matches!(
+        invalid_tx.as_invalid_tx_err(),
+        Some(InvalidTransaction::NonceTooLow { .. } | InvalidTransaction::NonceTooHigh { .. })
+    )
 }
 
 pub(crate) async fn maintain_tip_state<N, St, Provider>(
@@ -512,5 +531,47 @@ mod tests {
         let simulator = TopOfBlockSimulator::new_for_test();
 
         assert!(simulator.acquire_permit().await.unwrap().is_unlimited());
+    }
+
+    #[test]
+    fn non_transaction_errors_keep_tx() {
+        use revm::context_interface::result::EVMError;
+
+        // A state-provider/database read failure during simulation says nothing
+        // about the transaction's validity, so the tx must be kept, not evicted.
+        // Regression: previously every non-nonce error (infrastructure errors
+        // included) was treated as a revert and evicted the tx.
+        let db_err = EVMError::<std::io::Error, InvalidTransaction>::Database(
+            std::io::Error::other("simulated state read failure"),
+        );
+        assert!(keep_tx_on_simulation_error(&db_err));
+
+        let custom_err =
+            EVMError::<std::io::Error, InvalidTransaction>::Custom("evm misconfiguration".into());
+        assert!(keep_tx_on_simulation_error(&custom_err));
+    }
+
+    #[test]
+    fn nonce_gaps_kept_other_validity_errors_evicted() {
+        use revm::context_interface::result::EVMError;
+
+        // Nonce gaps are kept — the pool resolves ordering against pending state.
+        let too_low = EVMError::<std::io::Error, InvalidTransaction>::Transaction(
+            InvalidTransaction::NonceTooLow { tx: 1, state: 5 },
+        );
+        let too_high = EVMError::<std::io::Error, InvalidTransaction>::Transaction(
+            InvalidTransaction::NonceTooHigh { tx: 9, state: 5 },
+        );
+        assert!(keep_tx_on_simulation_error(&too_low));
+        assert!(keep_tx_on_simulation_error(&too_high));
+
+        // A genuine validity error (can never be included) is evicted.
+        let no_funds = EVMError::<std::io::Error, InvalidTransaction>::Transaction(
+            InvalidTransaction::LackOfFundForMaxFee {
+                fee: Box::new(U256::from(1u64)),
+                balance: Box::new(U256::ZERO),
+            },
+        );
+        assert!(!keep_tx_on_simulation_error(&no_funds));
     }
 }


### PR DESCRIPTION
hey, its moondev. was reading through the pre-simulation path and i think this one is a real bug rather than a nitpick.

### what happens

in `crates/op-rbuilder/src/pool/presim.rs`, `run_simulation` runs a revert-protected tx through the evm against the pinned tip state and decides whether to keep it in the pool:

- `Ok(..)` => keep only if it didn't revert
- `Err(..)` => keep only if it's a `NonceTooLow`/`NonceTooHigh` (the pool can still order those), otherwise drop it

the problem is that last "otherwise drop it" branch. `evm.transact` doesn't only fail because the tx is invalid, it also fails when the state read itself fails. the tip state is pinned to a specific block (`state_by_block_hash(tip.hash_slow())`), and by the time the background sim task actually runs that block can be reorged out or pruned. that surfaces as `EVMError::Database(..)`, which isn't a nonce error, so the current code treats it like a revert and evicts the tx.

so a transient state hiccup silently drops a valid, revert-protected tx. and in the override path (`pool/overrides.rs`) the sender already got `AddedTransactionOutcome { state: Pending }` back, so from their side the tx just disappears with no error. the only trace is a `debug!("evicting reverting tx")` line, which is misleading because it never reverted.

alloy's `EvmError` trait actually spells this out in its docs: "if caller occurs a error different from `EvmError::InvalidTransaction`, it should most likely be treated as fatal error flagging some EVM misconfiguration." ie a non-`InvalidTransaction` error is not a verdict on the tx.

### the fix

only evict on a genuine `InvalidTransaction` (keeping the existing nonce-gap pass-through), and fail open on everything else with a warning so the failure is visible. behavior for real reverts and real validity errors (insufficient funds etc.) is unchanged. pulled the decision into a small `keep_tx_on_simulation_error` helper and added unit tests for the db/custom (kept), nonce (kept) and fund (evicted) cases.

### notes

i know the contributing guide likes an issue first, happy to open one if you'd prefer. also happy to adjust naming or add a metric for the fail-open case. cheers
