### PR TITLE
Bound builder tx simulation gas limit to per tx limit

### DIFF
--- a/crates/op-rbuilder/src/builder/flashblocks_builder_tx.rs
+++ b/crates/op-rbuilder/src/builder/flashblocks_builder_tx.rs
@@ -9,7 +9,7 @@ use op_alloy_rpc_types::OpTransactionRequest;
 use reth_evm::precompiles::PrecompilesMap;
 use reth_provider::StateProvider;
 use reth_revm::State;
-use revm::{DatabaseRef, inspector::NoOpInspector};
+use revm::{DatabaseRef, context_interface::Cfg as _, inspector::NoOpInspector};
 use tracing::warn;
 
 use crate::{
@@ -246,8 +246,9 @@ impl FlashblocksNumberBuilderTx {
         ctx: &BuilderTxEnv<'_>,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<SimulationSuccessResult<T>, BuilderTransactionError> {
+        let simulation_gas_limit = ctx.block_gas_limit.min(evm.cfg_env().tx_gas_limit_cap());
         let tx_req = OpTransactionRequest::default()
-            .gas_limit(ctx.block_gas_limit)
+            .gas_limit(simulation_gas_limit)
             .max_fee_per_gas(ctx.base_fee.into())
             .to(self.flashblock_number_address)
             .from(self.signer.address) // use tee key as signer for simulations

--- a/crates/op-rbuilder/src/flashtestations/builder_tx.rs
+++ b/crates/op-rbuilder/src/flashtestations/builder_tx.rs
@@ -10,7 +10,7 @@ use reth_evm::{Evm, precompiles::PrecompilesMap};
 use reth_optimism_primitives::OpTransactionSigned;
 use reth_provider::StateProvider;
 use reth_revm::{State, database::StateProviderDatabase};
-use revm::{DatabaseCommit, DatabaseRef, inspector::NoOpInspector};
+use revm::{DatabaseCommit, DatabaseRef, context_interface::Cfg as _, inspector::NoOpInspector};
 use std::sync::{Arc, atomic::AtomicBool};
 use tracing::{debug, info, warn};
 
@@ -323,8 +323,9 @@ impl FlashtestationsBuilderTx {
         ctx: &BuilderTxEnv<'_>,
         evm: &mut OpEvm<impl Database + DatabaseRef, NoOpInspector, PrecompilesMap>,
     ) -> Result<SimulationSuccessResult<T>, BuilderTransactionError> {
+        let simulation_gas_limit = ctx.block_gas_limit.min(evm.cfg_env().tx_gas_limit_cap());
         let tx_req = OpTransactionRequest::default()
-            .gas_limit(ctx.block_gas_limit)
+            .gas_limit(simulation_gas_limit)
             .max_fee_per_gas(ctx.base_fee.into())
             .to(contract_address)
             .from(self.builder_signer.address)


### PR DESCRIPTION
## Summary

Fix builder contract simulations to use a protocol-valid transaction gas limit.

flashblocks number contract and flashtestations builder tx simulations after Karst failed because the simulation request copied the full block gas limit into the transaction gas limit, this bounds to the min of per tx cap and block limit. The final signed builder tx still uses measured gas from the successful simulation, plus the existing margin.

## Why

The previous simulation path used `ctx.block_gas_limit` directly as the transaction gas limit. That worked while the block gas limit was below the per-tx cap, but after Karst there is an additional per transaction gas limit