### PR TITLE
test: karst coverage

### DIFF
--- a/crates/op-rbuilder/src/tests/forks.rs
+++ b/crates/op-rbuilder/src/tests/forks.rs
@@ -1,7 +1,14 @@
-use crate::tests::BlockTransactionsExt;
+use crate::{
+    args::OpRbuilderArgs,
+    tests::{BlockTransactionsExt, LocalInstance, OpRbuilderArgsTestExt, karst_node_config},
+};
 use alloy_eips::{BlockNumberOrTag::Latest, Encodable2718, eip1559::MIN_PROTOCOL_BASE_FEE};
-use alloy_primitives::bytes;
+use alloy_network::ReceiptResponse;
+use alloy_primitives::{Address, Bytes, address, bytes, hex};
+use alloy_provider::{Provider, RootProvider};
 use macros::rb_test;
+use op_alloy_network::Optimism;
+use op_alloy_rpc_types::OpTransactionRequest;
 use std::time::Duration;
 
 #[rb_test]
@@ -123,5 +130,107 @@ async fn jovian_minimum_fee_must_be_set(rbuilder: LocalInstance) -> eyre::Result
         .build_new_block_with_txs_timestamp(vec![], None, Some(block_timestamp), None, None)
         .await;
     assert!(response.is_err());
+    Ok(())
+}
+
+/// A chain with `karstTime` set at genesis still builds and lands ordinary blocks
+#[rb_test(config = karst_node_config())]
+async fn karst_active_at_genesis(rbuilder: LocalInstance) -> eyre::Result<()> {
+    let driver = rbuilder.driver().await?;
+    let tx_one = driver.create_transaction().send().await?;
+    let tx_two = driver.create_transaction().send().await?;
+    let block = driver.build_new_block().await?;
+
+    assert!(block.includes(tx_one.tx_hash()));
+    assert!(block.includes(tx_two.tx_hash()));
+
+    Ok(())
+}
+
+/// EIP-7951/RIP-7212 P256VERIFY precompile address.
+const P256VERIFY_ADDRESS: Address = address!("0000000000000000000000000000000000000100");
+
+/// secp256r1 signature-verification input (msg_hash || r || s || pubkey_x || pubkey_y)
+/// See https://github.com/daimo-eth/p256-verifier/tree/master/test-vectors
+const P256_VALID_SIGNATURE: [u8; 160] = hex!(
+    "4cee90eb86eaa050036147a12d49004b6b9c72bd725d39d4785011fe190f0b4da73bd4903f0ce3b639bbbf6e8e80d16931ff4bcf5993d58468e8fb19086e8cac36dbcd03009df8c59286b162af3bd7fcc0450c9aa81be5d10d312af6c66b1d604aebd3099c618202fcfe16ae7770b0c49ab5eadf74b754204a3bb6060e44eff37618b065f9832de4ca6ca971a7a1adc826d0f7c00181a5fb2ddf79ae00b4e10e"
+);
+const P256_INVALID_SIGNATURE: [u8; 160] = hex!(
+    "3cee90eb86eaa050036147a12d49004b6b9c72bd725d39d4785011fe190f0b4da73bd4903f0ce3b639bbbf6e8e80d16931ff4bcf5993d58468e8fb19086e8cac36dbcd03009df8c59286b162af3bd7fcc0450c9aa81be5d10d312af6c66b1d604aebd3099c618202fcfe16ae7770b0c49ab5eadf74b754204a3bb6060e44eff37618b065f9832de4ca6ca971a7a1adc826d0f7c00181a5fb2ddf79ae00b4e10e"
+);
+
+async fn call_p256verify(
+    provider: &RootProvider<Optimism>,
+    input: [u8; 160],
+) -> eyre::Result<Bytes> {
+    let request = OpTransactionRequest::default()
+        .to(P256VERIFY_ADDRESS)
+        .input(Bytes::copy_from_slice(&input).into());
+
+    Ok(provider.call(request).latest().await?)
+}
+
+/// Under Karst, P256VERIFY is correctly wired up: a valid signature returns the 32-byte
+/// `0x...01`, an invalid one returns empty, per RIP-7212/EIP-7951.
+#[rb_test(config = karst_node_config())]
+async fn karst_p256verify_precompile_correctness(rbuilder: LocalInstance) -> eyre::Result<()> {
+    let provider = rbuilder.provider().await?;
+
+    let valid = call_p256verify(&provider, P256_VALID_SIGNATURE).await?;
+    assert_eq!(
+        valid,
+        bytes!("0x0000000000000000000000000000000000000000000000000000000000000001")
+    );
+
+    let invalid = call_p256verify(&provider, P256_INVALID_SIGNATURE).await?;
+    assert!(invalid.is_empty());
+
+    Ok(())
+}
+
+/// P256VERIFY exists since Fjord (RIP-7212), Karst precompile set only changes its price.
+/// We assert `>` rather than exact 3450-gas delta because EIP-7623's calldata gas floor can absorb part of the difference depending on byte makeup but can never flip the inequality.
+#[rb_test(config = karst_node_config())]
+async fn karst_p256verify_gas_repricing(rbuilder: LocalInstance) -> eyre::Result<()> {
+    let karst_driver = rbuilder.driver().await?;
+    let jovian = LocalInstance::new(OpRbuilderArgs::test_default()).await?;
+    let jovian_driver = jovian.driver().await?;
+
+    let karst_tx = karst_driver
+        .create_transaction()
+        .with_to(P256VERIFY_ADDRESS)
+        .with_input(Bytes::copy_from_slice(&P256_VALID_SIGNATURE))
+        .send()
+        .await?;
+    karst_driver.build_new_block().await?;
+
+    let jovian_tx = jovian_driver
+        .create_transaction()
+        .with_to(P256VERIFY_ADDRESS)
+        .with_input(Bytes::copy_from_slice(&P256_VALID_SIGNATURE))
+        .send()
+        .await?;
+    jovian_driver.build_new_block().await?;
+
+    let karst_receipt = karst_driver
+        .provider()
+        .get_transaction_receipt(*karst_tx.tx_hash())
+        .await?
+        .expect("karst p256verify tx not mined");
+    let jovian_receipt = jovian_driver
+        .provider()
+        .get_transaction_receipt(*jovian_tx.tx_hash())
+        .await?
+        .expect("jovian p256verify tx not mined");
+
+    assert!(karst_receipt.status(), "karst call should succeed");
+    assert!(jovian_receipt.status(), "jovian call should succeed");
+    assert!(
+        karst_receipt.gas_used() > jovian_receipt.gas_used(),
+        "karst gas_used ({}) should exceed jovian's ({}) under Osaka P256VERIFY repricing",
+        karst_receipt.gas_used(),
+        jovian_receipt.gas_used()
+    );
+
     Ok(())
 }

