### PR TITLE
fix: missed flashblocks at end metric

### DIFF
--- a/crates/op-rbuilder/src/builder/continuous/candidate_loop.rs
+++ b/crates/op-rbuilder/src/builder/continuous/candidate_loop.rs
@@ -24,6 +24,7 @@ use reth_provider::{
 use reth_revm::State;
 use revm::Database;
 use std::{
+    mem,
     sync::atomic::Ordering,
     time::{Duration, Instant},
 };
@@ -316,7 +317,7 @@ where
             drop(best_txs);
 
             if !sim_info.reverted_bundle_tx_hashes.is_empty() {
-                let hashes = sim_info.reverted_bundle_tx_hashes.drain(..).collect();
+                let hashes = mem::take(&mut sim_info.reverted_bundle_tx_hashes);
                 self.pool().remove_transactions(hashes);
             }
 

--- a/crates/op-rbuilder/src/builder/payload.rs
+++ b/crates/op-rbuilder/src/builder/payload.rs
@@ -37,6 +37,7 @@ use reth_revm::{
 };
 use reth_tasks::Runtime;
 use std::{
+    mem,
     ops::Deref,
     sync::{Arc, atomic::AtomicU64},
     time::{Duration, Instant},
@@ -1240,7 +1241,7 @@ where
 
         // Remove reverted bundle txs from the pool so they aren't re-simulated in future blocks
         if !info.reverted_bundle_tx_hashes.is_empty() {
-            let hashes = info.reverted_bundle_tx_hashes.drain(..).collect();
+            let hashes = mem::take(&mut info.reverted_bundle_tx_hashes);
             self.pool.remove_transactions(hashes);
         }
 

--- a/crates/op-rbuilder/src/builder/payload.rs
+++ b/crates/op-rbuilder/src/builder/payload.rs
@@ -95,7 +95,8 @@ impl BuildState {
 /// [`BuildState`] into a build task that may be cancelled.
 #[derive(Clone, Copy)]
 pub(crate) struct BuildProgress {
-    flashblock_index: u64,
+    /// Number of flashblocks built so far, excluding the index-0 fallback
+    flashblocks_built: u64,
     num_txs: usize,
     uncompressed_byte_size: u64,
 }
@@ -103,7 +104,7 @@ pub(crate) struct BuildProgress {
 impl BuildProgress {
     pub(crate) fn from_parts(fb_state: &FlashblocksState, info: &ExecutionInfo) -> Self {
         Self {
-            flashblock_index: fb_state.flashblock_index(),
+            flashblocks_built: fb_state.scheduled_flashblocks_built(),
             num_txs: info.executed_transactions.len(),
             uncompressed_byte_size: info.cumulative_uncompressed_bytes,
         }
@@ -127,7 +128,7 @@ impl<'a> JobDeps<'a> {
         PayloadBuildStats::new(
             self.payload_cancel.clone(),
             self.span.clone(),
-            progress.flashblock_index,
+            progress.flashblocks_built,
             progress.num_txs,
             progress.uncompressed_byte_size,
             target_flashblocks,
@@ -174,7 +175,8 @@ struct BuiltFlashblockOutput {
 pub(crate) struct PayloadBuildStats {
     cancellation: PayloadJobCancellation,
     span: tracing::Span,
-    flashblock_index: u64,
+    /// Flashblocks built, excluding the index-0 fallback
+    flashblocks_built: u64,
     num_txs: usize,
     uncompressed_byte_size: u64,
     target_flashblocks: u64,
@@ -267,6 +269,14 @@ impl FlashblocksState {
 
     pub(crate) fn flashblock_index(&self) -> u64 {
         self.flashblock_index
+    }
+
+    /// Number of scheduled flashblocks built so far, which excludes the index-0
+    /// fallback. `flashblock_index` is the index of the *next* flashblock to
+    /// build and only advances on a successful publish, so subtracting the
+    /// fallback's slot yields this count on every exit path.
+    fn scheduled_flashblocks_built(&self) -> u64 {
+        self.flashblock_index.saturating_sub(1)
     }
 
     pub(crate) fn target_flashblock_count(&self) -> u64 {
@@ -655,7 +665,7 @@ where
             return Ok(PayloadBuildStats::new(
                 payload_cancel,
                 span,
-                fb_state.flashblock_index(),
+                fb_state.scheduled_flashblocks_built(),
                 info.executed_transactions.len(),
                 info.cumulative_uncompressed_bytes,
                 0,
@@ -709,7 +719,7 @@ where
             return Ok(PayloadBuildStats::new(
                 payload_cancel,
                 span,
-                fb_state.flashblock_index(),
+                fb_state.scheduled_flashblocks_built(),
                 info.executed_transactions.len(),
                 info.cumulative_uncompressed_bytes,
                 0,
@@ -1355,7 +1365,7 @@ where
         let PayloadBuildStats {
             cancellation,
             span,
-            flashblock_index,
+            flashblocks_built,
             num_txs,
             uncompressed_byte_size,
             target_flashblocks,
@@ -1396,10 +1406,10 @@ where
         metrics.total_block_built_gauge.set(block_build_duration);
 
         metrics.block_built_success.increment(1);
-        metrics.flashblock_count.record(flashblock_index as f64);
+        metrics.flashblock_count.record(flashblocks_built as f64);
         metrics
             .missing_flashblocks_count
-            .increment(target_flashblocks.saturating_sub(flashblock_index));
+            .increment(target_flashblocks.saturating_sub(flashblocks_built));
         metrics
             .block_uncompressed_size
             .record(uncompressed_byte_size as f64);
@@ -1409,11 +1419,11 @@ where
             event = "build_complete",
             id = %payload_id,
             target_flashblocks,
-            flashblock_index,
+            flashblocks_built,
             "Flashblocks building complete"
         );
 
-        span.record("flashblocks_built", flashblock_index);
+        span.record("flashblocks_built", flashblocks_built);
     }
 }
 


### PR DESCRIPTION
The metric and log message at the end of flashblock building was overcounting the number of flashblocks we built by 1 because it was including the index-0 flashblock. So the metric for missed flashblocks would mistakenly show zero because we never miss more than one flashblock at the end.