### PR TITLE
Trigger binary and docker builds in release flow

### DIFF
--- a/.github/workflows/op_rbuilder_release_candidate.yaml
+++ b/.github/workflows/op_rbuilder_release_candidate.yaml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -45,6 +46,7 @@ jobs:
           git tag -a "$TAG" -m "op-rbuilder v${VERSION}-rc.${NEXT_RC}"
 
           echo "Created tag: $TAG"
+          echo "TAG=${TAG}" >> "$GITHUB_ENV"
 
       - name: Push tag
         run: |
@@ -52,3 +54,14 @@ jobs:
           git push origin --tags
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger release workflow
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Dispatching release workflow for ${TAG}"
+          gh workflow run op_rbuilder_release.yaml \
+            --ref "${TAG}" \
+            -f build-binary=true \
+            -f build-docker=true \
+            -f draft-release=true

--- a/.github/workflows/release-plz.yaml
+++ b/.github/workflows/release-plz.yaml
@@ -11,6 +11,7 @@ on:
 permissions:
   pull-requests: write
   contents: write
+  actions: write
 
 jobs:
   release-plz:
@@ -30,8 +31,24 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Create tags on release PR merge
+        id: release-plz
         uses: release-plz/action@v0.5
         with:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  
+      - name: Trigger release workflow
+        if: steps.release-plz.outputs.releases_created == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASES: ${{ steps.release-plz.outputs.releases }}
+        run: |
+          jq -r '.[].tag' <<< "$RELEASES" | while read -r tag; do
+            echo "Dispatching release workflow for ${tag}"
+            gh workflow run op_rbuilder_release.yaml \
+              --ref "${tag}" \
+              -f build-binary=true \
+              -f build-docker=true \
+              -f draft-release=true
+          done


### PR DESCRIPTION
## 📝 Summary

Trigger docker publish in the new release flow

## 💡 Motivation and Context

release candidates and tags were pushed but not docker builds

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