--- a/crates/op-rbuilder/src/tests/framework/instance.rs
+++ b/crates/op-rbuilder/src/tests/framework/instance.rs
@@ -336,6 +336,31 @@ fn chain_spec() -> Arc<OpChainSpec> {
     CHAIN_SPEC.clone()
 }
 
+/// Same genesis as [`chain_spec`], with Karst active at genesis.
+/// Use via [`karst_node_config`] to get a [`LocalInstance`] running under Karst.
+/// TODO: make it the default in [`LocalInstance`]
+fn karst_chain_spec() -> Arc<OpChainSpec> {
+    static CHAIN_SPEC: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
+        let genesis = include_str!("./artifacts/genesis.json.tmpl");
+        let mut genesis: serde_json::Value =
+            serde_json::from_str(genesis).expect("invalid genesis JSON");
+        genesis["config"]["karstTime"] = 0.into();
+        let genesis = serde_json::from_value(genesis).expect("invalid genesis JSON");
+        Arc::new(OpChainSpec::from_genesis(genesis))
+    });
+
+    CHAIN_SPEC.clone()
+}
+
+/// Node config for a chain with Karst active at genesis.
+/// Can be used in `#[rb_test]`: `#[rb_test(config = karst_node_config())]`
+pub fn karst_node_config() -> NodeConfig<OpChainSpec> {
+    NodeConfig::<OpChainSpec> {
+        chain: karst_chain_spec(),
+        ..default_node_config()
+    }
+}
+
 fn task_runtime() -> TaskRuntime {
     TaskRuntime::test()
 }


### PR DESCRIPTION
Adds `karst_node_config()` to in-process test framework 

Some tests covering:
- karst-at-genesis block building 
- P256VERIFY precompile 
- P256VERIFY Osaka gas repricing
