### PR TITLE
fix: derive config Defaults from cli defaults

### DIFF
--- a/crates/op-rbuilder/src/args/op.rs
+++ b/crates/op-rbuilder/src/args/op.rs
@@ -49,7 +49,7 @@ pub struct OpRbuilderArgs {
     pub log_pool_transactions: bool,
 
     /// How much time extra to wait for the block building job to complete and not get garbage collected
-    /// Also refered as block time leeway
+    /// Also referred to as block time leeway
     #[arg(long = "builder.extra-block-deadline-secs", default_value = "20")]
     pub extra_block_deadline_secs: u64,
 

--- a/crates/op-rbuilder/src/args/op.rs
+++ b/crates/op-rbuilder/src/args/op.rs
@@ -49,8 +49,10 @@ pub struct OpRbuilderArgs {
     pub log_pool_transactions: bool,
 
     /// How much time extra to wait for the block building job to complete and not get garbage collected
+    /// Also refered as block time leeway
     #[arg(long = "builder.extra-block-deadline-secs", default_value = "20")]
     pub extra_block_deadline_secs: u64,
+
     /// Whether to enable revert protection by default
     #[arg(long = "builder.enable-revert-protection", default_value = "false")]
     pub enable_revert_protection: bool,

--- a/crates/op-rbuilder/src/builder/config.rs
+++ b/crates/op-rbuilder/src/builder/config.rs
@@ -1,10 +1,7 @@
 use alloy_primitives::Address;
 
 use crate::args::OpRbuilderArgs;
-use core::{
-    net::{Ipv4Addr, SocketAddr},
-    time::Duration,
-};
+use core::{net::SocketAddr, time::Duration};
 use tracing::warn;
 
 /// Configuration values that are specific to the flashblocks builder.
@@ -67,23 +64,8 @@ pub struct FlashblocksConfig {
 
 impl Default for FlashblocksConfig {
     fn default() -> Self {
-        Self {
-            ws_addr: SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 1111),
-            interval: Duration::from_millis(250),
-            disable_state_root: false,
-            enable_incremental_state_root: false,
-            number_contract_address: None,
-            number_contract_use_permit: false,
-            send_offset_ms: 0,
-            end_buffer_ms: 0,
-            p2p_enabled: false,
-            p2p_port: 9009,
-            p2p_private_key_file: None,
-            p2p_known_peers: None,
-            p2p_max_peer_count: 50,
-            ws_subscriber_limit: None,
-            continuous_build: false,
-        }
+        Self::try_from(OpRbuilderArgs::default())
+            .expect("CLI defaults must produce a valid FlashblocksConfig")
     }
 }
 

--- a/crates/op-rbuilder/src/builder/mod.rs
+++ b/crates/op-rbuilder/src/builder/mod.rs
@@ -113,24 +113,8 @@ pub struct BuilderConfig {
 
 impl Default for BuilderConfig {
     fn default() -> Self {
-        Self {
-            builder_signer: None,
-            revert_protection: false,
-            flashtestations_config: FlashtestationsArgs::default(),
-            block_time: Duration::from_secs(2),
-            block_time_leeway: Duration::from_millis(500),
-            da_config: OpDAConfig::default(),
-            gas_limit_config: OpGasLimitConfig::default(),
-            sampling_ratio: 100,
-            max_gas_per_txn: None,
-            max_uncompressed_block_size: None,
-            gas_limiter_config: GasLimiterArgs::default(),
-            compute_limiter_config: ComputeLimiterArgs::default(),
-            backrun_bundle_args: BackrunBundleArgs::default(),
-            flashblocks_config: FlashblocksConfig::default(),
-            exclude_reverts_between_flashblocks: false,
-            enable_tx_tracking_debug_logs: false,
-        }
+        Self::try_from(OpRbuilderArgs::default())
+            .expect("CLI defaults must produce a valid BuilderConfig")
     }
 }
 


### PR DESCRIPTION
Reimpl BuilderConfig::default() and FlashblocksConfig::default() as Self::try_from(OpRbuilderArgs::default()).

There was a few differences:
- block_time_leeway 500ms -> 20s
- block_time 2s -> 1s
- ws_subscriber_limit None -> Some(256), 
- ws_addr 0.0.0.0 -> 127.0.0.1