### PR TITLE
feat(observability): count dropped built-payload channel sends

### DIFF
--- a/crates/op-rbuilder/src/builder/payload.rs
+++ b/crates/op-rbuilder/src/builder/payload.rs
@@ -1063,6 +1063,10 @@ where
 
     pub(crate) fn notify_built_payload(&self, payload: OpBuiltPayload) {
         if let Err(e) = self.built_fb_payload_tx.try_send(payload.clone()) {
+            self.builder_ctx
+                .metrics
+                .built_fb_payload_send_failed
+                .increment(1);
             warn!(
                 target: "payload_builder",
                 error = %e,
@@ -1071,6 +1075,10 @@ where
         }
 
         if let Err(e) = self.built_payload_tx.try_send(payload) {
+            self.builder_ctx
+                .metrics
+                .built_payload_send_failed
+                .increment(1);
             warn!(
                 target: "payload_builder",
                 error = %e,

--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -211,6 +211,13 @@ pub struct OpRBuilderMetrics {
     pub payload_job_cancellation_complete: Counter,
     /// Payload job ended due to a build error
     pub payload_job_cancellation_error: Counter,
+    /// Built flashblock payload dropped because the channel to `PayloadHandler`'s
+    /// p2p fan-out was full or closed. Nonzero means peers missed a flashblock.
+    pub built_fb_payload_send_failed: Counter,
+    /// Built payload dropped because the channel to `PayloadHandler`'s engine-tree
+    /// feedback was full or closed. Nonzero means the engine tree missed a
+    /// pre-cached payload and had to re-validate our own block the expensive way.
+    pub built_payload_send_failed: Counter,
 }
 
 impl OpRBuilderMetrics {


### PR DESCRIPTION
New `built_fb_payload_send_failed` / `built_payload_send_failed` counters, incremented when notify_built_payload  try_sends drop.

Nonzero means peers missed a flashblock and the engine tree had to re-validate block. This was only a log warning, and with this we can add this warning in advanced dashboard.